### PR TITLE
Add -o FILE / --output FILE option to redirect output

### DIFF
--- a/bcftools.txt
+++ b/bcftools.txt
@@ -111,6 +111,10 @@ OPTIONS
     in 'LIST'. For example, to include only sites which have no filters set,
     use *-f* '.,PASS'.
 
+*-o, --output* 'FILE'::
+    When output consists of a single stream, write it to 'FILE' rather than
+    to standard output, where it is written by default.
+
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     Output compressed BCF ('b'), uncompressed BCF ('u'), compressed VCF ('z'), uncompressed VCF ('v').
 
@@ -233,6 +237,9 @@ This command allows to add or remove annotations and apply user-written plugins.
 
         *missing2ref*;; Sets missing genotypes ("./.") to ref allele ("0/0").
 
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*
+
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     see *<<common_options,Common Options>>*
 
@@ -311,6 +318,9 @@ demand. The original calling model can be invoked with the *-c* option.
 *-M, --keep-masked-ref*::
     output sites where REF allele is N
 
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*
+
 *-V, --skip-variants* 'snps'|'indels'::
     skip indel/SNP sites
 
@@ -386,6 +396,9 @@ the *-a, --allow-overlaps* option is specified.
 *-q, --min-PQ* 'INT'::
     Break phase set if phasing quality is lower than 'INT'
 
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*
+
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     see *<<common_options,Common Options>>*
 
@@ -440,6 +453,9 @@ And similarly here, the second is filtered:
     "PASS" when the FILTER string is absent. The "\+" mode appends new FILTER
     strings of failed sites instead of replacing them. The "x" mode resets
     filters of sites which pass to "PASS". Modes "+" and "x" can both be set.
+
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*
 
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     see *<<common_options,Common Options>>*
@@ -568,6 +584,10 @@ in the other files.
     output positions present in this many (=), this many or more (+), or this
     many or fewer (-) files
 
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*.  When several files are being
+    output, their names are controlled via *-p* instead.
+
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     see *<<common_options,Common Options>>*
 
@@ -649,6 +669,9 @@ also given explicitly using the *--print-header* and *--use-header* options.
     prevent merging of SNPs and indels into one record, use *-m* 'both'. To
     prevent creation of multi-allelic records altogether, use *-m* 'none'.
 
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*
+
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     see *<<common_options,Common Options>>*
 
@@ -680,6 +703,9 @@ multiple rows.
     both SNPs and indels should be merged separately into two records, specify
     'both'; if SNPs and indels should be merged into a single record, specify
     'any'.
+
+*-o, --output* 'FILE'::
+    see *<<common_options,Common Options>>*
 
 *-O, --output-type* 'b'|'u'|'z'|'v'::
     see *<<common_options,Common Options>>*

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -24,6 +24,8 @@
  */
 
 #include <stdarg.h>
+#include <string.h>
+#include <errno.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <math.h>
@@ -66,7 +68,7 @@ typedef struct
     int flag;   // combination of CF_* flags above
     int output_type;
     htsFile *bcf_in, *out_fh;
-    char *bcf_fname;
+    char *bcf_fname, *output_fname;
     char **samples;             // for subsampling and ploidy
     int nsamples, *samples_map;
     char *regions, *targets;    // regions to process
@@ -348,7 +350,8 @@ static void init_data(args_t *args)
         args->aux.ploidy = ploidy;
     }
 
-    args->out_fh = hts_open("-", hts_bcf_wmode(args->output_type));
+    args->out_fh = hts_open(args->output_fname, hts_bcf_wmode(args->output_type));
+    if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
 
     if ( args->flag & CF_QCALL ) 
         return;
