### PR TITLE
added -m option to missing2ref

### DIFF
--- a/plugins/missing2ref.c
+++ b/plugins/missing2ref.c
@@ -25,17 +25,20 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <htslib/vcf.h>
+#include <htslib/vcfutils.h>
 #include <inttypes.h>
 #include <getopt.h>
 
 bcf_hdr_t *in_hdr, *out_hdr;
 int32_t *gts = NULL, mgts = 0;
+int *arr = NULL, marr = 0;
 uint64_t nchanged = 0;
 int new_gt = bcf_gt_unphased(0);
+int use_major = 0;
 
 const char *about(void)
 {
-    return "Set missing genotypes (\"./.\") to ref allele (\"0/0\" or \"0|0\").\n";
+    return "Set missing genotypes (\"./.\") to ref or major allele (\"0/0\" or \"0|0\").\n";
 }
 
 const char *usage(void)
@@ -49,9 +52,11 @@ const char *usage(void)
         "\n"
         "Plugin options:\n"
         "   -p, --phased       Set to \"0|0\" \n"
+        "   -m, --major        Set to major allele \n"
         "\n"
         "Example:\n"
         "   bcftools +missing2ref in.vcf -- -p\n"
+        "   bcftools +missing2ref in.vcf -- -p -m\n"
         "\n";
 }
 
@@ -62,13 +67,15 @@ int init(int argc, char **argv, bcf_hdr_t *in, bcf_hdr_t *out)
     static struct option loptions[] =
     {
         {"phased",0,0,'p'},
+        {"major",0,0,'m'},
         {0,0,0,0}
     };
