### PR TITLE
Changed sanity-check comparison to be case-insensity

### DIFF
--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -526,7 +526,7 @@ char **merge_alleles(char **a, int na, int *map, char **b, int *nb, int *mb)
     }
 
     // Sanity check: reference prefixes must be identical
-    if ( strncmp(a[0],b[0],rla<rlb?rla:rlb) )
+    if ( strncasecmp(a[0],b[0],rla<rlb?rla:rlb) )
     {
         fprintf(stderr, "The REF prefixes differ: %s vs %s (%d,%d)\n", a[0],b[0],rla,rlb);
         return NULL;


### PR DESCRIPTION
bcfools merge was failing due to a case (as in upper/lower) difference between the REFs.  
The fix is inserting 4 characters on 1 line.

I'm not 100% on how the case difference is getting in there.  My guess is that...
Our reference genome fasta is soft-masked with lower-case, which seem to be preserved sometimes but not others.  IMO, the preferred behaviour would be to always preserve the case of the REF allele as it is in the reference, but it isn't important enough for me to track it down at the moment.
