### PR TITLE
silence some compiler warnings introduced in #587

### DIFF
--- a/bam2bcf_indel.c
+++ b/bam2bcf_indel.c
@@ -373,8 +373,8 @@ int bcf_call_gap_prep(int n, int *n_plp, bam_pileup1_t **plp, int pos, bcf_calla
         int sc_a[16], sumq_a[16];
         int tmp, *sc = sc_a, *sumq = sumq_a;
         if (n_types > 1) {
-            sc   = malloc(n_types * sizeof(int));
-            sumq = calloc(n_types,  sizeof(int));
+            sc   = (int *)malloc(n_types * sizeof(int));
+            sumq = (int *)calloc(n_types,  sizeof(int));
         }
         for (s = K = 0; s < n; ++s) {
             for (i = 0; i < n_plp[s]; ++i, ++K) {


### PR DESCRIPTION
```
bam2bcf_indel.c: In function ‘bcf_call_gap_prep’:
bam2bcf_indel.c:376:18: warning: request for implicit conversion from ‘void *’ to ‘int *’ not permitted in C++ [-Wc++-compat]
             sc   = malloc(n_types * sizeof(int));
                  ^
bam2bcf_indel.c:377:18: warning: request for implicit conversion from ‘void *’ to ‘int *’ not permitted in C++ [-Wc++-compat]
             sumq = calloc(n_types,  sizeof(int));
                  ^
```