### PR TITLE
Python3 fix for plot-vcfstats

### DIFF
--- a/misc/plot-vcfstats
+++ b/misc/plot-vcfstats
@@ -1590,8 +1590,8 @@ sub plot_substitutions
             \\tfig = plt.figure(figsize=($$opts{img_width},$$opts{img_height}))
             \\tcm  = mpl.cm.get_cmap('autumn')
             \\tn = 12
-            \\tcol = range(n)
-            \\tfor i in range(n): col[i] = cm(1.*i/n)
+            \\tcol = []
+            \\tfor i in range(n): col.append(cm(1.*i/n))
             \\tax1 = fig.add_subplot(111)
             \\tax1.bar([row[0] for row in dat], [row[2] for row in dat], color=col)
             \\tax1.set_ylabel('Count')


### PR DESCRIPTION
Fix for the error:
```
TypeError: 'range' object does not support item assignment
```
in generated `plot.py`.

Fix https://github.com/samtools/bcftools/issues/624 .