### PR TITLE
view -x must be combined with -s or -S

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1569,7 +1569,8 @@ Convert between VCF and BCF. Former *bcftools subset*.
     comma-separated list of variant types to exclude
 
 *-x, --private*::
-    print sites where only the subset samples carry an non-reference allele
+    print sites where only the subset samples carry an non-reference allele.
+    This argument has no effect without either --samples or --samples-file.
 
 *-X, --exclude-private*::
     exclude sites where only the subset samples carry an non-reference allele


### PR DESCRIPTION
I was expecting to be able to use view --private without --samples, because my modified VCF only contains a single sample. To my surprise that was not the behaviour. Hence I suggest this edit to the docs for people like myself that make invalid assumptions.