### PR TITLE
allow downstream variables (e.g. plugindir) to evaluate libexecdir

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -31,6 +31,7 @@
 prefix       = @prefix@
 exec_prefix  = @exec_prefix@
 bindir       = @bindir@
+libexecdir   = @libexecdir@
 datarootdir  = @datarootdir@
 mandir       = @mandir@
 


### PR DESCRIPTION
Using --libexecdir=/path/FOO in ./configure is currently useless because config.mk doesn't include it, and so things like plugindir (which defaults to $(libexecdir)/bcftools) uses the default /path/libexec. This makes sure that libexecdir is properly taken from the ./configure options.