### PR TITLE
Bugfix: Allow INFO field name to have underscores

### DIFF
--- a/vcfquery.c
+++ b/vcfquery.c
@@ -298,7 +298,7 @@ static char *parse_tag(args_t *args, char *p, int is_gtf)
             if ( *q!='/' ) error("Could not parse format string: %s\n", args->format);
             p = ++q;
             str.l = 0;
-            while ( *q && isalnum(*q) ) q++;
+            while ( *q && (isalnum(*q) || *q=='_') ) q++;
             if ( q-p==0 ) error("Could not parse format string: %s\n", args->format);
             kputsn(p, q-p, &str);
             register_tag(args, T_INFO, str.s, is_gtf);


### PR DESCRIPTION
Lines 271 and 301 in `vcfquery.c` should do the same thing.

As [noted previously](https://github.com/samtools/htslib/pull/21#issuecomment-22306162), `%SOME_NAME` in the format string will work without this fix. However, `%INFO/SOME_NAME` will be parsed as `%INFO/SOME` without this fix.
