### PR TITLE
new plugin: GTsubset to output only sites where all the selected samples exclusively share a genotype

### DIFF
--- a/plugins/GTsubset.c
+++ b/plugins/GTsubset.c
@@ -1,0 +1,266 @@
+/*  plugins/GTsubset.c -- output only positions where the selected samples exclusively
+                  share a genotype, i.e. all selected samples must have the same
+                  genotype (including both alleles) and none of the unselected
+                  samples can have the same genotype
+
+    Copyright (C) 2016 Computational Biology of Infection Research,
+                       Helmholtz Centre for Infection Research, Braunschweig,
+                       Germany
+
+    Author: David Laehnemann <david.laehnemann@hhu.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+#include <math.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include <htslib/vcf.h>
+#include <htslib/synced_bcf_reader.h>
+
+#include "bcftools.h"
+
+typedef struct _args_t
+{
+    bcf_hdr_t *hdr;     /*! VCF file header */
+    int *gt_arr;        /*! temporary array, to store GTs of current line/record */
+    int ngt_arr;        /*! hold the number of current GT array entries */
+    int nsmp;           /*! number of samples, can be determined from header but is needed in multiple contexts */
+    int n_sel_smps;     /*! number of selected samples who should exclusively share genotypes */
+    int *selected_smps; /*! pointer to start of array containing 1 at indices corresponding to selected samples in header dict and 0 at others*/
+}
+args_t;
+
+static args_t args;
+
+const char *about(void)
+{
+    return "Output only sites where the requested samples all exclusively share a genotype (GT).\n";
+}
+
+
+const char *usage(void)
+{
+    return
+        "\n"
+        "About:   Output only sites where the requested samples all exclusively share a genotype (GT), i.e.\n"
+        "         all selected samples must have the same GT, while non of the others can have it.\n"
+        "Usage:   bcftools +GTsubset <multisample.bcf/.vcf.gz> [General Options] -- [Plugin Options] \n"
+        "\n"
+        "Options:\n"
+        "   run \"bcftools plugin\" for a list of common options\n"
+        "\n"
+        "Plugin options:\n"
+        "  -s,--sample-list     comma-separated list of samples; only those sites where all of these\n"
+        "                       samples exclusively share their genotype are given as output\n"
+        "\n"
+        "Example:\n"
+        "   bcftools +GTsubset in.vcf -- -s SMP1,SMP2 \n"
+        "\n";
+}
+
+
+int init(int argc, char **argv, bcf_hdr_t *in, bcf_hdr_t *out)
+{
+    memset(&args,0,sizeof(args_t));
+
+    int i;
+
+    static struct option loptions[] =
+    {
+        {"help",            no_argument,       0,'h'},
+        {"sample-list",     required_argument, 0,'s'},
+        {0,0,0,0}
+    };
+
+    char **smps_strs = NULL;
+
+    char c;
+    while ((c = getopt_long(argc, argv, "?s:h",loptions,NULL)) >= 0)
+    {
+        switch (c)
+        {
+            case 's': smps_strs = hts_readlist(optarg,0,&(args.n_sel_smps));
+                      if ( args.n_sel_smps == 0 )
+                      {
+                          fprintf(stderr, "Sample specification not valid.\n");
+                          error("%s", usage());
+                      }
+                      break;
+            case 'h': usage(); break;
+            case '?':
+            default: error("%s", usage()); break;
+        }
+    }
+    if ( optind != argc )  usage();  // too many files given
+
+    args.hdr = bcf_hdr_dup(in);
+
+    // Samples parsing from header and input option
+    if ( !bcf_hdr_nsamples(args.hdr) )
+    {
+        error("No samples in input file.\n");
+    }
+    args.nsmp = bcf_hdr_nsamples(args.hdr);
+    args.selected_smps = (int*) calloc(args.nsmp,sizeof(int));
+    for ( i = 0; i < args.n_sel_smps; i++ )
+    {
+        int ind = bcf_hdr_id2int(args.hdr, BCF_DT_SAMPLE, smps_strs[i]);
+        if ( ind == -1 )
+        {
+            error("Sample '%s' not in input vcf file.\n", smps_strs[i]);
+        } else {
+            args.selected_smps[ind] = 1;
+        }
+        free(smps_strs[i]);
+    }
+    free(smps_strs);
+
+    /*
+    fprintf(stderr, "Selected samples array:[");
+    for (i=0;i<args.nsmp;i++)
+    {
+        fprintf(stderr, " %i", args.selected_smps[i]);
+    }
+    fprintf(stderr, " ]\n");
+    */
+
+    if ( bcf_hdr_id2int(args.hdr, BCF_DT_ID, "GT")<0 ) error("[E::%s] GT not present in the header\n", __func__);
+
+    args.gt_arr = NULL;
+
+    return 0;
+}
+
+
+/*
+ * GT field (genotype) comparison function.
+ */
+bcf1_t *process(bcf1_t *rec)
+{
+    uint64_t i;
+    bcf_unpack(rec, BCF_UN_FMT); // unpack the Format fields, including the GT field
+    int gte_smp = 0; // number GT array entries per sample (should be 2, one entry per allele)
+    args.ngt_arr = 0;        /*! hold the number of current GT array entries */
+    if ( (gte_smp = bcf_get_genotypes(args.hdr, rec, &(args.gt_arr), &(args.ngt_arr) ) ) <= 0 )
+    {
+        error("GT not present at %s: %d\n", args.hdr->id[BCF_DT_CTG][rec->rid].key, rec->pos+1);
+    }
+
+    gte_smp /= args.nsmp; // divide total number of genotypes array entries (= args.ngt_arr) by number of samples
+
+    // initialize with missing genotype
+    int a1 = 0;
+    int a2 = 0;
+
+    // initialize with first selected sample genotype that is not missing
+    int gt = -1;
+    while ( (a1 == 0) || (a2 == 0) )
+    {
+       gt++;
+       if (gt == args.nsmp) break;
+       if (args.selected_smps[gt] == 0) continue;
+       a1 = (args.gt_arr + gte_smp * gt)[0];
+       if ( gte_smp == 2 ) a2 = (args.gt_arr + gte_smp * gt)[1];
+       else if ( gte_smp == 1 ) a2 = bcf_int32_vector_end;
+       else error("GTsubset does not support ploidy higher than 2.\n");
+    }
+//    fprintf(stderr, "a1: %i  a2: %i\n", a1, a2);
+
+    // check all genotypes if they match (for included samples) or disagree (for samples not included)
+    gt = 0;
+    for ( i = 0; i < args.nsmp; i++ )
+    {
+        int *gt_ptr = args.gt_arr + gte_smp * i;
+
+        int b1 = gt_ptr[0];
+        int b2;
+        if ( gte_smp == 2 ) // two entries available per sample, padded with missing values for haploid genotypes
+        {
+            b2 = gt_ptr[1];
+        }
+        else if (gte_smp == 1 ) // use vector end value for second entry, if only one is available
+        {
+            b2 = bcf_int32_vector_end;
+        }
+        else
+        {
+            error("GTsubset does not support ploidy higher than 2.\n");
+        }
+
+ //      fprintf(stderr, "b1: %i  b2: %i\n", b1, b2);
+        /* missing genotypes are counted as always passing, as they neither
+         * mismatch the initial selected genotype for a selected sample, nor
+         * do they match the initial selected genotype for an excluded sample's
+         * genotype */
+        if ( (b1 == 0) || (b2 == 0) )
+        {
+            gt++;
+//            fprintf(stderr, "missing => pass\n");
+            continue;
+        }
+        else if ( args.selected_smps[i] == 1 )
+        {
+            if ( (b1 == a1) && (b2 == a2) )
+            {
+                gt++;
+//                fprintf(stderr, "match => pass\n");
+                continue;
+            }
+            else
+            {
+//                fprintf(stderr, "no match => fail\n");
+                break;
+            }
+        }
+        else if ( args.selected_smps[i] == 0 )
+        {
+            if ( (b1 != a1 ) || (b2 != a2) )
+            {
+                gt++;
+ //               fprintf(stderr, "no match => pass\n");
+                continue;
+            }
+            else
+            {
+//                fprintf(stderr, "match => fail\n");
+                break;
+            }
+        }
+    }
+    if ( gt == args.nsmp )
+    {
+        return rec;
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
+void destroy(void)
+{
+    /* freeing up args */
+    bcf_hdr_destroy(args.hdr);
+    free(args.gt_arr);
+    free(args.selected_smps);
+}

--- a/plugins/GTsubset.mk
+++ b/plugins/GTsubset.mk
@@ -1,0 +1,2 @@
+plugins/GTsubset.so: plugins/GTsubset.c version.h version.c 
+	$(CC) $(PLUGIN_FLAGS) $(CFLAGS) $(EXTRA_CPPFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ version.c $< $(LIBS)

--- a/test/test.pl
+++ b/test/test.pl
@@ -197,6 +197,9 @@ test_vcf_plugin($opts,in=>'view',out=>'view.GTisec.Hv.out',cmd=>'+GTisec',args=>
 test_vcf_plugin($opts,in=>'view',out=>'view.GTisec.m.out',cmd=>'+GTisec',args=>'-- -m | grep -v bcftools');
 test_vcf_plugin($opts,in=>'view',out=>'view.GTisec.mv.out',cmd=>'+GTisec',args=>'-- -mv | grep -v bcftools');
 test_vcf_plugin($opts,in=>'view',out=>'view.GTisec.v.out',cmd=>'+GTisec',args=>'-- -v | grep -v bcftools');
+test_vcf_plugin($opts,in=>'view',out=>'view.GTsubset.NA1.out',cmd=>'+GTsubset --no-version',args=>'-- -s NA00001');
+test_vcf_plugin($opts,in=>'view',out=>'view.GTsubset.NA1NA2.out',cmd=>'+GTsubset --no-version',args=>'-- -s NA00001,NA00002');
+test_vcf_plugin($opts,in=>'view',out=>'view.GTsubset.NA1NA2NA3.out',cmd=>'+GTsubset --no-version',args=>'-- -s NA00001,NA00002,NA00003');
 test_vcf_concat($opts,in=>['concat.1.a','concat.1.b'],out=>'concat.1.vcf.out',do_bcf=>0,args=>'');
 test_vcf_concat($opts,in=>['concat.1.a','concat.1.b'],out=>'concat.1.bcf.out',do_bcf=>1,args=>'');
 test_vcf_concat($opts,in=>['concat.2.a','concat.2.b'],out=>'concat.2.vcf.out',do_bcf=>0,args=>'-a');

--- a/test/view.GTsubset.NA1.out
+++ b/test/view.GTsubset.NA1.out
@@ -1,0 +1,38 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=file:///seq/references/1000Genomes-NCBI37.fasta
+##contig=<ID=11,length=135006516>
+##contig=<ID=20,length=63025520>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw read depth">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=Dels,Number=1,Type=Float,Description="Fraction of reads containing spanning deletions">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HRun,Number=1,Type=Integer,Description="Largest contiguous homopolymer run of variant allele in either direction">
+##INFO=<ID=HWE,Number=1,Type=Float,Description="Hardy-Weinberg equilibrium test (PMID:15789306)">
+##INFO=<ID=ICF,Number=1,Type=Float,Description="Inbreeding coefficient F">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=IS,Number=2,Type=Float,Description="Maximum number of reads supporting an indel and fraction of indel reads">
+##INFO=<ID=MQ,Number=1,Type=Integer,Description="Root-mean-square mapping quality of covering reads">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total mapping quality zero reads">
+##INFO=<ID=PV4,Number=4,Type=Float,Description="P-values for strand bias, baseQ bias, mapQ bias and tail distance bias">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant confidence/quality by depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="# high-quality bases">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
+##FILTER=<ID=StrandBias,Description="Min P-value for strand bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=BaseQualBias,Description="Min P-value for baseQ bias (INFO/PV4) [1e-100]">
+##FILTER=<ID=MapQualBias,Description="Min P-value for mapQ bias (INFO/PV4) [0]">
+##FILTER=<ID=EndDistBias,Description="Min P-value for end distance bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=MinAB,Description="Minimum number of alternate bases (INFO/DP4) [2]">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+11	5464562	.	C	T	999	PASS	DP=0	GT:PL:DP:GQ	./.:0,0,0:.:.	./.:0,0,0:.:.	./.:0,0,0:.:.
+20	76962	rs6111385	T	C	999	PASS	DP4=110138,70822,421911,262673;DP=911531;Dels=0;FS=21.447;HWE=0.491006;ICF=-0.01062;MQ0=1;MQ=46;PV4=2.5e-09,0,0,1;QD=22.31	GT:PL:DP:GQ	0/1:255,0,255:193:99	1/1:255,255,0:211:99	1/1:255,255,0:182:99
+20	271225	.	T	TTTA,TA	999	StrandBias	DP4=29281,42401,27887,29245;DP=272732;INDEL;IS=95,0.748031;MQ=47;PV4=0,1,0,1;QD=0.0948;AN=6;AC=2,2	GT:DP:GQ:PL	0/2:33:49:151,53,203,0,52,159	0/1:51:99:255,0,213,255,255,255	1/2:47:99:255,255,255,255,0,241
+X	2942109	rs5939407	T	C	999	PASS	DP4=23273,27816,40128,48208;DP=146673;Dels=0;FS=43.639;HWE=0.622715;ICF=-0.01176;MQ0=1;MQ=46;PV4=0.65,1,0,1;QD=14.81;AN=4;AC=3	GT:PL:DP:GQ	0:0,255:20:99	1:255,0:33:99	1/1:255,157,0:52:99
+X	3048719	.	T	C	999	PASS	DP4=13263,27466,40128,48208;DP=146673;Dels=0;FS=43.639;HWE=0.622715;ICF=-0.01176;MQ0=1;MQ=46;PV4=0.65,1,0,1;QD=14.81;AN=4;AC=3	GT:PL:DP:GQ	0:0,255:20:99	1:255,0:33:99	0|1:255,0,157:52:99
+Y	8657215	.	C	A	999	PASS	DP4=74915,114274,1948,2955;DP=195469;Dels=0;FS=3.181;MQ0=0;MQ=50;PV4=0.86,1,0,1;QD=33.77;AN=2;AC=1	GT:PL:DP:GQ	0:0,255:47:99	1:255,0:64:99	.:.:.:.

--- a/test/view.GTsubset.NA1NA2.out
+++ b/test/view.GTsubset.NA1NA2.out
@@ -1,0 +1,41 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=file:///seq/references/1000Genomes-NCBI37.fasta
+##contig=<ID=11,length=135006516>
+##contig=<ID=20,length=63025520>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw read depth">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=Dels,Number=1,Type=Float,Description="Fraction of reads containing spanning deletions">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HRun,Number=1,Type=Integer,Description="Largest contiguous homopolymer run of variant allele in either direction">
+##INFO=<ID=HWE,Number=1,Type=Float,Description="Hardy-Weinberg equilibrium test (PMID:15789306)">
+##INFO=<ID=ICF,Number=1,Type=Float,Description="Inbreeding coefficient F">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=IS,Number=2,Type=Float,Description="Maximum number of reads supporting an indel and fraction of indel reads">
+##INFO=<ID=MQ,Number=1,Type=Integer,Description="Root-mean-square mapping quality of covering reads">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total mapping quality zero reads">
+##INFO=<ID=PV4,Number=4,Type=Float,Description="P-values for strand bias, baseQ bias, mapQ bias and tail distance bias">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant confidence/quality by depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="# high-quality bases">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
+##FILTER=<ID=StrandBias,Description="Min P-value for strand bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=BaseQualBias,Description="Min P-value for baseQ bias (INFO/PV4) [1e-100]">
+##FILTER=<ID=MapQualBias,Description="Min P-value for mapQ bias (INFO/PV4) [0]">
+##FILTER=<ID=EndDistBias,Description="Min P-value for end distance bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=MinAB,Description="Minimum number of alternate bases (INFO/DP4) [2]">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+11	5464562	.	C	T	999	PASS	DP=0	GT:PL:DP:GQ	./.:0,0,0:.:.	./.:0,0,0:.:.	./.:0,0,0:.:.
+20	126310	.	ACC	A	999	StrandBias;EndDistBias	DP4=125718,95950,113812,80890;DP=461867;HWE=0.24036;ICF=0.01738;INDEL;IS=374,0.937343;MQ=49;PV4=9e-30,1,0,3.8e-13;QD=0.0172;AN=6;AC=4	GT:DP:GQ:PL	0/1:117:99:255,0,132	0/1:111:99:255,0,139	1/1:78:99:255,213,0
+20	138125	rs2298108	G	T	999	PASS	DP4=174391,20849,82080,4950;DP=286107;Dels=0;FS=3200;HWE=0.199462;ICF=0.01858;MQ0=0;MQ=46;PV4=0,0,0,1;QD=17.22;AN=6;AC=4	GT:PL:DP:GQ	0/1:135,0,163:66:99	0/1:140,0,255:71:99	1/1:255,199,0:66:99
+20	138148	rs2298109	C	T	999	PASS	DP4=194136,45753,94945,14367;DP=356657;Dels=0;FS=3200;HWE=0.177865;ICF=0.0198;MQ0=0;MQ=47;PV4=0,0,0,1;QD=14.57;AN=6;AC=4	GT:PL:DP:GQ	0/1:195,0,255:87:99	0/1:192,0,255:82:99	1/1:255,235,0:78:99
+20	304568	.	C	T	999	PASS	DP4=16413,4543,945,156;DP=43557;Dels=0;FS=3200;HWE=0.076855;ICF=0.0213;MQ0=0;MQ=50;PV4=0,0,0,1;QD=15.45;AN=6;AC=4	GT:PL:DP:GQ	0|1:95,0,255:90:99	0|1:192,0,255:13:99	1|1:255,95,0:60:99
+20	326891	.	A	AC	999	PASS	DP4=125718,95950,113812,80890;DP=461867;HWE=0.24036;ICF=0.01738;INDEL;IS=374,0.937343;MQ=49;PV4=9e-30,1,0,3.8e-13;QD=0.0172;AN=4;AC=2	GT:DP:GQ:PL	0|1:117:99:255,0,132	0|1:111:99:255,0,139	./.:.:.:.,.,.
+X	2928329	rs62584840	C	T	999	PASS	DP4=302,9137,32,1329;DP=11020;Dels=0;FS=13.38;HWE=0.284332;ICF=0.0253;MQ0=0;MQ=49;PV4=0.094,0,0,1;QD=18.61;AN=4;AC=1	GT:PL:DP:GQ	0:0,56:2:73	0:0,81:3:98	0/1:73,0,19:4:30
+X	2933066	rs61746890	G	C	999	PASS	DP4=69865,100561,461,783;DP=173729;Dels=0;FS=10.833;MQ0=0;MQ=50;PV4=0.005,3.6e-14,0,1;QD=15.33;AN=4;AC=1	GT:PL:DP:GQ	0:0,255:39:99	0:0,255:37:99	0/1:255,255,255:62:99
+Y	10011673	rs78249411	G	A	999	MinAB	DP4=47351,30839,178796,279653;DP=550762;Dels=0;FS=41.028;MQ0=37362;MQ=26;PV4=0,0,0,1;QD=17.45;AN=2;AC=2	GT:PL:DP:GQ	1:126,101:146:37	1:95,0:130:99	.:.:.:.

--- a/test/view.GTsubset.NA1NA2NA3.out
+++ b/test/view.GTsubset.NA1NA2NA3.out
@@ -1,0 +1,36 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=file:///seq/references/1000Genomes-NCBI37.fasta
+##contig=<ID=11,length=135006516>
+##contig=<ID=20,length=63025520>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw read depth">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=Dels,Number=1,Type=Float,Description="Fraction of reads containing spanning deletions">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HRun,Number=1,Type=Integer,Description="Largest contiguous homopolymer run of variant allele in either direction">
+##INFO=<ID=HWE,Number=1,Type=Float,Description="Hardy-Weinberg equilibrium test (PMID:15789306)">
+##INFO=<ID=ICF,Number=1,Type=Float,Description="Inbreeding coefficient F">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=IS,Number=2,Type=Float,Description="Maximum number of reads supporting an indel and fraction of indel reads">
+##INFO=<ID=MQ,Number=1,Type=Integer,Description="Root-mean-square mapping quality of covering reads">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total mapping quality zero reads">
+##INFO=<ID=PV4,Number=4,Type=Float,Description="P-values for strand bias, baseQ bias, mapQ bias and tail distance bias">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant confidence/quality by depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="# high-quality bases">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
+##FILTER=<ID=StrandBias,Description="Min P-value for strand bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=BaseQualBias,Description="Min P-value for baseQ bias (INFO/PV4) [1e-100]">
+##FILTER=<ID=MapQualBias,Description="Min P-value for mapQ bias (INFO/PV4) [0]">
+##FILTER=<ID=EndDistBias,Description="Min P-value for end distance bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=MinAB,Description="Minimum number of alternate bases (INFO/DP4) [2]">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+11	2343543	.	A	.	999	PASS	DP=100223	GT:PL:DP:GQ	0/0:0,255,255:193:99	0/0:0,255,255:211:99	0/0:0,255,255:182:99
+11	5464562	.	C	T	999	PASS	DP=0	GT:PL:DP:GQ	./.:0,0,0:.:.	./.:0,0,0:.:.	./.:0,0,0:.:.
+20	326891	.	A	AC	999	PASS	DP4=125718,95950,113812,80890;DP=461867;HWE=0.24036;ICF=0.01738;INDEL;IS=374,0.937343;MQ=49;PV4=9e-30,1,0,3.8e-13;QD=0.0172;AN=4;AC=2	GT:DP:GQ:PL	0|1:117:99:255,0,132	0|1:111:99:255,0,139	./.:.:.:.,.,.
+Y	10011673	rs78249411	G	A	999	MinAB	DP4=47351,30839,178796,279653;DP=550762;Dels=0;FS=41.028;MQ0=37362;MQ=26;PV4=0,0,0,1;QD=17.45;AN=2;AC=2	GT:PL:DP:GQ	1:126,101:146:37	1:95,0:130:99	.:.:.:.


### PR DESCRIPTION
I.e. all sites will be written, where the selected samples share a genotype AND none of the other samples has the same genotype.

The plugin is written for the plugin framework and includes a make instruction file, tests and the expected output for the tests. Also have a look at the following messages of commits squashed for this pull request:

commit ee658467c1919015968e3f80073efd9e45ff0739
Author: dlaehnemann <david.laehnemann@hhu.de>
Date:   Tue Mar 15 18:15:27 2016 +0100

    Added license and added 'plugins/' to the plugins' source file description in header comment.

commit 9d94edd7d45f117b22fa6ece07c92ea11501b657
Author: dlaehnemann <david.laehnemann@hhu.de>
Date:   Tue Mar 15 10:19:06 2016 +0100

    Added tests in test/test.pl and corresponding output files: test/view.GTsubset.*.out

commit 1d28325858112c4711f2561bb152be5e82484177
Author: dlaehnemann <david.laehnemann@hhu.de>
Date:   Tue Mar 15 09:35:56 2016 +0100

    Clarifications of the main description and the usage message.

commit 44a487184fcf0c49e883a77be645df85b71241dc
Author: dlaehnemann <david.laehnemann@hhu.de>
Date:   Fri Mar 11 12:30:26 2016 +0100

    Basic version of GTsubset plugin. Works and basics have been tested on test/view.vcf.