### PR TITLE
gtcheck: improved cross-check mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ TABIX  = $(HTSDIR)/tabix
 
 CC       = gcc
 CPPFLAGS =
-CFLAGS   = -g -Wall -Wc++-compat -O2 -Wpadded
 CFLAGS   = -g -Wall -Wc++-compat -O2
 LDFLAGS  =
 LIBS     =
@@ -46,7 +45,7 @@ OBJS     = main.o vcfindex.o tabix.o \
            vcfstats.o vcfisec.o vcfmerge.o vcfquery.o vcffilter.o filter.o vcfsom.o \
            vcfnorm.o vcfgtcheck.o vcfview.o vcfannotate.o vcfroh.o vcfconcat.o \
            vcfcall.o mcall.o vcmp.o gvcf.o reheader.o convert.o vcfconvert.o tsv2vcf.o \
-           vcfcnv.o HMM.o vcfplugin.o consensus.o ploidy.o bin.o version.o \
+           vcfcnv.o HMM.o vcfplugin.o consensus.o ploidy.o bin.o hclust.o version.o \
            ccall.o em.o prob1.o kmin.o # the original samtools calling
 
 EXTRA_CPPFLAGS = -I. -I$(HTSDIR) -DPLUGINPATH=\"$(pluginpath)\"
@@ -148,7 +147,7 @@ vcfcall.o: vcfcall.c $(htslib_vcf_h) $(HTSDIR)/htslib/kfunc.h $(htslib_synced_bc
 vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(HTSDIR)/htslib/kseq.h $(htslib_bgzf_h) $(htslib_tbx_h) $(bcftools_h)
 vcfconvert.o: vcfconvert.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
 vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h
-vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h)
+vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) hclust.h
 vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h) $(HTSDIR)/htslib/kstring.h
 vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h)
 vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) vcmp.h $(HTSDIR)/htslib/khash.h
@@ -177,6 +176,7 @@ peakfit.o: peakfit.c peakfit.h $(htslib_hts_h) $(HTSDIR)/htslib/kstring.h
 consensus.o: consensus.c $(htslib_hts_h) $(HTSDIR)/htslib/kseq.h rbuf.h $(bcftools_h) $(HTSDIR)/htslib/regidx.h
 bin.o: bin.c $(bin_h)
 version.o: version.h version.c
+hclust.o: hclust.c hclust.h
 
 test/test-rbuf.o: test/test-rbuf.c rbuf.h
 

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1026,6 +1026,18 @@ Checks sample identity or, without *-g*, multi-sample cross-check is performed.
 *-a, --all-sites*::
     output for all sites
 
+*-c, --cluster* 'FLOAT','FLOAT'::
+    min inter- and max intra-sample error [0.23,-0.3]
+
+    The first "min" argument controls the typical error rate in multiplexed
+    runs ("lanelets") from the same sample. Lanelets with error rate less
+    than this will always be considered as coming from the same sample.
+    The second "max" argument is the reverse: lanelets with error rate
+    greater than the absolute value of this parameter will always be
+    considered as different samples. When the value is negative, the cutoff
+    may be heuristically lowered by the clustering engine. If positive, the
+    value is interpreted as a fixed cutoff.
+
 *-g, --genotypes* 'genotypes.vcf.gz'::
     reference genotypes to compare against
 

