### PR TITLE
move regidx from htslib to bcftools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ call_h = call.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) vcmp.h
 convert_h = convert.h $(htslib_vcf_h)
 tsv2vcf_h = tsv2vcf.h $(htslib_vcf_h)
 filter_h = filter.h $(htslib_vcf_h)
-ploidy_h = ploidy.h $(htslib_regidx_h)
+ploidy_h = ploidy.h regidx.h
 prob1_h = prob1.h $(htslib_vcf_h) $(call_h)
 roh_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kstring.h $(HTSDIR)/htslib/kseq.h $(bcftools_h)
 cnv_h = HMM.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h)
@@ -169,10 +169,10 @@ kmin.o: kmin.c kmin.h
 mcall.o: mcall.c $(HTSDIR)/htslib/kfunc.h $(call_h)
 prob1.o: prob1.c $(prob1_h)
 vcmp.o: vcmp.c $(htslib_hts_h) vcmp.h
-ploidy.o: ploidy.c $(htslib_regidx_h) $(HTSDIR)/htslib/khash_str2int.h $(HTSDIR)/htslib/kseq.h $(htslib_hts_h) $(bcftools_h) $(ploidy_h)
+ploidy.o: ploidy.c regidx.h $(HTSDIR)/htslib/khash_str2int.h $(HTSDIR)/htslib/kseq.h $(htslib_hts_h) $(bcftools_h) $(ploidy_h)
 polysomy.o: polysomy.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(bcftools_h) peakfit.h
 peakfit.o: peakfit.c peakfit.h $(htslib_hts_h) $(HTSDIR)/htslib/kstring.h
-consensus.o: consensus.c $(htslib_hts_h) $(HTSDIR)/htslib/kseq.h rbuf.h $(bcftools_h) $(HTSDIR)/htslib/regidx.h
+consensus.o: consensus.c $(htslib_hts_h) $(HTSDIR)/htslib/kseq.h rbuf.h $(bcftools_h) regidx.h
 version.o: version.h version.c
 
 test/test-rbuf.o: test/test-rbuf.c rbuf.h

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ OBJS     = main.o vcfindex.o tabix.o \
            vcfstats.o vcfisec.o vcfmerge.o vcfquery.o vcffilter.o filter.o vcfsom.o \
            vcfnorm.o vcfgtcheck.o vcfview.o vcfannotate.o vcfroh.o vcfconcat.o \
            vcfcall.o mcall.o vcmp.o gvcf.o reheader.o convert.o vcfconvert.o tsv2vcf.o \
-           vcfcnv.o HMM.o vcfplugin.o consensus.o ploidy.o version.o \
+           vcfcnv.o HMM.o vcfplugin.o consensus.o ploidy.o regidx.o version.o \
            ccall.o em.o prob1.o kmin.o # the original samtools calling
 
 EXTRA_CPPFLAGS = -I. -I$(HTSDIR) -DPLUGINPATH=\"$(pluginpath)\"
@@ -172,6 +172,7 @@ vcmp.o: vcmp.c $(htslib_hts_h) vcmp.h
 ploidy.o: ploidy.c regidx.h $(HTSDIR)/htslib/khash_str2int.h $(HTSDIR)/htslib/kseq.h $(htslib_hts_h) $(bcftools_h) $(ploidy_h)
 polysomy.o: polysomy.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(bcftools_h) peakfit.h
 peakfit.o: peakfit.c peakfit.h $(htslib_hts_h) $(HTSDIR)/htslib/kstring.h
+regidx.o: regidx.c $(htslib_hts_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) regidx.h
 consensus.o: consensus.c $(htslib_hts_h) $(HTSDIR)/htslib/kseq.h rbuf.h $(bcftools_h) regidx.h
 version.o: version.h version.c
 

--- a/consensus.c
+++ b/consensus.c
@@ -35,8 +35,8 @@
 #include <htslib/kstring.h>
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/kseq.h>
-#include <htslib/regidx.h>
 #include "bcftools.h"
