### PR TITLE
Fix dependencies for Mac OSX to stop unnecessary recompilation of plu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bcftools
 *.o
 /version.h
 plugins/*.so
+plugins/*.dSYM
 plugins/*.P
 
 /test/test-rbuf

--- a/Makefile
+++ b/Makefile
@@ -106,13 +106,23 @@ test: $(PROG) plugins test/test-rbuf $(BGZIP) $(TABIX)
 test-plugins: $(PROG) plugins test/test-rbuf $(BGZIP) $(TABIX)
 	./test/test.pl --plugins --exec bgzip=$(BGZIP) --exec tabix=$(TABIX)
 
+## $(shell), :=, and ifeq/.../endif are GNU Make-specific.  If you don't have
+## GNU Make, comment out the parts of this conditional that don't apply.
+PLATFORM := $(shell uname -s)
+ifeq "$(PLATFORM)" "Darwin"
+SHLIB_FLAVOUR = dylib
+htslib_shared = $(HTSDIR)/libhts.dylib
+else
+SHLIB_FLAVOUR = so
+htslib_shared = $(HTSDIR)/libhts.so
+endif
 
 # Plugin rules
 PLUGINC = $(foreach dir, plugins, $(wildcard $(dir)/*.c))
 PLUGINS = $(PLUGINC:.c=.so)
 PLUGINM = $(PLUGINC:.c=.mk)
 
-%.so: %.c version.h version.c $(HTSDIR)/libhts.so
+%.so: %.c version.h version.c $(htslib_shared)
 	$(CC) -fPIC -shared $(CFLAGS) $(EXTRA_CPPFLAGS) $(CPPFLAGS) -L$(HTSDIR) $(LDFLAGS) -o $@ version.c $< -lhts $(LIBS)
 
 -include $(PLUGINM)

--- a/plugins/fixploidy.mk
+++ b/plugins/fixploidy.mk
@@ -1,2 +1,2 @@
-plugins/fixploidy.so: plugins/fixploidy.c version.h version.c ploidy.h ploidy.c $(HTSDIR)/libhts.so
+plugins/fixploidy.so: plugins/fixploidy.c version.h version.c ploidy.h ploidy.c $(htslib_shared)
 	$(CC) -fPIC -shared $(CFLAGS) $(EXTRA_CPPFLAGS) $(CPPFLAGS) -L$(HTSDIR) $(LDFLAGS) -o $@ ploidy.c version.c $< -lhts $(LIBS)

--- a/plugins/vcf2sex.mk
+++ b/plugins/vcf2sex.mk
@@ -1,2 +1,2 @@
-plugins/vcf2sex.so: plugins/vcf2sex.c version.h version.c ploidy.h ploidy.c $(HTSDIR)/libhts.so
+plugins/vcf2sex.so: plugins/vcf2sex.c version.h version.c ploidy.h ploidy.c $(htslib_shared)
 	$(CC) -fPIC -shared $(CFLAGS) $(EXTRA_CPPFLAGS) $(CPPFLAGS) -L$(HTSDIR) $(LDFLAGS) -o $@ ploidy.c version.c $< -lhts $(LIBS)


### PR DESCRIPTION
…gins

* Plugins should depend on libhts.dylib not libhts.so on OSX
* Add *.dSYM to .gitignore

Fixes #249