### PR TITLE
update linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,15 @@ CFLAGS   = -g -Wall -Wc++-compat -O2
 LDFLAGS  =
 LIBS     =
 
+ifeq "$(shell uname -s)" "Darwin"
+DYNAMIC_FLAGS = -Wl,-export_dynamic
+else
+DYNAMIC_FLAGS = -rdynamic
+endif
+
 # TODO Use configure or htslib.pc to add -rdynamic/-ldl conditionally
 ALL_CPPFLAGS = -I. $(HTSLIB_CPPFLAGS) $(CPPFLAGS)
-ALL_LDFLAGS  = -rdynamic $(HTSLIB_LDFLAGS) $(LDFLAGS)
+ALL_LDFLAGS  = $(DYNAMIC_FLAGS) $(HTSLIB_LDFLAGS) $(LDFLAGS)
 ALL_LIBS     = -lm -lz -ldl $(LIBS)
 
 OBJS     = main.o vcfindex.o tabix.o \


### PR DESCRIPTION
1. Use `-Wl,-export_dynamic` instead of `-rdynamic` on macOS

See #388 and https://sourceforge.net/p/samtools/mailman/message/34699333/

2. Always link with -rdynamic/-ldl

See samtools/samtools@3c15c88,  #549 and #482.
