### PR TITLE
Tidy upsfor C99 / _XOPEN_SOURCE=600 compliance.

### DIFF
--- a/bam2bcf_indel.c
+++ b/bam2bcf_indel.c
@@ -370,10 +370,12 @@ int bcf_call_gap_prep(int n, int *n_plp, bam_pileup1_t **plp, int pos, bcf_calla
     }
     free(ref2); free(query);
     { // compute indelQ
-        int *sc, tmp, *sumq;
-        sc   = (int*) alloca(n_types * sizeof(int));
-        sumq = (int*) alloca(n_types * sizeof(int));
-        memset(sumq, 0, sizeof(int) * n_types);
+        int sc_a[16], sumq_a[16];
+        int tmp, *sc = sc_a, *sumq = sumq_a;
+        if (n_types > 1) {
+            sc   = malloc(n_types * sizeof(int));
+            sumq = calloc(n_types,  sizeof(int));
+        }
         for (s = K = 0; s < n; ++s) {
             for (i = 0; i < n_plp[s]; ++i, ++K) {
                 bam_pileup1_t *p = plp[s] + i;
@@ -454,6 +456,9 @@ int bcf_call_gap_prep(int n, int *n_plp, bam_pileup1_t **plp, int pos, bcf_calla
                 //fprintf(stderr, "X pos=%d read=%d:%d name=%s call=%d type=%d seqQ=%d indelQ=%d\n", pos, s, i, bam1_qname(p->b), (p->aux>>16)&0x3f, bca->indel_types[(p->aux>>16)&0x3f], (p->aux>>8)&0xff, p->aux&0xff);
             }
         }
+
+        if (sc   != sc_a)   free(sc);
+        if (sumq != sumq_a) free(sumq);
     }
     free(score1); free(score2);
     // free

--- a/bin.c
+++ b/bin.c
@@ -39,7 +39,7 @@ bin_t *bin_init(const char *list_def, float min, float max)
     bin_t *bin = (bin_t*) calloc(1,sizeof(bin_t));
 
     // a comma indicates a list, otherwise a file
-    int is_file = index(list_def,',') ? 0 : 1;
+    int is_file = strchr(list_def,',') ? 0 : 1;
     int i, nlist;
     char **list = hts_readlist(list_def, is_file, &nlist);
     bin->nbins = nlist;

--- a/consensus.c
+++ b/consensus.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <getopt.h>
 #include <unistd.h>

--- a/csq.c
+++ b/csq.c
@@ -151,6 +151,10 @@
 #include "smpl_ilist.h"
 #include "rbuf.h"
 
+#ifndef __FUNCTION__
+#  define __FUNCTION__ __func__
+#endif
+
 // Logic of the filters: include or exclude sites which match the filters?
 #define FLT_INCLUDE 1
 #define FLT_EXCLUDE 2

--- a/filter.c
+++ b/filter.c
@@ -24,6 +24,7 @@ THE SOFTWARE.  */
 
 #include <ctype.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <errno.h>
 #include <math.h>
 #include <wordexp.h>
@@ -33,6 +34,10 @@ THE SOFTWARE.  */
 #include "bcftools.h"
 #include <htslib/hts_defs.h>
 #include <htslib/vcfutils.h>
+
+#ifndef __FUNCTION__
+#  define __FUNCTION__ __func__
+#endif
 
 uint64_t bcf_double_missing    = 0x7ff0000000000001;
 uint64_t bcf_double_vector_end = 0x7ff0000000000002;

--- a/mcall.c
+++ b/mcall.c
@@ -1224,7 +1224,7 @@ void mcall_trim_numberR(call_t *call, bcf1_t *rec, int nals, int nout_als, int o
             {
                 int k = call->als_map[j];
                 if ( k==-1 ) continue;   // to be dropped
-                memcpy(tmp_new+size*k, tmp_ori+size*j, size);
+                memcpy((char *)tmp_new+size*k, (char *)tmp_ori+size*j, size);
             }
             bcf_update_info_int32(call->hdr, rec, key, tmp_new, nout_als);
         }
@@ -1247,8 +1247,8 @@ void mcall_trim_numberR(call_t *call, bcf1_t *rec, int nals, int nout_als, int o
 
         for (j=0; j<nsmpl; j++)
         {
-            void *ptr_src = tmp_ori + j*nals*size;
-            void *ptr_dst = tmp_new + j*nout_als*size;
+            char *ptr_src = (char *)tmp_ori + j*nals*size;
+            char *ptr_dst = (char *)tmp_new + j*nout_als*size;
             int k;
             for (k=0; k<nals; k++)
             {

--- a/mpileup.c
+++ b/mpileup.c
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <unistd.h>
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include <limits.h>
 #include <errno.h>
 #include <sys/stat.h>

--- a/plugins/fill-from-fasta.c
+++ b/plugins/fill-from-fasta.c
@@ -24,6 +24,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <htslib/vcf.h>
 #include <htslib/faidx.h>

--- a/plugins/fill-tags.c
+++ b/plugins/fill-tags.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <math.h>
 #include <htslib/hts.h>

--- a/plugins/fixploidy.c
+++ b/plugins/fixploidy.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <ctype.h>

--- a/plugins/fixref.c
+++ b/plugins/fixref.c
@@ -73,6 +73,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <math.h>
 #include <htslib/hts.h>

--- a/plugins/guess-ploidy.c
+++ b/plugins/guess-ploidy.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <stdint.h>

--- a/prob1.c
+++ b/prob1.c
@@ -157,8 +157,9 @@ int test16(bcf1_t *b, anno16_t *a);
 static int cal_pdg(const bcf1_t *b, bcf_p1aux_t *ma)
 {
     int i, j;
-    long *p, tmp;
-    p = (long*) alloca(b->n_allele * sizeof(long));
+    long p_a[16], *p=p_a, tmp;
+    if (b->n_allele > 16)
+        p = (long*) malloc(b->n_allele * sizeof(long));
     memset(p, 0, sizeof(long) * b->n_allele);
 
     // Set P(D|g) for each sample and sum phread likelihoods across all samples to create lk
@@ -177,6 +178,8 @@ static int cal_pdg(const bcf1_t *b, bcf_p1aux_t *ma)
             tmp = p[j], p[j] = p[j-1], p[j-1] = tmp;
     for (i = b->n_allele - 1; i >= 0; --i)
         if ((p[i]&0xf) == 0) break;
+    if (p != p_a)
+        free(p);
     return i;
 }
 

--- a/regidx.c
+++ b/regidx.c
@@ -22,6 +22,7 @@
     THE SOFTWARE.
 */
 
+#include <strings.h>
 #include <htslib/hts.h>
 #include <htslib/kstring.h>
 #include <htslib/kseq.h>
@@ -170,7 +171,7 @@ inline int regidx_push(regidx_t *idx, char *chr_beg, char *chr_end, uint32_t beg
     if ( idx->payload_size )
     {
         if ( mreg != list->mreg ) list->dat = realloc(list->dat,idx->payload_size*list->mreg);
-        memcpy(list->dat + idx->payload_size*(list->nreg-1), payload, idx->payload_size);
+        memcpy((char *)list->dat + idx->payload_size*(list->nreg-1), payload, idx->payload_size);
     }
     if ( !list->unsorted && list->nreg>1 && cmp_regs(&list->reg[list->nreg-2],&list->reg[list->nreg-1])>0 ) list->unsorted = 1;
     return 0;
@@ -247,7 +248,7 @@ void regidx_destroy(regidx_t *idx)
         if ( idx->free )
         {
             for (j=0; j<list->nreg; j++)
-                idx->free(list->dat + idx->payload_size*j);
+                idx->free((char *)list->dat + idx->payload_size*j);
         }
         free(list->dat);
         free(list->reg);
@@ -278,7 +279,9 @@ int _reglist_build_index(regidx_t *regidx, reglist_t *list)
             for (i=0; i<list->nreg; i++)
             {
                 size_t iori = ptr[i] - list->reg;
-                memcpy(tmp_dat+i*regidx->payload_size, list->dat+iori*regidx->payload_size, regidx->payload_size);
+                memcpy((char *)tmp_dat+i*regidx->payload_size,
+                       (char *)list->dat+iori*regidx->payload_size,
+                       regidx->payload_size);
             }
             free(list->dat);
             list->dat = tmp_dat;
@@ -386,7 +389,7 @@ int regidx_overlap(regidx_t *regidx, const char *chr, uint32_t beg, uint32_t end
     regitr->beg = list->reg[ireg].beg;
     regitr->end = list->reg[ireg].end;
     if ( regidx->payload_size )
-        regitr->payload = list->dat + regidx->payload_size*ireg;
+        regitr->payload = (char *)list->dat + regidx->payload_size*ireg;
 
     return 1;
 }
@@ -554,7 +557,7 @@ int regitr_overlap(regitr_t *regitr)
     regitr->beg = list->reg[i].beg;
     regitr->end = list->reg[i].end;
     if ( itr->ridx->payload_size )
-        regitr->payload = list->dat + itr->ridx->payload_size*i;
+        regitr->payload = (char *)list->dat + itr->ridx->payload_size*i;
 
     return 1;
 }
@@ -585,7 +588,7 @@ int regitr_loop(regitr_t *regitr)
     regitr->beg = itr->list->reg[itr->ireg].beg;
     regitr->end = itr->list->reg[itr->ireg].end;
     if ( regidx->payload_size )
-        regitr->payload = itr->list->dat + regidx->payload_size*itr->ireg;
+        regitr->payload = (char *)itr->list->dat + regidx->payload_size*itr->ireg;
     itr->ireg++;
 
     return 1;

--- a/tabix.c
+++ b/tabix.c
@@ -94,13 +94,15 @@ int main_tabix(int argc, char *argv[])
         if (!is_force) {
             char *fn;
             FILE *fp;
-            fn = (char*)alloca(strlen(argv[optind]) + 5);
+            fn = (char*)malloc(strlen(argv[optind]) + 5);
             strcat(strcpy(fn, argv[optind]), min_shift <= 0? ".tbi" : ".csi");
             if ((fp = fopen(fn, "rb")) != 0) {
                 fclose(fp);
+                free(fn);
                 fprintf(stderr, "[E::%s] the index file exists; use option '-f' to overwrite\n", __func__);
                 return 1;
             }
+            free(fn);
         }
         if ( tbx_index_build(argv[optind], min_shift, &conf) )
         {

--- a/tsv2vcf.c
+++ b/tsv2vcf.c
@@ -24,6 +24,7 @@
 */
 
 #include <ctype.h>
+#include <strings.h>
 #include "tsv2vcf.h"
 
 tsv_t *tsv_init(const char *str)

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <stdio.h>
+#include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <ctype.h>

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -24,6 +24,7 @@ THE SOFTWARE.  */
 
 #include <stdarg.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <unistd.h>
 #include <getopt.h>

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -665,7 +665,7 @@ static void naive_concat(args_t *args)
         // Output all non-header data that were read together with the header block
         if ( fp->block_length - nskip > 0 )
         {
-            if ( bgzf_write(bgzf_out, fp->uncompressed_block+nskip, fp->block_length-nskip)<0 ) error("Error: %d\n",fp->errcode);
+            if ( bgzf_write(bgzf_out, (char *)fp->uncompressed_block+nskip, fp->block_length-nskip)<0 ) error("Error: %d\n",fp->errcode);
         }
         if ( bgzf_flush(bgzf_out)<0 ) error("Error: %d\n",bgzf_out->errcode);
 

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <stdio.h>
+#include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <ctype.h>

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -24,6 +24,7 @@ THE SOFTWARE.  */
 
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <unistd.h>
 #include <getopt.h>

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <stdio.h>
+#include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <ctype.h>

--- a/vcfplugin.c
+++ b/vcfplugin.c
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <stdio.h>
+#include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <ctype.h>

--- a/vcfroh.c
+++ b/vcfroh.c
@@ -1129,9 +1129,9 @@ int main_vcfroh(int argc, char *argv[])
                 break;
             case 'o': args->output_fname = optarg; break;
             case 'O': 
-                if ( index(optarg,'s') || index(optarg,'S') ) args->output_type |= OUTPUT_ST;
-                if ( index(optarg,'r') || index(optarg,'R') ) args->output_type |= OUTPUT_RG;
-                if ( index(optarg,'z') || index(optarg,'z') ) args->output_type |= OUTPUT_GZ;
+                if ( strchr(optarg,'s') || strchr(optarg,'S') ) args->output_type |= OUTPUT_ST;
+                if ( strchr(optarg,'r') || strchr(optarg,'R') ) args->output_type |= OUTPUT_RG;
+                if ( strchr(optarg,'z') || strchr(optarg,'z') ) args->output_type |= OUTPUT_GZ;
                 break;
             case 'e': args->estimate_AF = optarg; naf_opts++; break;
             case 'b': args->buffer_size = optarg; break;

--- a/vcfview.c
+++ b/vcfview.c
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <stdio.h>
+#include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <ctype.h>


### PR DESCRIPTION
Changes relate to:
- Replacement of alloca with malloc.
- Replacement of index with strchr.
- Use of \_\_func\_\_ if \_\_FUNCTION\_\_ is undefined.
- Inclusion of strings.h for strcasecmp and friends.
- Avoidance of arithmetic on void*.

Note we already use \_\_func\_\_ in some source files, so maybe we should
do a search and replace of the \_\_FUNCTION\_\_ uses instead of redefining
it?

Some non-standard components still exist, but are left as the solution
is possibly more painful than the problem (if indeed they ever do
become a problem).

Remaing warnings from gcc6 -g -Wall -O2 -pedantic -std=c99 -D\_XOPEN\_SOURCE=600

1) filter.c:1469:55: warning: format '%p' expects argument of type 'void \*', but argument 3 has type 'void (\*)(filter_t \*, bcf1_t \*, struct _token_t \*) {aka void (\*)(struct _filter_t \*, struct <anonymous> \*, struct _token_t \*)}' [-Wformat=]
         if ( tok->setter ) fprintf(stderr,"\t[setter %p]", tok->setter);
                                                       ^
This isn't something that is possible to resolve in an easy manner,
nor is it likely to be a portability concern.

2) vcfcnv.c:549:13: warning: string length '5195' is greater than the length '4095' ISO C99 compilers are required to support [-Woverlength-strings]
             "\n",
             ^~~~

This is trivial to fix, but we can fix it in the unlikely event it
ever becomes a genuine portability issue.

3) vcfplugin.c:265:20: warning: ISO C forbids conversion of object pointer to function pointer type [-Wpedantic]
     plugin->init = (dl_init_f) dlsym(plugin->handle, "init");

plugin->init is a dl_init_f type, typedef as int (z\*dl_init_f) (int, char \*\*, bcf_hdr_t \*, bcf_hdr_t \*);
Converting a function pointer to void\* invokes undefined behaviour,
but the very nature of dlsym relies on this and given it is defined in
POSIX then I believe this behaviour is also defined.