--- a/hclust.c
+++ b/hclust.c
@@ -309,9 +309,6 @@ float calc_dev(node_t **dat, int n)
  */
 float hclust_set_threshold(hclust_t *clust, float min_inter_dist, float max_intra_dist)
 {
-    if ( max_intra_dist > 0 ) return max_intra_dist;    // use fixed cutoff
-    max_intra_dist = fabs(max_intra_dist);
-
     node_t **dat = clust->rmme + clust->ndat;
     int i, ndat = clust->nrmme - clust->ndat;
  
@@ -329,8 +326,15 @@ float hclust_set_threshold(hclust_t *clust, float min_inter_dist, float max_intr
         ksprintf(&clust->str,"DEV\t%f\t%f\n",th,dev);
         if ( min_dev > dev && th >= min_inter_dist ) { min_dev = dev; imin = i; }
     }
-    th = imin==-1 ? max_intra_dist : dat[imin]->value;
-    if ( th > max_intra_dist ) th = max_intra_dist;
+    if ( max_intra_dist > 0 )
+        th = max_intra_dist;  // use fixed cutoff, the above was only for debugging output
+    else
+    {
+        // dynamic cutoff
+        max_intra_dist = fabs(max_intra_dist);
+        th = imin==-1 ? max_intra_dist : dat[imin]->value;
+        if ( th > max_intra_dist ) th = max_intra_dist;
+    }
     ksprintf(&clust->str,"TH\t%f\n", th);
     ksprintf(&clust->str,"MAX_DIST\t%f\n", dat[ndat-1]->value);
     ksprintf(&clust->str,"MIN_INTER\t%f\n", min_inter_dist);

--- a/hclust.c
+++ b/hclust.c
@@ -1,0 +1,396 @@
+/* The MIT License
+
+   Copyright (c) 2016 Genome Research Ltd.
+
+   Author: Petr Danecek <pd3@sanger.ac.uk>
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+ */
+
+#include <htslib/hts.h>
+#include <htslib/kstring.h>
+#include <stdlib.h>
+#include "bcftools.h"
+#include "hclust.h"
+
+typedef struct _node_t
+{
+    struct _node_t *akid, *bkid, *next, *prev, *parent;
+    int id, idx;    // id: unique node id; idx: current index to pdist
+    float value;    // max pairwise dist of elements within the node
+}
+node_t;
+
+struct _hclust_t
+{
+    int ndat, nclust;       // ndat: number of elements (pdist matrix size); nclust: current number of clusters
+    float *pdist;           // pairwise cluster distances, diagonal matrix accessed via the PDIST macro
+    node_t *first, *last;   // clusters are maintained in a double-linked list
+    node_t **rmme;          // convenience array to remove all allocated nodes at the end
+    int nrmme;
+    kstring_t str;          // (for debugging) pointer to str.s is returned by create_dot()
+    char **dbg;             // (for debugging) created by create_list() via set_threshold() and returned by explain()
+    int ndbg, mdbg;
+};
+
+node_t *append_node(hclust_t *clust, int idx)
+{
+    node_t *node = (node_t*) calloc(1,sizeof(node_t));
+
+    clust->nclust++;
+    node->id  = clust->nrmme;
+    node->idx = idx;
+    if ( !clust->first )
+    {
+        clust->first = node; 
+        clust->last  = node; 
+    }
+    else
+    {
+        node->prev = clust->last;
+        clust->last->next = node; 
+        clust->last = node; 
+    }
+    
+    if ( clust->nrmme >= clust->ndat*2 ) error("hclust fixme: %d vs %d\n",clust->nrmme,clust->ndat);
+    clust->rmme[clust->nrmme++] = node;
+
+    return node;
+}
+void remove_node(hclust_t *clust, node_t *node)
+{
+    if ( node==clust->first ) clust->first = node->next;
+    if ( node==clust->last ) clust->last = node->prev;
+    if ( node->next ) node->next->prev = node->prev;
+    if ( node->prev ) node->prev->next = node->next;
+    clust->nclust--;
+}
+
+#if DEBUG
+void hclust_debug(hclust_t *clust)
+{
+    int i;
+    fprintf(stderr,"nrmme=%d  nclust=%d\n", clust->nrmme,clust->nclust);
+    for (i=0; i<clust->nrmme; i++)
+    {
+        node_t *node = clust->rmme[i];
+        int akid  = node->akid ? node->akid->id : -1;
+        int bkid  = node->bkid ? node->bkid->id : -1;
+        int akidx = node->akid ? node->akid->idx : -1;
+        int bkidx = node->bkid ? node->bkid->idx : -1;
+        fprintf(stderr,"\t%d\t%d\t%f\t%d %d\t%d %d\n",node->id,node->idx,node->value,akid,bkid,akidx,bkidx);
+    }
+
+    int j;
+    for (i=1; i<clust->ndat; i++)
+    {
+        int active = 0;
+        node_t *node = clust->first;
+        while (node)
+        {
+            if ( node->idx==i ) { active=1; break; }
+            node = node->next;
+        }
+        fprintf(stderr,"%2d%c ",i,active?'*':' ');
+        for (j=0; j<i; j++)
+        {
+            if ( PDIST(clust->pdist,i,j)==9 )
+                fprintf(stderr,"  -----  ");
+            else
+                fprintf(stderr," %f", PDIST(clust->pdist,i,j));
+        }
+        fprintf(stderr,"\n");
+    }
+    for (j=0; j<clust->ndat-1; j++) fprintf(stderr,"  %6d ",j); fprintf(stderr,"\n");
+}
+#endif
+
+hclust_t *hclust_init(int n, float *pdist)
+{
+    hclust_t *clust = (hclust_t*) calloc(1,sizeof(hclust_t));
+    clust->ndat  = n;
+    clust->pdist = pdist;
+    clust->rmme = (node_t**) calloc(n*2,sizeof(node_t*));
+
+    // init clusters
+    int i;
+    for (i=0; i<clust->ndat; i++) append_node(clust,i);
+
+    // build the tree
+    while ( clust->nclust>1 )
+    {
+        // find two clusters with minimum distance
+        float min_value = HUGE_VAL;
+        node_t *iclust = clust->first->next;
+        node_t *min_iclust = NULL, *min_jclust = NULL;
+        while ( iclust )
+        {
+            node_t *jclust = clust->first;
+            while ( jclust!=iclust )
+            {
+                float value = PDIST(clust->pdist,iclust->idx,jclust->idx);
+                if ( value < min_value ) 
+                { 
+                    min_value  = value;
+                    min_iclust = iclust;
+                    min_jclust = jclust; 
+                }
+                jclust = jclust->next;
+            }
+            iclust = iclust->next;
+        }
+        assert( min_iclust && min_jclust ); // pdist contains inf or nan, fix the caller
+        remove_node(clust,min_iclust);
+        remove_node(clust,min_jclust);
+
+        // update the pairwise distances. We keep the matrix and as we are moving up the
+        // tree, we use fewer columns/rows as the number of clusters decreases: we reuse
+        // i-th and leave j-th unused. Inter-cluster distance is defined as maximum distance
+        // between pairwise distances of elements within the cluster.
+        iclust = clust->first;
+        while ( iclust )
+        {
+            if ( PDIST(clust->pdist,iclust->idx,min_iclust->idx) < PDIST(clust->pdist,iclust->idx,min_jclust->idx) )
+                PDIST(clust->pdist,iclust->idx,min_iclust->idx) = PDIST(clust->pdist,iclust->idx,min_jclust->idx);
+            iclust = iclust->next;
+        }
+
+        node_t *node = append_node(clust,min_iclust->idx);
+        node->akid  = min_iclust;
+        node->bkid  = min_jclust;
+        node->value = min_value;
+        node->akid->parent = node;
+        node->bkid->parent = node;
+    }
+
+    return clust;
+}
+void hclust_destroy(hclust_t *clust)
+{
+    int i;
+    for (i=0; i<clust->nrmme; i++) free(clust->rmme[i]);
+    free(clust->rmme);
+    free(clust->dbg);
+    free(clust->str.s);
+    free(clust);
+}
+
+char *hclust_create_dot(hclust_t *clust, char **labels, float th)
+{
+    clust->str.l = 0;
+    ksprintf(&clust->str,"digraph myGraph {");
+
+    int i;
+    for (i=0; i<clust->nrmme; i++)
+    {
+        node_t *node = clust->rmme[i];
+        if ( node->value )
+            ksprintf(&clust->str,"\"%d\" [label=\"%f\"];", node->id,node->value);
+        else
+            ksprintf(&clust->str,"\"%d\" [label=\"%s\"];", node->id,labels[node->idx]);
+    }
+    for (i=0; i<clust->nrmme; i++)
+    {
+        node_t *node = clust->rmme[i];
+        if ( node->akid )
+        {
+            if ( node->value >= th && node->akid && node->akid->value < th )
+                ksprintf(&clust->str,"\"%d\" -> \"%d\" [color=\"#D43F3A\" penwidth=3];", node->id,node->akid->id);
+            else
+                ksprintf(&clust->str,"\"%d\" -> \"%d\";", node->id,node->akid->id);
+        }
+
+        if ( node->bkid )
+        {
+            if ( node->value >= th && node->bkid && node->bkid->value < th )
+                ksprintf(&clust->str,"\"%d\" -> \"%d\" [color=\"#D43F3A\" penwidth=3];", node->id,node->bkid->id);
+            else
+                ksprintf(&clust->str,"\"%d\" -> \"%d\";", node->id,node->bkid->id);
+        }
+    }
+    ksprintf(&clust->str,"};");
+    return clust->str.s;
+}
+char **hclust_explain(hclust_t *clust, int *nlines)
+{
+    clust->ndbg = 0;
+    char *beg = clust->str.s;
+    while ( *beg )
+    {
+        char *end = beg;
+        while ( *end && *end!='\n' ) end++;
+        clust->ndbg++;
+        hts_expand(char*,clust->ndbg,clust->mdbg,clust->dbg);
+        clust->dbg[clust->ndbg-1] = beg;
+        if ( !*end ) break;
+        *end = 0;
+        beg = end + 1;
+    }
+
+    *nlines = clust->ndbg;
+    return clust->dbg;
+}
+
+cluster_t *append_cluster(node_t *node, cluster_t *cluster, int *nclust, node_t **stack)
+{
+    (*nclust)++;
+    cluster = (cluster_t*) realloc(cluster,sizeof(cluster_t)*(*nclust));
+    cluster_t *clust = &cluster[*nclust-1];
+    clust->nmemb = 0;
+    clust->memb  = NULL;
+    clust->dist  = node->value;
+
+    int nstack = 1;
+    stack[0] = node;
+
+    while ( nstack )
+    {
+        node_t *node = stack[--nstack];
+        node_t *akid = node->akid;
+        node_t *bkid = node->bkid;
+        if ( node->akid )
+        {
+            stack[nstack++] = akid;
+            stack[nstack++] = bkid;
+        }
+        else    
+        {
+            clust->nmemb++;
+            clust->memb = (int*) realloc(clust->memb,sizeof(int)*clust->nmemb);
+            clust->memb[clust->nmemb-1] = node->id;
+        }
+    }
+    return cluster;
+}
+
+int cmp_nodes(const void *a, const void *b)
+{
+    const node_t *an = *((const node_t**) a);
+    const node_t *bn = *((const node_t**) b);
+    if ( an->value < bn->value ) return -1;
+    if ( an->value > bn->value ) return 1;
+    return 0;
+}
+
+float calc_dev(node_t **dat, int n)
+{
+    float avg = 0, dev = 0;
+    int i;
+    for (i=0; i<n; i++) avg += dat[i]->value;
+    avg /= n;
+    for (i=0; i<n; i++) dev += (dat[i]->value - avg)*(dat[i]->value - avg);
+    return sqrt(dev/n);
+}
+
+/*
+    Heuristics to determine clustering cutoff: sort nodes by distance and
+    split into two groups by minimizing the standard deviation.
+    This works best when two elements from a single different sample are
+    included in the mix.
+        - min_inter_dist .. smaller values are always considered identical
+        - max_intra_dist .. larger values are always considered different
+ */
+float hclust_set_threshold(hclust_t *clust, float min_inter_dist, float max_intra_dist)
+{
+    if ( max_intra_dist > 0 ) return max_intra_dist;    // use fixed cutoff
+    max_intra_dist = fabs(max_intra_dist);
+
+    node_t **dat = clust->rmme + clust->ndat;
+    int i, ndat = clust->nrmme - clust->ndat;
+ 
+    qsort(dat, ndat, sizeof(dat), cmp_nodes);
+
+    clust->str.l = 0;
+    float th, min_dev = HUGE_VAL;
+    int imin = -1;
+    for (i=0; i<ndat; i++)
+    {
+        float dev = 0;
+        if ( i>0 ) dev += calc_dev(dat,i);
+        if ( i+1<ndat ) dev += calc_dev(dat+i,ndat-i);
+        th  = dat[i]->value;
+        ksprintf(&clust->str,"DEV\t%f\t%f\n",th,dev);
+        if ( min_dev > dev && th >= min_inter_dist ) { min_dev = dev; imin = i; }
+    }
+    th = imin==-1 ? max_intra_dist : dat[imin]->value;
+    if ( th > max_intra_dist ) th = max_intra_dist;
+    ksprintf(&clust->str,"TH\t%f\n", th);
+    ksprintf(&clust->str,"MAX_DIST\t%f\n", dat[ndat-1]->value);
+    ksprintf(&clust->str,"MIN_INTER\t%f\n", min_inter_dist);
+    ksprintf(&clust->str,"MAX_INTRA\t%f\n", max_intra_dist);
+    return th;
+} 
+
+cluster_t *hclust_create_list(hclust_t *clust, float min_inter_dist, float *max_intra_dist, int *nclust)
+{
+    float cutoff = *max_intra_dist = hclust_set_threshold(clust, min_inter_dist, *max_intra_dist);
+
+    node_t **stack = (node_t**) malloc(sizeof(node_t*)*clust->ndat);
+    node_t **tmp = (node_t**) malloc(sizeof(node_t*)*clust->ndat);
+    stack[0] = clust->first;
+    int nstack = 1;
+    
+    cluster_t *cluster = NULL;
+    int ncluster = 0;
+
+    if ( stack[0]->value < cutoff )
+    {
+        // all values are within the limits - create a single cluster
+        cluster = append_cluster(stack[0], cluster, &ncluster, tmp);
+        nstack = 0;
+    }
+
+    while ( nstack )
+    {
+        node_t *node = stack[--nstack];
+        node_t *akid = node->akid;
+        node_t *bkid = node->bkid;
+        if ( !akid )
+        {
+            cluster = append_cluster(node, cluster, &ncluster, tmp);
+            continue;
+        }
+
+        if ( node->value >= cutoff && akid->value < cutoff )
+            cluster = append_cluster(akid, cluster, &ncluster, tmp);
+        else    
+            stack[nstack++] = akid;
+
+        if ( node->value >= cutoff && bkid->value < cutoff )
+            cluster = append_cluster(bkid, cluster, &ncluster, tmp);
+        else    
+            stack[nstack++] = bkid;
+    }
+
+    free(tmp);
+    free(stack);
+
+    *nclust = ncluster;
+    return cluster;
+}
+
+void hclust_destroy_list(cluster_t *clust, int nclust)
+{
+    int i;
+    for (i=0; i<nclust; i++) free(clust[i].memb);
+    free(clust);
+}
+
+

--- a/hclust.h
+++ b/hclust.h
@@ -1,0 +1,77 @@
+/* The MIT License
+
+   Copyright (c) 2016 Genome Research Ltd.
+
+   Author: Petr Danecek <pd3@sanger.ac.uk>
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+ */
+
+/*
+    Simple hierarchical clustering
+*/
+
+#ifndef __HCLUST_H__
+#define __HCLUST_H__
+
+#include <stdio.h>
+
+typedef struct _hclust_t hclust_t;
+
+typedef struct
+{
+    float dist;
+    int nmemb, *memb;
+}
+cluster_t;
+
+#define PDIST(mat,a,b) (mat)[((a)>(b)?((a)*((a)-1)/2+(b)):((b)*((b)-1)/2+(a)))]
+
+/*
+ *  hclust_init() - init and run clustering
+ *  @n:     number of elements
+ *  @pdist: pairwise distances. The array will be modified by hclust and
+ *          must exist until hclust_destroy() is called
+ */
+hclust_t *hclust_init(int n, float *pdist);
+void hclust_destroy(hclust_t *clust);
+
+/*
+ *  hclust_create_list() - returns a list of clusters
+ *  @min_inter_dist: minimum inter-cluster distance. If smaller, elements are considered
+ *                   homogenous, belonging to the same cluster.
+ *  @max_intra_dist: maximum intra-cluster distance allowed. If smaller than 0,
+ *                   the threshold can be heuristically lowered, otherwise considered
+ *                   a fixed cutoff. The pointer will be filled to the cutoff actually used.
+ */
+cluster_t *hclust_create_list(hclust_t *clust, float min_inter_dist, float *max_intra_dist, int *nclust);
+void hclust_destroy_list(cluster_t *clust, int nclust);
+
+/* 
+ *  Access debugging data used in the decision making process.  Note that this
+ *  must be called immediately after hclust_create_list because other calls,
+ *  such as hclust_create_dot(), invalidate the temporary data structures.
+ */
+char **hclust_explain(hclust_t *clust, int *nlines);
+
+char *hclust_create_dot(hclust_t *clust, char **labels, float th);
+
+#endif
+

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -35,7 +35,9 @@ THE SOFTWARE.  */
 #include <htslib/vcf.h>
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/vcfutils.h>
+#include <inttypes.h>
 #include "bcftools.h"
+#include "hclust.h"
 
 typedef struct
 {
@@ -43,10 +45,10 @@ typedef struct
     bcf_hdr_t *gt_hdr, *sm_hdr; // VCF with genotypes to compare against and the query VCF
     int ntmp_arr, npl_arr;
     int32_t *tmp_arr, *pl_arr;
-    double *lks, *sites;
+    double *lks, *sites, min_inter_err, max_intra_err;
     int *cnts, *dps, hom_only, cross_check, all_sites;
     char *cwd, **argv, *gt_fname, *plot, *query_sample, *target_sample;
-    int argc, no_PLs;
+    int argc, no_PLs, narr, nsmpl;
 }
 args_t;
 
@@ -133,6 +135,7 @@ static void plot_check(args_t *args, char *target_sample, char *query_sample)
     free(fname);
 }
 
