### PR TITLE
Fix mendelian plugin not recognizing some cases

### DIFF
--- a/plugins/mendelian.c
+++ b/plugins/mendelian.c
@@ -195,11 +195,13 @@ bcf1_t *process(bcf1_t *rec)
         if ( bcf_gt_is_missing(c) || bcf_gt_is_missing(d) ) continue; 
         if ( bcf_gt_is_missing(e) || bcf_gt_is_missing(f) ) continue; 
 
-        mother = (1<<bcf_gt_allele(a)) | (1<<bcf_gt_allele(b));
-        father = (1<<bcf_gt_allele(c)) | (1<<bcf_gt_allele(d));
-        child  = (1<<bcf_gt_allele(e)) | (1<<bcf_gt_allele(f));
+        mother = bcf_gt_allele(a) + bcf_gt_allele(b);
+        father = bcf_gt_allele(c) + bcf_gt_allele(d);
+        child  = bcf_gt_allele(e) + bcf_gt_allele(f);
 
-        if ( (mother&child) && (father&child) ) 
+        if ( ( child == 0 && mother <= 1 && father <= 1 )
+             || ( child == 1 && mother + father >= 1 && mother + father <= 3 )
+             || ( child == 2 && mother >= 1 && father >= 1 ) )
         {
             trio->nok++;
         }

--- a/test/mendelian.1.out
+++ b/test/mendelian.1.out
@@ -1,9 +1,28 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
-##contig=<ID=1,assembly=b37,length=249250621>
-##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1	mom2	dad2	child2
-1	100	.	A	G	100	PASS	.	GT	./.	./.	./.	1/1	0/1	1/1
-1	101	.	A	T	100	PASS	.	GT	0/0	0/1	0/1	1/1	0/1	1/0
-1	102	.	A	T	100	PASS	.	GT	0/0	0/1	0/1	1/1	0/1	1/0
+##contig=<ID=1>
+##contig=<ID=2>
+##contig=<ID=3>
+##contig=<ID=4>
+##contig=<ID=5>
+##contig=<ID=6>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1
+1	100	.	A	G	100	PASS	.	GT	0/0	0/0	0/0
+1	101	.	A	G	100	PASS	.	GT	./.	./.	./.
+1	102	.	A	G	100	PASS	.	GT	./.	./.	./.
+2	200	.	A	G	100	PASS	.	GT	0/0	0/1	0/0
+2	201	.	A	G	100	PASS	.	GT	0/0	0/1	0/1
+2	202	.	A	G	100	PASS	.	GT	./.	./.	./.
+3	300	.	A	G	100	PASS	.	GT	./.	./.	./.
+3	301	.	A	G	100	PASS	.	GT	0/0	1/1	0/1
+3	302	.	A	G	100	PASS	.	GT	./.	./.	./.
+4	400	.	A	G	100	PASS	.	GT	0/1	0/0	0/0
+4	401	.	A	G	100	PASS	.	GT	0/1	0/0	0/1
+4	402	.	A	G	100	PASS	.	GT	./.	./.	./.
+5	500	.	A	G	100	PASS	.	GT	0/1	0/1	0/0
+5	501	.	A	G	100	PASS	.	GT	0/1	0/1	0/1
+5	502	.	A	G	100	PASS	.	GT	0/1	0/1	1/1
+6	600	.	A	G	100	PASS	.	GT	./.	./.	./.
+6	601	.	A	G	100	PASS	.	GT	0/1	1/1	0/1
+6	602	.	A	G	100	PASS	.	GT	0/1	1/1	1/1

--- a/test/mendelian.2.out
+++ b/test/mendelian.2.out
@@ -1,8 +1,21 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
-##contig=<ID=1,assembly=b37,length=249250621>
-##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1	mom2	dad2	child2
-1	101	.	A	T	100	PASS	.	GT	0/0	0/1	0/1	1/1	0/1	1/0
-1	102	.	A	T	100	PASS	.	GT	0/0	0/1	0/1	1/1	0/1	1/0
+##contig=<ID=1>
+##contig=<ID=2>
+##contig=<ID=3>
+##contig=<ID=4>
+##contig=<ID=5>
+##contig=<ID=6>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1
+1	100	.	A	G	100	PASS	.	GT	0/0	0/0	0/0
+2	200	.	A	G	100	PASS	.	GT	0/0	0/1	0/0
+2	201	.	A	G	100	PASS	.	GT	0/0	0/1	0/1
+3	301	.	A	G	100	PASS	.	GT	0/0	1/1	0/1
+4	400	.	A	G	100	PASS	.	GT	0/1	0/0	0/0
+4	401	.	A	G	100	PASS	.	GT	0/1	0/0	0/1
+5	500	.	A	G	100	PASS	.	GT	0/1	0/1	0/0
+5	501	.	A	G	100	PASS	.	GT	0/1	0/1	0/1
+5	502	.	A	G	100	PASS	.	GT	0/1	0/1	1/1
+6	601	.	A	G	100	PASS	.	GT	0/1	1/1	0/1
+6	602	.	A	G	100	PASS	.	GT	0/1	1/1	1/1