-    while ((c = getopt_long(argc, argv, "p?h",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "mp?h",loptions,NULL)) >= 0)
     {
         switch (c) 
         {
             case 'p': new_gt = bcf_gt_phased(0); break;
+            case 'm': use_major = 1; break;
             case 'h':
             case '?':
             default: fprintf(stderr,"%s", usage()); exit(1); break;
@@ -82,8 +89,38 @@ int init(int argc, char **argv, bcf_hdr_t *in, bcf_hdr_t *out)
 bcf1_t *process(bcf1_t *rec)
 {
     int ngts = bcf_get_genotypes(in_hdr, rec, &gts, &mgts);
-
     int i, changed = 0;
+    
+    // Calculating allele frequency for each allele and determining major allele
+    // only do this if use_major is true
+    int majorAllele = -1;
+    int maxAC = -1;
+    int an = 0;
+    if(use_major == 1){
+        hts_expand(int,rec->n_allele,marr,arr);
+        int ret = bcf_calc_ac(in_hdr,rec,arr,BCF_UN_FMT);
+        if(ret > 0){
+            for(i=0; i < rec->n_allele; ++i){
+                an += arr[i];
+                if(*(arr+i) > maxAC){
+                    maxAC = *(arr+i);
+                    majorAllele = i;
+                }
+            }
+        }
+        else{
+            fprintf(stderr,"Warning: Could not calculate allele count at position %d\n", rec->pos);
+            exit(1);
+        }
+
+        // replacing new_gt by major allele
+        if(bcf_gt_is_phased(new_gt))
+            new_gt = bcf_gt_phased(majorAllele);
+        else
+            new_gt = bcf_gt_unphased(majorAllele);
+    }
+
+    // replace gts
     for (i=0; i<ngts; i++)
     {
         if ( gts[i]==bcf_gt_missing )

--- a/test/plugin-missing2ref.out.vcf
+++ b/test/plugin-missing2ref.out.vcf
@@ -1,0 +1,30 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=TEST,Number=1,Type=Integer,Description="Testing Tag">
+##FORMAT=<ID=TT,Number=A,Type=Integer,Description="Testing Tag, with commas and \"escapes\" and escaped escapes combined with \\\"quotes\\\\\"">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=GL,Number=G,Type=Float,Description="Genotype Likelihood">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=test,Description="Testing filter">
+##contig=<ID=1,assembly=b37,length=249250621>
+##contig=<ID=2,assembly=b37,length=249250621>
+##contig=<ID=3,assembly=b37,length=198022430>
+##contig=<ID=4,assembly=b37,length=191154276>
+##test=<ID=4,IE=5>
+##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
+##readme=AAAAAA
+##readme=BBBBBB
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=STR,Number=1,Type=String,Description="Test string type">
+##bcftools_pluginCommand=plugin missing2ref -o test.out.vcf -- missing2ref -p -m
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
+1	3000150	.	C	T	59.2	PASS	.	GT:GQ	1|1:245	1|1:245	0/1:245	1/1:245
+1	3000151	.	C	T	59.2	PASS	.	GT:DP:GQ	0|0:32:245	0|0:32:245	0|0:32:245	0|0:32:245
+1	3062915	id3D	GTTT	G	12.9	q10	DP4=1,2,3,4;INDEL;STR=test	GT:GQ:DP:GL	0/1:409:35:-20,-5,-20	0/1:409:35:-20,-5,-20	0/1:409:35:-20,-5,-20	0/1:409:35:-20,-5,-20
+1	3062915	idSNP	G	T,C	12.6	test	TEST=5;DP4=1,2,3,4	GT:TT:GQ:DP:GL	0/1:0,1:409:35:-20,-5,-20,-20,-5,-20	2:0,1:409:35:-20,-5,-20	2/2:0,1:409:35:-20,-5,-20	2|2:0,1:409:35:-20,-5,-20
+2	3199812	.	G	GTT,GT	82.7	PASS	.	GT:GQ:DP	0|0:322:26	0|0:322:26	0|0:322:26	0|0:322:26
+3	3212016	.	CTT	C,CT	79	PASS	.	GT:GQ:DP	0|0:91:26	0|0:91:26	0|0:91:26	0|0:91:26
+4	3258448	.	TACACACAC	T	59.9	PASS	.	GT:GQ:DP	0|0:325:31	0|0:325:31	0|0:325:31	0|0:325:31

--- a/test/plugin-missing2ref.vcf
+++ b/test/plugin-missing2ref.vcf
@@ -1,0 +1,29 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=TEST,Number=1,Type=Integer,Description="Testing Tag">
+##FORMAT=<ID=TT,Number=A,Type=Integer,Description="Testing Tag, with commas and \"escapes\" and escaped escapes combined with \\\"quotes\\\\\"">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=GL,Number=G,Type=Float,Description="Genotype Likelihood">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=test,Description="Testing filter">
+##contig=<ID=1,assembly=b37,length=249250621>
+##contig=<ID=2,assembly=b37,length=249250621>
+##contig=<ID=3,assembly=b37,length=198022430>
+##contig=<ID=4,assembly=b37,length=191154276>
+##test=<ID=4,IE=5>
+##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
+##readme=AAAAAA
+##readme=BBBBBB
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=STR,Number=1,Type=String,Description="Test string type">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C	D
+1	3000150	.	C	T	59.2	PASS	.	GT:GQ	./.:245	./.:245	0/1:245	1/1:245
+1	3000151	.	C	T	59.2	PASS	.	GT:DP:GQ	./.:32:245	./.:32:245	0|0:32:245	0|0:32:245
+1	3062915	id3D	GTTT	G	12.9	q10	DP4=1,2,3,4;INDEL;STR=test	GT:GQ:DP:GL	0/1:409:35:-20,-5,-20	0/1:409:35:-20,-5,-20	0/1:409:35:-20,-5,-20	0/1:409:35:-20,-5,-20
+1	3062915	idSNP	G	T,C	12.6	test	TEST=5;DP4=1,2,3,4	GT:TT:GQ:DP:GL	0/1:0,1:409:35:-20,-5,-20,-20,-5,-20	2:0,1:409:35:-20,-5,-20	2/2:0,1:409:35:-20,-5,-20	./.:0,1:409:35:-20,-5,-20
+2	3199812	.	G	GTT,GT	82.7	PASS	.	GT:GQ:DP	./.:322:26	./.:322:26	./.:322:26	./.:322:26
+3	3212016	.	CTT	C,CT	79	PASS	.	GT:GQ:DP	./.:91:26	./.:91:26	./.:91:26	./.:91:26
+4	3258448	.	TACACACAC	T	59.9	PASS	.	GT:GQ:DP	./.:325:31	./.:325:31	./.:325:31	./.:325:31


### PR DESCRIPTION
Added option to the plugin `missing2ref` that sets missing to major allele (also works for multiallelic sites).  Works together with -p option.

I also added a test VCF. The following command should give an almost identical (except for one comment line) VCF to `test/plugin-missing2ref.out.vcf`

````
bcftools plugin missing2ref test/plugin-missing2ref.vcf -- -p -m
````

I have not integrated this test into the testing framework, but I hope that would be easy for someone familiar with the code to achieve.

I tested this code against release 1.1.  Not sure if it'll work on the current `develop` branch