### PR TITLE
index: add option to set the path for the index file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for bcftools, utilities for Variant Call Format VCF/BCF files.
 #
-#   Copyright (C) 2012-2015 Genome Research Ltd.
+#   Copyright (C) 2012-2016 Genome Research Ltd.
 #
 #   Author: Petr Danecek <pd3@sanger.ac.uk>
 #
@@ -147,7 +147,7 @@ vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)
 vcfconvert.o: vcfconvert.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
 vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h
 vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h)
-vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h)
+vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h) $(HTSDIR)/htslib/kstring.h
 vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h)
 vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) vcmp.h $(HTSDIR)/htslib/khash.h
 vcfnorm.o: vcfnorm.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_faidx_h) $(bcftools_h) rbuf.h

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1110,6 +1110,10 @@ the CSI first and then the TBI.
 *-m, --min-shift 'INT'*::
     set minimal interval size for CSI indices to 2&#94;INT; default: 14
 
+*-o, --output-file 'FILE'*::
+    output file name. If not set, then the index will be created
+    using the input file name plus a '.csi' or '.tbi' extension
+
 *-t, --tbi*::
     generate TBI-format index for VCF files
 

--- a/test/test.pl
+++ b/test/test.pl
@@ -452,6 +452,18 @@ sub test_index
     cmd("$$opts{bin}/bcftools view -Ob $$opts{path}/$args{in}.vcf > $$opts{tmp}/$args{in}.bcf");
     cmd("$$opts{bin}/bcftools index -f $$opts{tmp}/$args{in}.bcf");
     test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools view -H $$opts{tmp}/$args{in}.bcf $args{reg}");
+
+    # output path
+    unlink("$$opts{tmp}/$args{in}.bcf.csi", "$$opts{tmp}/$args{in}.bcf.csi", "$$opts{tmp}/$args{in}.vcf.gz.tbi");
+    cmd("$$opts{bin}/bcftools index -fo $$opts{tmp}/$args{in}.csi $$opts{tmp}/$args{in}.bcf");
+    test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools view -H $$opts{tmp}/$args{in}.bcf $args{reg}");
+
+    # streaming
+    cmd("$$opts{bin}/bcftools view -Oz $$opts{path}/$args{in}.vcf | tee $$opts{tmp}/$args{in}.vcf.gz | $$opts{bin}/bcftools index -fo $$opts{tmp}/$args{in}.vcf.gz.csi");
+    test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools view -H $$opts{tmp}/$args{in}.vcf.gz $args{reg}");
+
+    cmd("$$opts{bin}/bcftools view -Ob $$opts{path}/$args{in}.vcf | tee $$opts{tmp}/$args{in}.bcf | $$opts{bin}/bcftools index -fo $$opts{tmp}/$args{in}.bcf.csi");
+    test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools view -H $$opts{tmp}/$args{in}.bcf $args{reg}");
 }
 
 sub test_vcf_idxstats