+#include "regidx.h"
 #include "rbuf.h"
 
 typedef struct

--- a/ploidy.c
+++ b/ploidy.c
@@ -22,11 +22,11 @@
     THE SOFTWARE.
 */
 
-#include <htslib/regidx.h>
 #include <htslib/khash_str2int.h>
 #include <htslib/kseq.h>
 #include <htslib/hts.h>
 #include "bcftools.h"
+#include "regidx.h"
 #include "ploidy.h"
 
 struct _ploidy_t

--- a/ploidy.h
+++ b/ploidy.h
@@ -55,7 +55,7 @@
 #ifndef __PLOIDY_H__
 #define __PLOIDY_H__
 
-#include <htslib/regidx.h>
+#include "regidx.h"
 
 typedef struct _ploidy_t ploidy_t;
 

--- a/regidx.c
+++ b/regidx.c
@@ -1,0 +1,338 @@
+/* 
+    Copyright (C) 2014 Genome Research Ltd.
+
+    Author: Petr Danecek <pd3@sanger.ac.uk>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+#include <htslib/hts.h>
+#include <htslib/kstring.h>
+#include <htslib/kseq.h>
+#include <htslib/khash_str2int.h>
+#include "regidx.h"
+
+#define LIDX_SHIFT 13   // number of insignificant index bits
+
+// List of regions for one chromosome
+typedef struct
+{
+    int *idx, nidx;
+    int nregs, mregs;   // n:used, m:alloced
+    reg_t *regs;
+    void *payload;
+}
+reglist_t;
+
+// Container of all sequences
+struct _regidx_t
+{
+    int nseq, mseq;     // n:used, m:alloced
+    reglist_t *seq;     // regions for each sequence
+    void *seq2regs;     // hash for fast lookup from chr name to regions
+    char **seq_names;
+    regidx_free_f free;     // function to free any data allocated by regidx_parse_f
+    regidx_parse_f parse;   // parse one input line
+    void *usr;              // user data to pass to regidx_parse_f
+
+    // temporary data for index initialization
+    kstring_t str;
+    int rid_prev, start_prev, end_prev;
+    int payload_size;
+    void *payload;
+};
+
+int regidx_seq_nregs(regidx_t *idx, const char *seq)
+{
+    int iseq;
+    if ( khash_str2int_get(idx->seq2regs, seq, &iseq)!=0 ) return 0; // no such sequence
+    return idx->seq[iseq].nregs;
+}
+
+int regidx_nregs(regidx_t *idx)
+{
+    int i, nregs = 0;
+    for (i=0; i<idx->nseq; i++) nregs += idx->seq[i].nregs;
+    return nregs;
+}
+
+char **regidx_seq_names(regidx_t *idx, int *n)
+{
+    *n = idx->nseq;
+    return idx->seq_names;
+}
+
+int _regidx_build_index(regidx_t *idx)
+{
+    int iseq;
+    for (iseq=0; iseq<idx->nseq; iseq++)
+    {
+        reglist_t *list = &idx->seq[iseq];
+        int j,k, imax = 0;   // max index bin
+        for (j=0; j<list->nregs; j++)
+        {
+            int ibeg = list->regs[j].start >> LIDX_SHIFT;
+            int iend = list->regs[j].end >> LIDX_SHIFT;
+            if ( imax < iend + 1 )
+            {
+                int old_imax = imax; 
+                imax = iend + 1;
+                kroundup32(imax);
+                list->idx = (int*) realloc(list->idx, imax*sizeof(int));
+                for (k=old_imax; k<imax; k++) list->idx[k] = -1;
+            }
+            if ( ibeg==iend )
+            {
+                if ( list->idx[ibeg]<0 ) list->idx[ibeg] = j;
+            }
+            else
+            {
+                for (k=ibeg; k<=iend; k++)
+                    if ( list->idx[k]<0 ) list->idx[k] = j;
+            }
+            list->nidx = iend + 1;
+        }
+    }
+    return 0;
+}
+
+int regidx_insert(regidx_t *idx, char *line)
+{
+    if ( !line )
+        return _regidx_build_index(idx);
+
+    char *chr_from, *chr_to;
+    reg_t reg;
+    int ret = idx->parse(line,&chr_from,&chr_to,&reg,idx->payload,idx->usr);
+    if ( ret==-2 ) return -1;   // error
+    if ( ret==-1 ) return 0;    // skip the line
+
+    int rid;
+    idx->str.l = 0;
+    kputsn(chr_from, chr_to-chr_from+1, &idx->str);
+    if ( khash_str2int_get(idx->seq2regs, idx->str.s, &rid)!=0 )
+    {
+        idx->nseq++;
+        int m_prev = idx->mseq;
+        hts_expand0(reglist_t,idx->nseq,idx->mseq,idx->seq);
+        hts_expand0(char*,idx->nseq,m_prev,idx->seq_names);
+        idx->seq_names[idx->nseq-1] = strdup(idx->str.s);
+        rid = khash_str2int_inc(idx->seq2regs, idx->seq_names[idx->nseq-1]);
+    }
+
+    reglist_t *list = &idx->seq[rid];
+    list->nregs++;
+    int m_prev = list->mregs;
+    hts_expand(reg_t,list->nregs,list->mregs,list->regs);
+    list->regs[list->nregs-1] = reg;
+    if ( idx->payload_size )
+    {
+        if ( m_prev < list->mregs ) list->payload = realloc(list->payload,idx->payload_size*list->mregs);
+        memcpy(list->payload + idx->payload_size*(list->nregs-1), idx->payload, idx->payload_size);
+    }
+
+    if ( idx->rid_prev==rid )
+    {
+        if ( idx->start_prev > reg.start || (idx->start_prev==reg.start && idx->end_prev>reg.end) ) 
+        { 
+            fprintf(stderr,"The regions are not sorted: %s:%d-%d is before %s:%d-%d\n", 
+                idx->str.s,idx->start_prev+1,idx->end_prev+1,idx->str.s,reg.start+1,reg.end+1); 
+            return -1;
+        }
+    }
+    idx->rid_prev = rid;
+    idx->start_prev = reg.start;
+    idx->end_prev = reg.end;
+    return 0;
+}
+
+regidx_t *regidx_init(const char *fname, regidx_parse_f parser, regidx_free_f free_f, size_t payload_size, void *usr_dat)
+{
+    if ( !parser )
+    {
+        if ( !fname ) parser = regidx_parse_tab;
+        else
+        {
+            int len = strlen(fname);
+            if ( len>=7 && !strcasecmp(".bed.gz",fname+len-7) )
+                parser = regidx_parse_bed;
+            else if ( len>=8 && !strcasecmp(".bed.bgz",fname+len-8) )
+                parser = regidx_parse_bed;
+            else if ( len>=4 && !strcasecmp(".bed",fname+len-4) )
+                parser = regidx_parse_bed;
+            else
+                parser = regidx_parse_tab;
+        }
+    }
+
+    regidx_t *idx = (regidx_t*) calloc(1,sizeof(regidx_t));
+    idx->free  = free_f;
+    idx->parse = parser;
+    idx->usr   = usr_dat;
+    idx->seq2regs = khash_str2int_init();
+    idx->rid_prev   = -1;
+    idx->start_prev = -1;
+    idx->end_prev   = -1;
+    idx->payload_size = payload_size;
+    if ( payload_size ) idx->payload = malloc(payload_size);
+
+    if ( !fname ) return idx;
+    
+    kstring_t str = {0,0,0};
+
+    htsFile *fp = hts_open(fname,"r");
+    if ( !fp ) goto error;
+
+    while ( hts_getline(fp, KS_SEP_LINE, &str) > 0 )
+    {
+        if ( regidx_insert(idx, str.s) ) goto error;
+    }
+    regidx_insert(idx, NULL);
+    
+    free(str.s);
+    hts_close(fp);
+    return idx;
+
+error:
+    free(str.s);
+    if ( fp ) hts_close(fp);
+    regidx_destroy(idx);
+    return NULL;
+}
+
+void regidx_destroy(regidx_t *idx)
+{
+    int i, j;
+    for (i=0; i<idx->nseq; i++)
+    {
+        reglist_t *list = &idx->seq[i];
+        if ( idx->free )
+        {
+            for (j=0; j<list->nregs; j++)
+                idx->free(list->payload + idx->payload_size*j);
+        }
+        free(list->payload);
+        free(list->regs);
+        free(list->idx);
+    }
+    free(idx->seq_names);
+    free(idx->seq);
+    free(idx->str.s);
+    free(idx->payload);
+    khash_str2int_destroy_free(idx->seq2regs);
+    free(idx);
+}
+
+int regidx_overlap(regidx_t *idx, const char *chr, uint32_t from, uint32_t to, regitr_t *itr)
+{
+    if ( itr ) itr->i = itr->n = 0;
+
+    int iseq;
+    if ( khash_str2int_get(idx->seq2regs, chr, &iseq)!=0 ) return 0; // no such sequence
+
+    reglist_t *list = &idx->seq[iseq];
+    if ( !list->nregs ) return 0;
+
+    int i, ibeg = from>>LIDX_SHIFT; 
+    int ireg = ibeg < list->nidx ? list->idx[ibeg] : list->idx[ list->nidx - 1 ];
+    if ( ireg < 0 )
+    {
+        // linear search; if slow, replace with binary search
+        if ( ibeg > list->nidx ) ibeg = list->nidx;
+        for (i=ibeg - 1; i>=0; i--)
+            if ( list->idx[i] >=0 ) break;
+        ireg = i>=0 ? list->idx[i] : 0;
+    }
+    for (i=ireg; i<list->nregs; i++)
+    {
+        if ( list->regs[i].start > to ) return 0;   // no match
+        if ( list->regs[i].end >= from && list->regs[i].start <= to ) break; // found
+    }
+
+    if ( i>=list->nregs ) return 0;   // no match
+
+    if ( !itr ) return 1;
+
+    itr->i = 0;
+    itr->n = list->nregs - i;
+    itr->reg = &idx->seq[iseq].regs[i];
+    if ( idx->payload_size )
+        itr->payload = idx->seq[iseq].payload + i*idx->payload_size;
+    else
+        itr->payload = NULL;
+
+    return 1;
+}
+
+int regidx_parse_bed(const char *line, char **chr_beg, char **chr_end, reg_t *reg, void *payload, void *usr)
+{
+    char *ss = (char*) line;
+    while ( *ss && isspace(*ss) ) ss++;
+    if ( !*ss ) return -1;      // skip blank lines
+    if ( *ss=='#' ) return -1;  // skip comments
+    
+    char *se = ss;
+    while ( *se && !isspace(*se) ) se++;
+    if ( !*se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
+
+    *chr_beg = ss;
+    *chr_end = se-1;
+
+    ss = se+1;
+    reg->start = hts_parse_decimal(ss, &se, 0);
+    if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
+
+    ss = se+1;
+    reg->end = hts_parse_decimal(ss, &se, 0) - 1;
+    if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
+    
+    return 0;
+}
+
+int regidx_parse_tab(const char *line, char **chr_beg, char **chr_end, reg_t *reg, void *payload, void *usr)
+{
+    char *ss = (char*) line;
+    while ( *ss && isspace(*ss) ) ss++;
+    if ( !*ss ) return -1;      // skip blank lines
+    if ( *ss=='#' ) return -1;  // skip comments
+    
+    char *se = ss;
+    while ( *se && !isspace(*se) ) se++;
+    if ( !*se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
+
+    *chr_beg = ss;
+    *chr_end = se-1;
+
+    ss = se+1;
+    reg->start = hts_parse_decimal(ss, &se, 0) - 1;
+    if ( ss==se ) { fprintf(stderr,"Could not parse bed line: %s\n", line); return -2; }
+
+    if ( !se[0] || !se[1] )
+        reg->end = reg->start;
+    else
+    {
+        ss = se+1;
+        reg->end = hts_parse_decimal(ss, &se, 0);
+        if ( ss==se ) reg->end = reg->start;
+        else reg->end--;
+    }
+    
+    return 0;
+}
+

--- a/regidx.h
+++ b/regidx.h
@@ -1,0 +1,154 @@
+/* 
+    Copyright (C) 2014 Genome Research Ltd.
+
+    Author: Petr Danecek <pd3@sanger.ac.uk>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
+
+/*
+    Regions indexing with an optional payload. Inspired by samtools/bedidx.c.
+    This code is intended as future replacement of bcf_sr_regions_t.
+
+    Example of usage:
+
+        // Init the parser and print regions. In this example the payload is a
+        // pointer to a string. For the description of parse_custom and
+        // free_custom functions, see regidx_parse_f and regidx_free_f below,
+        // and for working example see test/test-regidx.c.
+        regidx_t *idx = regidx_init(in_fname,parse_custom,free_custom,sizeof(char*),NULL);
+
+        // Query overlap with chr:from-to
+        regitr_t itr;
+        if ( regidx_overlap(idx, chr,from,to, &itr) ) printf("There is an overlap!\n");
+
+        while ( REGITR_OVERLAP(itr,from,to) )
+        {
+            printf("[%d,%d] overlaps with [%d,%d], payload=%s\n", from,to, 
+                REGITR_START(itr), REGITR_END(itr), REGITR_PAYLOAD(itr,char*));
+            itr.i++;
+        }
+
+        regidx_destroy(regs);
+*/
+
+#ifndef HTSLIB_REGIDX_H
+#define HTSLIB_REGIDX_H
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _regidx_t regidx_t;
+typedef struct
+{
+    uint32_t start, end;
+}
+reg_t;
+typedef struct
+{
+    int i, n;
+    reg_t *reg;
+    void *payload;
+}
+regitr_t;
+
+#define REGITR_START(itr) (itr).reg[(itr).i].start
+#define REGITR_END(itr)   (itr).reg[(itr).i].end
+#define REGITR_PAYLOAD(itr,type_t) ((type_t*)(itr).payload)[(itr).i]
+#define REGITR_OVERLAP(itr,from,to) (itr.i < itr.n && REGITR_START(itr)<=to && REGITR_END(itr)>=from )
+
+/*
+ *  regidx_parse_f - Function to parse one input line, such as regidx_parse_bed
+ *  or regidx_parse_tab below. The function is expected to set `chr_from` and
+ *  `chr_to` to point to first and last character of chromosome name and set
+ *  coordinates `reg->start` and `reg->end` (0-based, inclusive). If
+ *  regidx_init() was called with non-zero payload_size, the `payload` points
+ *  to a memory location of the payload_size and `usr` is data passed to
+ *  regidx_init(). Any memory allocated by the function will be freed by
+ *  regidx_free_f on regidx_destroy().
+ *
+ *  Return value: 0 on success, -1 to skip a record, -2 on fatal error.
+ */
+typedef int  (*regidx_parse_f)(const char *line, char **chr_beg, char **chr_end, reg_t *reg, void *payload, void *usr);
+typedef void (*regidx_free_f)(void *payload);
+
+int regidx_parse_bed(const char*,char**,char**,reg_t*,void*,void*);   // CHROM,FROM,TO (0-based,right-open)
+int regidx_parse_tab(const char*,char**,char**,reg_t*,void*,void*);   // CHROM,POS (1-based, inclusive)
+
+/*
+ *  regidx_init() - creates new index
+ *  @param fname:  input file name or NULL if regions will be added one-by-one via regidx_insert()
+ *  @param parsef: regidx_parse_bed, regidx_parse_tab or see description of regidx_parse_f. If NULL,
+ *                 the format will be autodected, currently either regidx_parse_tab (the default) or
+ *                 regidx_parse_bed (file must be named 'bed' or 'bed.gz') will be used. Note that
+ *                 the exact autodetection algorithm will change.
+ *  @param freef:  NULL or see description of regidx_parse_f
+ *  @param payload_size: 0 with regidx_parse_bed, regidx_parse_tab or see regidx_parse_f
+ *  @param usr:    optional user data passed to regidx_parse_f
+ *
+ *  Returns index on success or NULL on error.
+ */
+regidx_t *regidx_init(const char *fname, regidx_parse_f parsef, regidx_free_f freef, size_t payload_size, void *usr);
+
+/*
+ *  regidx_destroy() - free memory allocated by regidx_init
+ */
+void regidx_destroy(regidx_t *idx);
+
+/*
+ *  regidx_overlap() - check overlap of the location chr:from-to with regions
+ *  @param start,end:   0-based start, end coordinate (inclusive)
+ *  @param itr:         pointer to iterator, can be NULL if not needed
+ *
+ *  Returns 0 if there is no overlap or 1 if overlap is found. The overlapping
+ *  regions can be iterated as shown in the example above.
+ */
+int regidx_overlap(regidx_t *idx, const char *chr, uint32_t start, uint32_t end, regitr_t *itr);
+
+/*
+ *  regidx_insert() - add a new region. 
+ *
+ *  After last region has been added, call regidx_insert(idx,NULL) to
+ *  build the index.
+ *
+ *  Returns 0 on success or -1 on error.
+ */
+int regidx_insert(regidx_t *idx, char *line);
+
+/*
+ *  regidx_seq_names() - return list of all sequence names
+ */
+char **regidx_seq_names(regidx_t *idx, int *n);
+
+/*
+ *  regidx_seq_nregs() - number of regions
+ *  regidx_nregs()  - total number of regions
+ */
+int regidx_seq_nregs(regidx_t *idx, const char *seq);
+int regidx_nregs(regidx_t *idx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/regidx.h
+++ b/regidx.h
@@ -1,5 +1,5 @@
 /* 
-    Copyright (C) 2014 Genome Research Ltd.
+    Copyright (C) 2014-2016 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
 
@@ -23,7 +23,7 @@
 */
 
 /*
-    Regions indexing with an optional payload. Inspired by samtools/bedidx.c.
+    Region indexing with an optional payload. Inspired by samtools/bedidx.c.
     This code is intended as future replacement of bcf_sr_regions_t.
 
     Example of usage:
@@ -46,6 +46,28 @@
         }
 
         regidx_destroy(regs);
+
+
+    Another example, loop over all regions:
+        
+        regidx_t *idx = regidx_init(in_fname,NULL,NULL,0,NULL);
+        regitr_t itr;
+        REGITR_INIT(itr);
+        while ( regidx_loop(idx,&itr) )
+            printf("chr=%s  beg=%d  end=%d\n", regitr_seqname(&itr),REGITR_START(itr),REGITR_END(itr));
+        regidx_destroy(regs);
+
+
+    A note about memory requirements: All regions are stored in memory. When
+    the whole uint32_t range is indexed (beg=0,end=UINT32_MAX), the index takes
+    up to 2.1MB of memory per sequence (50MB in total for 24 sequences). 
+    Howeveer, in typical usage the memory requirements are 10x lower, for
+    example 200k human exons require 0.2MB per sequence (5MB in total). With
+    only one region per per sequence (e.g. whole chromosomes), the index is not
+    build and the required memory is neglibible. The index is created only when
+    regidx_overlap() is called, therefore in the regidx_loop() mode the memory
+    is always small.
+
 */
 
 #ifndef HTSLIB_REGIDX_H
@@ -69,6 +91,7 @@ typedef struct
     int i, n;
     reg_t *reg;
     void *payload;
+    int seq;
 }
 regitr_t;
 
