### PR TITLE
Update norm test VCF headers to v4.2

### DIFF
--- a/test/norm.merge.out
+++ b/test/norm.merge.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.merge.strict.out
+++ b/test/norm.merge.strict.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.merge.vcf
+++ b/test/norm.merge.vcf
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.out
+++ b/test/norm.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.setref.out
+++ b/test/norm.setref.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.setref.vcf
+++ b/test/norm.setref.vcf
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.split.and.norm.out
+++ b/test/norm.split.and.norm.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.split.out
+++ b/test/norm.split.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.split.vcf
+++ b/test/norm.split.vcf
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">

--- a/test/norm.vcf
+++ b/test/norm.vcf
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.1
+##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">


### PR DESCRIPTION
These VCF files contain features that were only introduced in v4.2 of the VCF spec (e.g. `Number=R`) and should be updated accordingly.