--- a/test/mendelian.3.out
+++ b/test/mendelian.3.out
@@ -1,7 +1,17 @@
 ##fileformat=VCFv4.2
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
-##contig=<ID=1,assembly=b37,length=249250621>
-##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1	mom2	dad2	child2
-1	100	.	A	G	100	PASS	.	GT	0/0	0/0	1/1	1/1	0/1	1/1
+##contig=<ID=1>
+##contig=<ID=2>
+##contig=<ID=3>
+##contig=<ID=4>
+##contig=<ID=5>
+##contig=<ID=6>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1
+1	101	.	A	G	100	PASS	.	GT	0/0	0/0	0/1
+1	102	.	A	G	100	PASS	.	GT	0/0	0/0	1/1
+2	202	.	A	G	100	PASS	.	GT	0/0	0/1	1/1
+3	300	.	A	G	100	PASS	.	GT	0/0	1/1	0/0
+3	302	.	A	G	100	PASS	.	GT	0/0	1/1	1/1
+4	402	.	A	G	100	PASS	.	GT	0/1	0/0	1/1
+6	600	.	A	G	100	PASS	.	GT	0/1	1/1	0/0

--- a/test/mendelian.vcf
+++ b/test/mendelian.vcf
@@ -1,8 +1,27 @@
 ##fileformat=VCFv4.2
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
-##contig=<ID=1,assembly=b37,length=249250621>
-##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1	mom2	dad2	child2
-1	100	.	A	G	100	PASS	.	GT	0/0	0/0	1/1	1/1	0/1	1/1
-1	101	.	A	T	100	PASS	.	GT	0/0	0/1	0/1	1/1	0/1	1/0
-1	102	.	A	T	100	PASS	.	GT	0/0	0/1	0/1	1/1	0/1	1/0
+##contig=<ID=1>
+##contig=<ID=2>
+##contig=<ID=3>
+##contig=<ID=4>
+##contig=<ID=5>
+##contig=<ID=6>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	mom1	dad1	child1
+1	100	.	A	G	100	PASS	.	GT	0/0	0/0	0/0
+1	101	.	A	G	100	PASS	.	GT	0/0	0/0	0/1
+1	102	.	A	G	100	PASS	.	GT	0/0	0/0	1/1
+2	200	.	A	G	100	PASS	.	GT	0/0	0/1	0/0
+2	201	.	A	G	100	PASS	.	GT	0/0	0/1	0/1
+2	202	.	A	G	100	PASS	.	GT	0/0	0/1	1/1
+3	300	.	A	G	100	PASS	.	GT	0/0	1/1	0/0
+3	301	.	A	G	100	PASS	.	GT	0/0	1/1	0/1
+3	302	.	A	G	100	PASS	.	GT	0/0	1/1	1/1
+4	400	.	A	G	100	PASS	.	GT	0/1	0/0	0/0
+4	401	.	A	G	100	PASS	.	GT	0/1	0/0	0/1
+4	402	.	A	G	100	PASS	.	GT	0/1	0/0	1/1
+5	500	.	A	G	100	PASS	.	GT	0/1	0/1	0/0
+5	501	.	A	G	100	PASS	.	GT	0/1	0/1	0/1
+5	502	.	A	G	100	PASS	.	GT	0/1	0/1	1/1
+6	600	.	A	G	100	PASS	.	GT	0/1	1/1	0/0
+6	601	.	A	G	100	PASS	.	GT	0/1	1/1	0/1
+6	602	.	A	G	100	PASS	.	GT	0/1	1/1	1/1


### PR DESCRIPTION
The "mendelian" plugin currently fails to recognize the following case as mendelian inconsistency: both the father and the mother carry two copies of the REF allele, but the child carries a copy of the ALT allele.  Issue was fixed, and test cases were added to cover this and similar cases.