+#if 0
 static void plot_cross_check(args_t *args)
 {
     char *fname;
@@ -214,6 +217,7 @@ static void plot_cross_check(args_t *args)
     py_plot(fname);
     free(fname);
 }
+#endif
 
 static void init_data(args_t *args)
 {
@@ -229,14 +233,6 @@ static void init_data(args_t *args)
         args->cnts  = (int*) calloc(nsamples,sizeof(int));
         args->sites = (double*) calloc(nsamples,sizeof(double));
         args->dps   = (int*) calloc(nsamples,sizeof(int));
-    }
-    else
-    {
-        int nsamples = bcf_hdr_nsamples(args->sm_hdr);
-        int narr = (nsamples-1)*nsamples/2;
-        args->lks  = (double*) calloc(narr,sizeof(double));
-        args->cnts = (int*) calloc(narr,sizeof(int));
-        args->dps  = (int*) calloc(narr,sizeof(int));
     }
 }
 
@@ -540,161 +536,154 @@ static inline int is_hom_most_likely(int nals, int *pls)
     return min_is_hom;
 }
 
+int process_GT(args_t *args, bcf1_t *line, uint32_t *ntot, uint32_t *ndif)
+{
+    int ngt = bcf_get_genotypes(args->sm_hdr, line, &args->tmp_arr, &args->ntmp_arr);
+
+    if ( ngt<=0 ) return 1;                 // GT not present
+    if ( ngt!=args->nsmpl*2 ) return 2;     // not diploid
+    ngt /= args->nsmpl;
+    
+    int i,j, idx = 0;
+    for (i=1; i<args->nsmpl; i++)
+    {
+        int32_t *a = args->tmp_arr + i*ngt;
+        if ( bcf_gt_is_missing(a[0]) || bcf_gt_is_missing(a[1]) || a[1]==bcf_int32_vector_end ) { idx+=i; continue; }
+        int agt = 1<<bcf_gt_allele(a[0]) | 1<<bcf_gt_allele(a[1]);
+
+        for (j=0; j<i; j++)
+        {
+            int32_t *b = args->tmp_arr + j*ngt;
+            if ( bcf_gt_is_missing(b[0]) || bcf_gt_is_missing(b[1]) || b[1]==bcf_int32_vector_end ) { idx++; continue; }
+            int bgt = 1<<bcf_gt_allele(b[0]) | 1<<bcf_gt_allele(b[1]);
+
+            ntot[idx]++;
+            if ( agt!=bgt ) ndif[idx]++;
+            idx++;
+        }
+    }
+    return 0;
+}
+int process_PL(args_t *args, bcf1_t *line, uint32_t *ntot, uint32_t *ndif)
+{
+    int npl = bcf_get_format_int32(args->sm_hdr, line, "PL", &args->tmp_arr, &args->ntmp_arr);
+
+    if ( npl<=0 ) return 1;                 // PL not present
+    npl /= args->nsmpl;
+    
+    int i,j,k, idx = 0;
+    for (i=1; i<args->nsmpl; i++)
+    {
+        int32_t *a = args->tmp_arr + i*npl;
+        int imin = -1;
+        for (k=0; k<npl; k++)
+        {
+            if ( a[k]==bcf_int32_vector_end ) break;
+            if ( a[k]==bcf_int32_missing ) continue;
+            if ( imin==-1 || a[imin] > a[k] ) imin = k;
+        }
+        if ( imin<0 ) { idx+=i; continue; }
+
+        for (j=0; j<i; j++)
+        {
+            int32_t *b = args->tmp_arr + j*npl;
+            int jmin = -1;
+            for (k=0; k<npl; k++)
+            {
+                if ( b[k]==bcf_int32_vector_end ) break;
+                if ( b[k]==bcf_int32_missing ) continue;
+                if ( jmin==-1 || b[jmin] > b[k] ) jmin = k;
+            }
+            if ( jmin<0 ) { idx++; continue; }
+
+            ntot[idx]++;
+            if ( imin!=jmin ) ndif[idx]++;
+            idx++;
+        }
+    }
+    return 0;
+}
+
 static void cross_check_gts(args_t *args)
 {
-    int nsamples = bcf_hdr_nsamples(args->sm_hdr), ndp_arr = 0;
-    unsigned int *dp = (unsigned int*) calloc(nsamples,sizeof(unsigned int)), *ndp = (unsigned int*) calloc(nsamples,sizeof(unsigned int)); // this will overflow one day...
-    int fake_pls = args->no_PLs, ignore_dp = 0;
+    args->nsmpl = bcf_hdr_nsamples(args->sm_hdr);
+    args->narr  = (args->nsmpl-1)*args->nsmpl/2;
 
-    int i,j,k,idx, pl_warned = 0, dp_warned = 0;
-    int32_t *dp_arr = NULL;
-    int *is_hom = args->hom_only ? (int*) malloc(sizeof(int)*nsamples) : NULL;
-    if ( bcf_hdr_id2int(args->sm_hdr, BCF_DT_ID, "PL")<0 )
-    {
-        if ( bcf_hdr_id2int(args->sm_hdr, BCF_DT_ID, "GT")<0 )
-            error("[E::%s] Neither PL nor GT present in the header of %s\n", __func__, args->files->readers[0].fname);
-        if ( !args->no_PLs )
-            fprintf(stderr,"Warning: PL not present in the header of %s, using GT instead\n", args->files->readers[0].fname);
-        fake_pls = 1;
-    }
-    if ( bcf_hdr_id2int(args->sm_hdr, BCF_DT_ID, "DP")<0 ) ignore_dp = 1;
-
-    FILE *fp = args->plot ? open_file(NULL, "w", "%s.tab", args->plot) : stdout;
-    print_header(args, fp);
-    if ( args->all_sites ) fprintf(fp,"# [1]SD, Average Site Discordance\t[2]Chromosome\t[3]Position\t[4]Number of available pairs\t[5]Average discordance\n");
+    uint32_t *ndif = (uint32_t*) calloc(args->narr,4);
+    uint32_t *ntot = (uint32_t*) calloc(args->narr,4);
 
     while ( bcf_sr_next_line(args->files) )
     {
-        bcf1_t *line = args->files->readers[0].buffer[0];
-        bcf_unpack(line, BCF_UN_FMT);
+        bcf1_t *line = bcf_sr_get_line(args->files,0);
 
-        int npl;
-        if ( !fake_pls )
+        // use PLs unless no_PLs is set and GT exists
+        if ( args->no_PLs )
         {
-            npl = bcf_get_format_int32(args->sm_hdr, line, "PL", &args->pl_arr, &args->npl_arr);
-            if ( npl<=0 ) { pl_warned++; continue; }
-            npl /= nsamples;
+            if ( process_GT(args,line,ntot,ndif)==0 ) continue;
         }
-        else
-            npl = fake_PLs(args, args->sm_hdr, line);
-        int mdp = 0;
-        if ( !ignore_dp && (mdp=bcf_get_format_int32(args->sm_hdr, line, "DP", &dp_arr, &ndp_arr)) <= 0 ) dp_warned++;
-
-        if ( args->hom_only )
-        {
-            for (i=0; i<nsamples; i++)
-                is_hom[i] = is_hom_most_likely(line->n_allele, args->pl_arr+i*npl);
-        }
-
-        double sum = 0; int nsum = 0;
-        idx = 0;
-        for (i=0; i<nsamples; i++)
-        {
-            int *ipl = &args->pl_arr[i*npl];
-            if ( *ipl==-1 ) { idx += i; continue; } // missing genotype
-            if ( mdp>0 && (dp_arr[i]==bcf_int32_missing || !dp_arr[i]) ) { idx += i; continue; }
-            if ( args->hom_only && !is_hom[i] ) { idx += i; continue; }
-
-            for (j=0; j<i; j++)
-            {
-                int *jpl = &args->pl_arr[j*npl];
-                if ( *jpl==-1 ) { idx++; continue; } // missing genotype
-                if ( mdp>0 && (dp_arr[j]==bcf_int32_missing || !dp_arr[j]) ) { idx++; continue; }
-                if ( args->hom_only && !is_hom[j] ) { idx++; continue; }
-
-                int min_pl = INT_MAX;
-                for (k=0; k<npl; k++)
-                {
-                    if ( ipl[k]==bcf_int32_missing || jpl[k]==bcf_int32_missing ) break;
-                    if ( ipl[k]==bcf_int32_vector_end || jpl[k]==bcf_int32_vector_end ) { k = npl; break; }
-                    if ( min_pl > ipl[k]+jpl[k] ) min_pl = ipl[k]+jpl[k];
-                }
-                if ( k!=npl ) { idx++; continue; }
-
-                if ( args->all_sites ) { sum += min_pl; nsum++; }
-                args->lks[idx] += min_pl;
-                args->cnts[idx]++;
-
-                if ( mdp>0 )
-                {
-                    args->dps[idx] += dp_arr[i] < dp_arr[j] ? dp_arr[i] : dp_arr[j];
-                    dp[i] += dp_arr[i]; ndp[i]++;
-                    dp[j] += dp_arr[j]; ndp[j]++;
-                }
-                else
-                {
-                    args->dps[idx]++;
-                    dp[i]++; ndp[i]++;
-                    dp[j]++; ndp[j]++;
-                }
-                idx++;
-            }
-        }
-        if ( args->all_sites )
-            fprintf(fp,"SD\t%s\t%d\t%d\t%.0f\n", args->sm_hdr->id[BCF_DT_CTG][line->rid].key, line->pos+1, nsum, nsum?sum/nsum:0);
+        process_PL(args,line,ntot,ndif);
     }
-    if ( dp_arr ) free(dp_arr);
-    if ( args->pl_arr ) free(args->pl_arr);
-    if ( args->tmp_arr ) free(args->tmp_arr);
-    if ( is_hom ) free(is_hom);
+    
+    FILE *fp = stdout;
+    print_header(args, fp);
 
-    if ( pl_warned ) fprintf(stderr, "[W::%s] PL was not found at %d site(s)\n", __func__, pl_warned);
-    if ( dp_warned ) fprintf(stderr, "[W::%s] DP was not found at %d site(s)\n", __func__, dp_warned);
+    float *tmp = (float*)malloc(sizeof(float)*args->nsmpl*(args->nsmpl-1)/2);
 
-    // Output samples sorted by average discordance
-    double *score  = (double*) calloc(nsamples,sizeof(double));
-    args->sites = (double*) calloc(nsamples,sizeof(double));
-    idx = 0;
-    for (i=0; i<nsamples; i++)
+    // Output pairwise distances
+    fprintf(fp, "# ERR, error rate\t[2]Pairwise error rate\t[3]Number of sites compared\t[4]Sample i\t[5]Sample j\n");
+    int i,j, idx = 0;
+    for (i=0; i<args->nsmpl; i++)
     {
         for (j=0; j<i; j++)
         {
-            score[i] += args->lks[idx];
-            score[j] += args->lks[idx];
-            args->sites[i] += args->cnts[idx];
-            args->sites[j] += args->cnts[idx];
+            float err = ntot[idx] ? (float)ndif[idx]/ntot[idx] : 1e-10;
+            fprintf(fp, "ERR\t%f\t%"PRId32"\t%s\t%s\n", err, ntot[idx],args->sm_hdr->samples[i],args->sm_hdr->samples[j]);
+            PDIST(tmp,i,j) = err;
             idx++;
         }
     }
-    for (i=0; i<nsamples; i++)
-        if ( args->sites[i] ) score[i] /= args->sites[i];
-    double **p = (double**) malloc(sizeof(double*)*nsamples), avg_score = 0;
-    for (i=0; i<nsamples; i++) p[i] = &score[i];
-    qsort(p, nsamples, sizeof(int*), cmp_doubleptr);
-    // The average discordance gives the number of differing sites in % with -G1
-    fprintf(fp, "# [1]SM\t[2]Average Discordance\t[3]Average depth\t[4]Average number of sites\t[5]Sample\t[6]Sample ID\n");
-    for (i=0; i<nsamples; i++)
+
+    // Cluster samples
+    int nlist;
+    float clust_max_err = args->max_intra_err;
+    hclust_t *clust = hclust_init(args->nsmpl,tmp);
+    cluster_t *list = hclust_create_list(clust,args->min_inter_err,&clust_max_err,&nlist);
+    fprintf(fp, "# CLUSTER\t[2]Maximum inter-cluster ERR\t[3-]List of samples\n");
+    for (i=0; i<nlist; i++)
     {
-        idx = p[i] - score;
-        double adp = ndp[idx] ? (double)dp[idx]/ndp[idx] : 0;
-        double nsites = args->sites[idx]/(nsamples-1);
-        avg_score += score[idx];
-        fprintf(fp, "SM\t%f\t%.2lf\t%.0lf\t%s\t%d\n", score[idx]*100., adp, nsites, args->sm_hdr->samples[idx],i);
+        fprintf(fp,"CLUSTER\t%f", list[i].dist);
+        for (j=0; j<list[i].nmemb; j++)
+            fprintf(fp,"\t%s",args->sm_hdr->samples[list[i].memb[j]]);
+        fprintf(fp,"\n");
     }
+    hclust_destroy_list(list,nlist);
+    // Debugging output: the cluster graph and data used for deciding
+    char **dbg = hclust_explain(clust,&nlist);
+    for (i=0; i<nlist; i++)
+        fprintf(fp,"DBG\t%s\n", dbg[i]);
+    fprintf(fp, "# TH, clustering threshold\t[2]Value\nTH\t%f\n",clust_max_err);
+    fprintf(fp, "# DOT\t[2]Cluster graph, visualize e.g. as \"this-output.txt | grep ^DOT | cut -f2- | dot -Tsvg -o graph.svg\"\n");
+    fprintf(fp, "DOT\t%s\n", hclust_create_dot(clust,args->sm_hdr->samples,clust_max_err));
+    hclust_destroy(clust);
+    free(tmp);
 
-    //  // Overall score: maximum absolute deviation from the average score
-    //  fprintf(fp, "# [1] MD\t[2]Maximum deviation\t[3]The culprit\n");
-    //  fprintf(fp, "MD\t%f\t%s\n", (score[idx] - avg_score/nsamples)*100., args->sm_hdr->samples[idx]);    // idx still set
-    free(p);
-    free(score);
-    free(dp);
-    free(ndp);
 
-    // Pairwise discordances
+    // Deprecated output for temporary backward compatibility
+    fprintf(fp, "# Warning: The CN block is deprecated and will be removed in future releases. Use ERR instead.\n");
     fprintf(fp, "# [1]CN\t[2]Discordance\t[3]Number of sites\t[4]Average minimum depth\t[5]Sample i\t[6]Sample j\n");
     idx = 0;
-    for (i=0; i<nsamples; i++)
+    for (i=0; i<args->nsmpl; i++)
     {
         for (j=0; j<i; j++)
         {
-            fprintf(fp, "CN\t%.0f\t%d\t%.2f\t%s\t%s\n", args->lks[idx], args->cnts[idx], args->cnts[idx]?(double)args->dps[idx]/args->cnts[idx]:0.0,
-                    args->sm_hdr->samples[i],args->sm_hdr->samples[j]);
+            fprintf(fp, "CN\t%"PRId32"\t%"PRId32"\t0\t%s\t%s\n", ndif[idx], ntot[idx],args->sm_hdr->samples[i],args->sm_hdr->samples[j]);
             idx++;
         }
     }
-    fclose(fp);
-    if ( args->plot )
-        plot_cross_check(args);
+
+    free(ndif);
+    free(ntot);
+    free(args->tmp_arr);
 }
 
 static char *init_prefix(char *prefix)