@@ -457,6 +460,7 @@ static void usage(args_t *args)
     fprintf(stderr, "Usage:   bcftools call [options] <in.vcf.gz>\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "File format options:\n");
+    fprintf(stderr, "   -o, --output <file>             write output to a file [standard output]\n");
     fprintf(stderr, "   -O, --output-type <b|u|z|v>     output type: 'b' compressed BCF; 'u' uncompressed BCF; 'z' compressed VCF; 'v' uncompressed VCF [v]\n");
     fprintf(stderr, "   -r, --regions <region>          restrict to comma-separated list of regions\n");
     fprintf(stderr, "   -R, --regions-file <file>       restrict to regions listed in a file\n");
@@ -507,6 +511,8 @@ int main_vcfcall(int argc, char *argv[])
     args.aux.min_perm_p = 0.01;
     args.aux.min_lrt    = 1;
     args.flag           = CF_ACGT_ONLY;
+    args.output_fname   = "-";
+    args.output_type    = FT_VCF;
     args.aux.trio_Pm_SNPs = 1 - 1e-8;
     args.aux.trio_Pm_ins  = args.aux.trio_Pm_del  = 1 - 1e-9;
 
@@ -517,6 +523,7 @@ int main_vcfcall(int argc, char *argv[])
         {"help",0,0,'h'},
         {"gvcf",1,0,'g'},
         {"format-fields",1,0,'f'},
+        {"output",1,0,'o'},
         {"output-type",1,0,'O'},
         {"regions",1,0,'r'},
         {"regions-file",1,0,'R'},
@@ -542,7 +549,7 @@ int main_vcfcall(int argc, char *argv[])
     };
 
     char *tmp = NULL;
