### PR TITLE
getopt_long() returns int, not char

### DIFF
--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
         {"seed",1,0,'s'},
         {0,0,0,0}
     };
-    char c;
+    int c;
     int seed = (int)time(NULL);
     while ((c = getopt_long(argc, argv, "hvs:",loptions,NULL)) >= 0) 
     {


### PR DESCRIPTION
This fails on architectures where char is unsigned by default. Thanks @AdrianBunk.