### PR TITLE
mpileup: require the reference fasta by default

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1574,7 +1574,11 @@ multiple regions and many alignment files are processed.
 
 *-f, --fasta-ref* 'FILE'::
     The *faidx*-indexed reference file in the FASTA format. The file can be
-    optionally compressed by *bgzip* [null]
+    optionally compressed by *bgzip*. Reference is required by default
+    unless the *--no-reference* option is set [null]
+
+*--no-reference*::
+    Do not require the *--fasta-ref* option.
 
 *-G, --read-groups* [&#94;]'FILE'::
     list of read groups to include or exclude if prefixed with "&#94;".

--- a/mpileup.c
+++ b/mpileup.c
@@ -821,6 +821,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
     fprintf(fp,
 "  -E, --redo-BAQ          recalculate BAQ on the fly, ignore existing BQs\n"
 "  -f, --fasta-ref FILE    faidx indexed reference sequence file\n"
+"      --no-reference      do not require fasta reference file\n"
 "  -G, --read-groups FILE  select or exclude read groups listed in the file\n"
 "  -q, --min-MQ INT        skip alignments with mapQ smaller than INT [%d]\n", mplp->min_mq);
     fprintf(fp,
@@ -879,7 +880,7 @@ int bam_mpileup(int argc, char *argv[])
     int c;
     const char *file_list = NULL;
     char **fn = NULL;
-    int nfiles = 0, use_orphan = 0;
+    int nfiles = 0, use_orphan = 0, noref = 0;
     mplp_conf_t mplp;
     memset(&mplp, 0, sizeof(mplp_conf_t));
     mplp.min_baseQ = 13;
@@ -907,6 +908,7 @@ int bam_mpileup(int argc, char *argv[])
         {"ignore-RG", no_argument, NULL, 5},
         {"ignore-rg", no_argument, NULL, 5},
         {"gvcf", required_argument, NULL, 'g'},
+        {"non-reference", no_argument, NULL, 7},
         {"no-version", no_argument, NULL, 8},
         {"threads",required_argument,NULL,9},
         {"illumina1.3+", no_argument, NULL, '6'},
@@ -969,6 +971,7 @@ int bam_mpileup(int argc, char *argv[])
             if (mplp.fai == NULL) return 1;
             mplp.fai_fname = optarg;
             break;
+        case  7 : noref = 1; break;
         case  8 : mplp.record_cmd_line = 0; break;
         case  9 : mplp.n_threads = strtol(optarg, 0, 0); break;
         case 'd': mplp.max_depth = atoi(optarg); break;
@@ -1070,6 +1073,10 @@ int bam_mpileup(int argc, char *argv[])
     if (argc == 1)
     {
         print_usage(stderr, &mplp);
+        return 1;
+    }
+    if (!mplp.fai && !noref) {
+        fprintf(stderr,"Error: mpileup requires the --reference option by default; use --no-reference to run without a fasta reference\n");
         return 1;
     }
     int ret,i;


### PR DESCRIPTION
Piping `mpileup` into `call` using default options will produce
an empty VCF because REF is filled with `N` when the reference
is not present and `call` ignores such sites by default.
Seeing as bcftools/mpileup is only doing VCF output rather than
the pileup text output, we now require the reference by default.
Requirement can be switched off with the `--no-reference` option.

Resolves samtools/samtools#256