--- a/vcfindex.c
+++ b/vcfindex.c
@@ -1,4 +1,3 @@
-
 /*  vcfindex.c -- Index bgzip compressed VCF/BCF files for random access.
 
     Copyright (C) 2014-2016 Genome Research Ltd.
@@ -32,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <sys/stat.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+#include <htslib/kstring.h>
 #include "bcftools.h"
 
 #define BCF_LIDX_SHIFT    14
@@ -43,10 +43,11 @@ static void usage(void)
     fprintf(stderr, "Usage:   bcftools index [options] <in.bcf>|<in.vcf.gz>\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Indexing options:\n");
-    fprintf(stderr, "    -c, --csi            generate CSI-format index for VCF/BCF files [default]\n");
-    fprintf(stderr, "    -f, --force          overwrite index if it already exists\n");
-    fprintf(stderr, "    -m, --min-shift INT  set minimal interval size for CSI indices to 2^INT [14]\n");
-    fprintf(stderr, "    -t, --tbi            generate TBI-format index for VCF files\n");
+    fprintf(stderr, "    -c, --csi                generate CSI-format index for VCF/BCF files [default]\n");
+    fprintf(stderr, "    -f, --force              overwrite index if it already exists\n");
+    fprintf(stderr, "    -m, --min-shift INT      set minimal interval size for CSI indices to 2^INT [14]\n");
+    fprintf(stderr, "    -o, --output-file FILE   optional output index file name\n");
+    fprintf(stderr, "    -t, --tbi                generate TBI-format index for VCF files\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Stats options:\n");
     fprintf(stderr, "    -n, --nrecords       print number of records based on existing index file\n");
@@ -57,10 +58,6 @@ static void usage(void)
 
 int vcf_index_stats(char *fname, int stats)
 {
-    char *fn_out = NULL;
-    FILE *out;
-    out = fn_out ? fopen(fn_out, "w") : stdout;
-
     const char **seq;
     int i, nseq;
     tbx_t *tbx = NULL;
@@ -74,12 +71,12 @@ int vcf_index_stats(char *fname, int stats)
     if ( hts_get_format(fp)->format==vcf )
     {
         tbx = tbx_index_load(fname);
-        if ( !tbx ) { fprintf(stderr,"Could not load TBI index: %s\n", fname); return 1; }
+        if ( !tbx ) { fprintf(stderr,"Could not load index for VCF: %s\n", fname); return 1; }
     }
     else if ( hts_get_format(fp)->format==bcf )
     {
         idx = bcf_index_load(fname);
-        if ( !idx ) { fprintf(stderr,"Could not load CSI index: %s\n", fname); return 1; }
+        if ( !idx ) { fprintf(stderr,"Could not load index for BCF file: %s\n", fname); return 1; }
     }
     else
     {
@@ -97,7 +94,7 @@ int vcf_index_stats(char *fname, int stats)
         if (stats&2 || !records) continue;
         bcf_hrec_t *hrec = bcf_hdr_get_hrec(hdr, BCF_HL_CTG, "ID", seq[i], NULL);
         int hkey = hrec ? bcf_hrec_find_key(hrec, "length") : -1;
-        fprintf(out,"%s\t%s\t%" PRIu64 "\n", seq[i], hkey<0?".":hrec->vals[hkey], records);
+        printf("%s\t%s\t%" PRIu64 "\n", seq[i], hkey<0?".":hrec->vals[hkey], records);
     }
     if (!sum)
     {
@@ -106,14 +103,13 @@ int vcf_index_stats(char *fname, int stats)
         bcf1_t *rec = bcf_init1();
         if (bcf_read1(fp, hdr, rec) >= 0)
         {
-            fprintf(stderr,"%s index of %s does not contain any count metadata. Please re-index with a newer version of bcftools or tabix.\n", tbx ? "TBI" : "CSI", fname);
+            fprintf(stderr,"index of %s does not contain any count metadata. Please re-index with a newer version of bcftools or tabix.\n", fname);
             return 1;
         }
         bcf_destroy1(rec);
     }
-    if (stats&2) fprintf(out, "%" PRIu64 "\n", sum);
+    if (stats&2) printf("%" PRIu64 "\n", sum);
     free(seq);
-    fclose(out);
     hts_close(fp);
     bcf_hdr_destroy(hdr);
     if (tbx)
@@ -127,6 +123,7 @@ int main_vcfindex(int argc, char *argv[])
 {
     int c, force = 0, tbi = 0, stats = 0;
     int min_shift = BCF_LIDX_SHIFT;
+    char *outfn = NULL;
 
     static struct option loptions[] =
     {
@@ -136,11 +133,12 @@ int main_vcfindex(int argc, char *argv[])
         {"min-shift",required_argument,NULL,'m'},
         {"stats",no_argument,NULL,'s'},
         {"nrecords",no_argument,NULL,'n'},
+        {"output-file",required_argument,NULL,'o'},
         {NULL, 0, NULL, 0}
     };
 
     char *tmp;
-    while ((c = getopt_long(argc, argv, "ctfm:sn", loptions, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "ctfm:sno:", loptions, NULL)) >= 0)
     {
         switch (c)
         {
@@ -153,10 +151,10 @@ int main_vcfindex(int argc, char *argv[])
                 break;
             case 's': stats |= 1; break;
             case 'n': stats |= 2; break;
+            case 'o': outfn = optarg; break;
             default: usage();
         }
     }
-    if ( optind==argc ) usage();
     if (stats>2)
     {
         fprintf(stderr, "[E::%s] expected only one of --stats or --nrecords options\n", __func__);
@@ -173,69 +171,48 @@ int main_vcfindex(int argc, char *argv[])
         return 1;
     }
 
-    char *fname = argv[optind];
+    char *fname = NULL;
+    if ( optind>=argc )
+    {
+        if ( !isatty(fileno((FILE *)stdin)) ) fname = "-";  // reading from stdin
+        else usage();
+    }
+    else fname = argv[optind];
     if (stats) return vcf_index_stats(fname, stats);
 
-    htsFile *fp = hts_open(fname,"r"); 
-    if ( !fp ) error("Failed to read %s\n", fname);
-    htsFormat type = *hts_get_format(fp);
-    hts_close(fp);
-
-    if ( (type.format!=bcf && type.format!=vcf) || type.compression!=bgzf )
+    kstring_t idx_fname = {0,0,0};
+    if (outfn)
+        kputs(outfn,&idx_fname);
+    else
     {
-        fprintf(stderr, "[E::%s] unknown filetype; expected bgzip compressed VCF or BCF\n", __func__);
-        if ( type.compression!=bgzf )
-            fprintf(stderr, "[E::%s] was the VCF/BCF compressed with bgzip?\n", __func__);
-        return 1;
+        if (!strcmp(fname, "-")) { fprintf(stderr, "[E::%s] must specify an output path for index file when reading VCF/BCF from stdin\n", __func__); return 1; }
+        ksprintf(&idx_fname, "%s.%s", fname, tbi ? "tbi" : "csi");
     }
-    if (tbi && type.format==bcf)
-    {
-        fprintf(stderr, "[Warning] TBI-index does not work for BCF files. Generating CSI instead.\n");
-        tbi = 0; min_shift = BCF_LIDX_SHIFT;
-    }
-    if (min_shift == 0 && type.format==bcf)
-    {
-        fprintf(stderr, "[E::%s] Require min_shift>0 for BCF files.\n", __func__);
-        return 1;
-    }
-    if (!tbi && type.format==vcf && min_shift == 0)
-    {
-        fprintf(stderr, "[Warning] min-shift set to 0 for VCF file. Generating TBI file.\n");
-        tbi = 1;
-    }
-
     if (!force)
     {
         // Before complaining about existing index, check if the VCF file isn't newer.
-        char *idx_fname = (char*)alloca(strlen(fname) + 5);
-        strcat(strcpy(idx_fname, fname), tbi ? ".tbi" : ".csi");
         struct stat stat_tbi, stat_file;
-        if ( stat(idx_fname, &stat_tbi)==0 )
+        if ( stat(idx_fname.s, &stat_tbi)==0 )
         {
             stat(fname, &stat_file);
             if ( stat_file.st_mtime <= stat_tbi.st_mtime )
             {
-                fprintf(stderr,"[E::%s] the index file exists. Please use '-f' to overwrite.\n", __func__);
+                fprintf(stderr,"[E::%s] the index file exists. Please use '-f' to overwrite %s\n", __func__, idx_fname.s);
+                free(idx_fname.s);
                 return 1;
             }
         }
     }
 
-    if (type.format==bcf)
-    {
-        if ( bcf_index_build(fname, min_shift) != 0 )
-        {
-            fprintf(stderr,"[E::%s] bcf_index_build failed for %s\n", __func__, fname);
-            return 1;
-        }
-    }
-    else
-    {
-        if ( tbx_index_build(fname, min_shift, &tbx_conf_vcf) != 0 )
-        {
-            fprintf(stderr,"[E::%s] tbx_index_build failed for %s\n", __func__, fname);
-            return 1;
-        }
+    int ret = bcf_index_build2(fname, idx_fname.s, min_shift);
+    free(idx_fname.s);
+    if (ret != 0) {
+        if (ret == -2)
+            error("index: failed to open \"%s\"\n", fname);
+        else if (ret == -3)
+            error("index: \"%s\" is in a format that cannot be usefully indexed\n", fname);
+        else
+            error("index: \"%s\" is corrupted or unsorted\n", fname);
     }
     return 0;
 }


### PR DESCRIPTION
* removed filetype testing from `main()` as this prevents indexing streamed input files
* do not have to set `-` for stdin
* fail if reading from stdin and index path not set
* stats error messages cleaned up - VCF index can be CSI or TBI, so don't specify
* remove unused `fn_out` variable from stats
* requires samtools/htslib#330

Resolves #373

[NEWS]
* index: now has an option to set the path of the index file and can index a file from stdin
    `bcftools view -Ob in.vcf | tee in.bcf | bcftools index -o in.bcf.csi`