@@ -76,6 +99,8 @@ regitr_t;
 #define REGITR_END(itr)   (itr).reg[(itr).i].end
 #define REGITR_PAYLOAD(itr,type_t) ((type_t*)(itr).payload)[(itr).i]
 #define REGITR_OVERLAP(itr,from,to) (itr.i < itr.n && REGITR_START(itr)<=to && REGITR_END(itr)>=from )
+#define REGITR_INIT(itr)  (itr).reg = 0
+
 
 /*
  *  regidx_parse_f - Function to parse one input line, such as regidx_parse_bed
@@ -92,8 +117,14 @@ regitr_t;
 typedef int  (*regidx_parse_f)(const char *line, char **chr_beg, char **chr_end, reg_t *reg, void *payload, void *usr);
 typedef void (*regidx_free_f)(void *payload);
 
-int regidx_parse_bed(const char*,char**,char**,reg_t*,void*,void*);   // CHROM,FROM,TO (0-based,right-open)
-int regidx_parse_tab(const char*,char**,char**,reg_t*,void*,void*);   // CHROM,POS (1-based, inclusive)
+/*
+ *  A note about the parsers: 
+ *      - leading spaces are ignored
+ *      - lines starting with "#" are ignored
+ */
+int regidx_parse_bed(const char*,char**,char**,reg_t*,void*,void*);   // CHROM or whitespace-separated CHROM,FROM,TO (0-based,right-open)
+int regidx_parse_tab(const char*,char**,char**,reg_t*,void*,void*);   // CHROM or whitespace-separated CHROM,POS (1-based, inclusive)
+int regidx_parse_reg(const char*,char**,char**,reg_t*,void*,void*);   // CHROM, CHROM:POS, CHROM:FROM-TO, CHROM:FROM- (1-based, inclusive)
 
 /*
  *  regidx_init() - creates new index
@@ -126,14 +157,22 @@ void regidx_destroy(regidx_t *idx);
 int regidx_overlap(regidx_t *idx, const char *chr, uint32_t start, uint32_t end, regitr_t *itr);
 
 /*
+ *  regidx_loop() - loop over all regions
+ *  Returns 0 when done or 1 when itr is set to next region
+ */
+int regidx_loop(regidx_t *idx, regitr_t *itr);
+
+/*  Current sequence name */
+const char *regitr_seqname(regidx_t *idx, regitr_t *itr);
+
+/*
  *  regidx_insert() - add a new region. 
- *
- *  After last region has been added, call regidx_insert(idx,NULL) to
- *  build the index.
+ *  regidx_insert_list() - add new regions from a list
  *
  *  Returns 0 on success or -1 on error.
  */
 int regidx_insert(regidx_t *idx, char *line);
+int regidx_insert_list(regidx_t *idx, char *line, char delim);
 
 /*
  *  regidx_seq_names() - return list of all sequence names


### PR DESCRIPTION
regidx: import regidx api from htslib into bcftools
This is meant as a temporary change while we extend the
regidx api, but allow bcftools code to use these changes
before they appear in some form in htslib.

extend regidx API with:
* added functions to loop over all regions
* lazy index build in case random access is not required
* support for chromosome names only, beg-end coordinates not mandatory
* set cap at maximum coordinate at 2147483647, hts_itr does not support larger
* tab and reg parsers will throw on finding a `0` to catch user
  error of using 0-based rather than 1-based coords