-	while ((c = getopt_long(argc, argv, "h?O:r:R:s:S:t:T:ANMV:vcmp:C:XYn:P:f:ig:", loptions, NULL)) >= 0) 
+	while ((c = getopt_long(argc, argv, "h?o:O:r:R:s:S:t:T:ANMV:vcmp:C:XYn:P:f:ig:", loptions, NULL)) >= 0)
     {
 		switch (c) 
         {
@@ -558,6 +565,7 @@ int main_vcfcall(int argc, char *argv[])
             case 'c': args.flag |= CF_CCALL; break;          // the original EM based calling method
             case 'i': args.flag |= CF_INS_MISSED; break;
             case 'v': args.aux.flag |= CALL_VARONLY; break;
+            case 'o': args.output_fname = optarg; break;
             case 'O': 
                       switch (optarg[0]) {
                           case 'b': args.output_type = FT_BCF_GZ; break;

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -24,6 +24,8 @@
  */
 
 #include <stdio.h>
+#include <string.h>
+#include <errno.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <htslib/vcf.h>
@@ -105,7 +107,7 @@ typedef struct
     vcmp_t *vcmp;
     maux_t *maux;
     int header_only, collapse, output_type, force_samples;
-    char *header_fname, *regions_list, *info_rules, *file_list;
+    char *header_fname, *output_fname, *regions_list, *info_rules, *file_list;
     info_rule_t *rules;
     int nrules;
     strdict_t *tmph;
@@ -1782,7 +1784,8 @@ void bcf_hdr_append_version(bcf_hdr_t *hdr, int argc, char **argv, const char *c
 
 void merge_vcf(args_t *args)
 {
-    args->out_fh  = hts_open("-", hts_bcf_wmode(args->output_type));
+    args->out_fh  = hts_open(args->output_fname, hts_bcf_wmode(args->output_type));
+    if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
     args->out_hdr = bcf_hdr_init("w");
 
     if ( args->header_fname )
@@ -1845,6 +1848,7 @@ static void usage(void)
     fprintf(stderr, "    -i, --info-rules <tag:method,..>   rules for merging INFO fields (method is one of sum,avg,min,max,join) or \"-\" to turn off the default [DP:sum,DP4:sum]\n");
     fprintf(stderr, "    -l, --file-list <file>             read file names from the file\n");
     fprintf(stderr, "    -m, --merge <string>               merge sites with differing alleles for <snps|indels|both|all|none>, see man page for details [both]\n");
+    fprintf(stderr, "    -o, --output <file>                write output to a file [standard output]\n");
     fprintf(stderr, "    -O, --output-type <b|u|z|v>        'b' compressed BCF; 'u' uncompressed BCF; 'z' compressed VCF; 'v' uncompressed VCF [v]\n");
 	fprintf(stderr, "    -r, --regions <region>             restrict to comma-separated list of regions\n");
     fprintf(stderr, "    -R, --regions-file <file>          restrict to regions listed in a file\n");
@@ -1858,6 +1862,8 @@ int main_vcfmerge(int argc, char *argv[])
     args_t *args = (args_t*) calloc(1,sizeof(args_t));
     args->files  = bcf_sr_init();
     args->argc   = argc; args->argv = argv;
+    args->output_fname = "-";
+    args->output_type = FT_VCF;
     args->collapse = COLLAPSE_BOTH;
     int regions_is_file = 0;
 
@@ -1870,16 +1876,18 @@ int main_vcfmerge(int argc, char *argv[])
         {"use-header",1,0,1},
         {"print-header",0,0,2},
         {"force-samples",0,0,3},
+        {"output",1,0,'o'},
         {"output-type",1,0,'O'},
         {"regions",1,0,'r'},
         {"regions-file",1,0,'R'},
         {"info-rules",1,0,'i'},
         {0,0,0,0}
     };
-    while ((c = getopt_long(argc, argv, "hm:f:r:R:O:i:l:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hm:f:r:R:o:O:i:l:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'l': args->file_list = optarg; break;
             case 'i': args->info_rules = optarg; break;
+            case 'o': args->output_fname = optarg; break;
             case 'O': 
                 switch (optarg[0]) {
                     case 'b': args->output_type = FT_BCF_GZ; break;

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -88,7 +88,7 @@ typedef struct
     bcf_srs_t *files;       // using the synced reader only for -r option
     bcf_hdr_t *hdr;
     faidx_t *fai;
-    char **argv, *ref_fname, *vcf_fname, *region, *targets;
+    char **argv, *output_fname, *ref_fname, *vcf_fname, *region, *targets;
     int argc, rmdup, output_type, check_ref;
     int nchanged, nskipped, ntotal, mrows_op, mrows_collapse, parsimonious;
 }
@@ -1740,7 +1740,8 @@ static void destroy_data(args_t *args)
 
 static void normalize_vcf(args_t *args)
 {
-    htsFile *out = hts_open("-", hts_bcf_wmode(args->output_type));
+    htsFile *out = hts_open(args->output_fname, hts_bcf_wmode(args->output_type));
+    if ( out == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
     bcf_hdr_append_version(args->hdr, args->argc, args->argv, "bcftools_norm");
     bcf_hdr_write(out, args->hdr);
 
@@ -1801,6 +1802,7 @@ static void usage(void)
     fprintf(stderr, "    -D, --remove-duplicates           remove duplicate lines of the same type.\n");
     fprintf(stderr, "    -f, --fasta-ref <file>            reference sequence\n");
     fprintf(stderr, "    -m, --multiallelics <-|+>[type]   split multiallelics (-) or join biallelics (+), type: snps|indels|both|any [both]\n");
+    fprintf(stderr, "    -o, --output <file>               write output to a file [standard output]\n");
     fprintf(stderr, "    -O, --output-type <type>          'b' compressed BCF; 'u' uncompressed BCF; 'z' compressed VCF; 'v' uncompressed VCF [v]\n");
     fprintf(stderr, "    -r, --regions <region>            restrict to comma-separated list of regions\n");
     fprintf(stderr, "    -R, --regions-file <file>         restrict to regions listed in a file\n");
@@ -1817,6 +1819,8 @@ int main_vcfnorm(int argc, char *argv[])
     args_t *args  = (args_t*) calloc(1,sizeof(args_t));
     args->argc    = argc; args->argv = argv;
     args->files   = bcf_sr_init();
+    args->output_fname = "-";
+    args->output_type = FT_VCF;
     args->aln_win = 100;
     args->buf_win = 1000;
     args->mrows_collapse = COLLAPSE_BOTH;
@@ -1834,11 +1838,12 @@ int main_vcfnorm(int argc, char *argv[])
         {"targets-file",1,0,'T'},
         {"site-win",1,0,'W'},
         {"remove-duplicates",0,0,'D'},
+        {"output",1,0,'o'},
         {"output-type",1,0,'O'},
         {"check-ref",1,0,'c'},
         {0,0,0,0}
     };
-    while ((c = getopt_long(argc, argv, "hr:R:f:w:DO:c:m:t:T:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hr:R:f:w:Do:O:c:m:t:T:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'm':
                 if ( optarg[0]=='-' ) args->mrows_op = MROWS_SPLIT;
@@ -1867,6 +1872,7 @@ int main_vcfnorm(int argc, char *argv[])
                     default: error("The output type \"%s\" not recognised\n", optarg);
                 }
                 break;
+            case 'o': args->output_fname = optarg; break;
             case 'D': args->rmdup = 1; break;
             case 'f': args->ref_fname = optarg; break;
             case 'r': args->region = optarg; break;


### PR DESCRIPTION
As discussed back when we moved `--output-type` to `-O` to make room for it, add a `-o` option to specify an output file without needing `>FILE` shell redirection -- thus avoiding needing to quote shell metacharacters when writing scripts, etc.

As a pull request, so that you can regenerate _bcftools.1_ when merging it should you wish.
