### PR TITLE
Update bcftools.txt

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1489,7 +1489,7 @@ Convert between VCF and BCF. Former *bcftools subset*.
     print sites with at least 'INT' alleles listed in REF and ALT columns
 
 *-M, --max-alleles* 'INT'::
-    print sites with at most 'INT' alleles listed in REF and ALT columns
+    print sites with at most 'INT' alleles listed in REF and ALT columns. Use -M 2 with -v snps to only view biallelic SNPs.
 
 *-n, --novel*::
     print novel sites only (ID column is ".")


### PR DESCRIPTION
I was pretty sure it would be possible to extract biallelic SNPs with bcftools, but the word biallelic appears nowhere in the documentation. I found the functionality by searching for the string allel. I added an example of what I imagine is a frequent use of bcftools. I'm happy to move this to an example/FAQ page instead to keep the documentation clean/minimal/streamlined. Thanks.