@@ -713,6 +702,7 @@ static void usage(void)
     fprintf(stderr, "\n");
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "    -a, --all-sites                 output comparison for all sites\n");
+    fprintf(stderr, "    -c, --cluster <min,max>         min inter- and max intra-sample error [0.23,-0.3]\n");
     fprintf(stderr, "    -g, --genotypes <file>          genotypes to compare against\n");
     fprintf(stderr, "    -G, --GTs-only <int>            use GTs, ignore PLs, using <int> for unseen genotypes [99]\n");
     fprintf(stderr, "    -H, --homs-only                 homozygous genotypes only (useful for low coverage data)\n");
@@ -736,8 +726,16 @@ int main_vcfgtcheck(int argc, char *argv[])
     char *regions = NULL, *targets = NULL;
     int regions_is_file = 0, targets_is_file = 0;
 
+    // In simulated sample swaps the minimum error was 0.3 and maximum intra-sample error was 0.23
+    //    - min_inter: pairs with smaller err value will be considered identical 
+    //    - max_intra: pairs with err value bigger than abs(max_intra_err) will be considered
+    //                  different. If negative, the cutoff may be heuristically lowered
+    args->min_inter_err =  0.23;
+    args->max_intra_err = -0.3;
+
     static struct option loptions[] =
     {
+        {"cluster",1,0,'c'},
         {"GTs-only",1,0,'G'},
         {"all-sites",0,0,'a'},
         {"homs-only",0,0,'H'},
@@ -753,8 +751,17 @@ int main_vcfgtcheck(int argc, char *argv[])
         {0,0,0,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "hg:p:s:S:Hr:R:at:T:G:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hg:p:s:S:Hr:R:at:T:G:c:",loptions,NULL)) >= 0) {
         switch (c) {
+            case 'c':
+                args->min_inter_err = strtod(optarg,&tmp);
+                if ( *tmp )
+                {
+                    if ( *tmp!=',') error("Could not parse: -c %s\n", optarg);
+                    args->max_intra_err = strtod(tmp+1,&tmp);
+                    if ( *tmp ) error("Could not parse: -c %s\n", optarg);
+                }
+                break;
             case 'G':
                 args->no_PLs = strtol(optarg,&tmp,10);
                 if ( *tmp ) error("Could not parse argument: --GTs-only %s\n", optarg);

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -606,6 +606,17 @@ int process_PL(args_t *args, bcf1_t *line, uint32_t *ntot, uint32_t *ndif)
 
 static void cross_check_gts(args_t *args)
 {
+    // Initialize things: check which tags are defined in the header, sample names etc.
+    if ( bcf_hdr_id2int(args->sm_hdr, BCF_DT_ID, "PL")<0 )
+    {
+        if ( bcf_hdr_id2int(args->sm_hdr, BCF_DT_ID, "GT")<0 )
+            error("[E::%s] Neither PL nor GT present in the header of %s\n", __func__, args->files->readers[0].fname);
+        if ( !args->no_PLs ) {
+            fprintf(stderr,"Warning: PL not present in the header of %s, using GT instead\n", args->files->readers[0].fname);
+            args->no_PLs = 99;
+        }
+    }
+
     args->nsmpl = bcf_hdr_nsamples(args->sm_hdr);
     args->narr  = (args->nsmpl-1)*args->nsmpl/2;
 


### PR DESCRIPTION
This new version is more robust to the variations in the number of compared
sites and reports error rate lines (ERR), the new default way of estimating
sample similarity. The program also attempts to do a simple hierarchical
clustering. If the new cluster does not work as expect (the real error rate
is different from the defaults), the `-c <min,max>` option can be tuned:

- the first "min" argument controls the typical error rate in lanelets
from the same sample. Lanelets with error rate smaller than this will be
always considered as coming from the same sample.

- the second "max" argument is the reverse: lanelets with error rate
bigger than the absolute value of this parameter will be always
considered as different samples. When the value is negative, the cutoff
may be heuristically lowered by the clustering engine. If positive, the
value is interpreted as a fixed cutoff.

Also the -g mode should be improved at some point.

- [x] add documentation to man page