### PR TITLE
Typo in consensus example

### DIFF
--- a/howtos/consensus-sequence.html
+++ b/howtos/consensus-sequence.html
@@ -92,7 +92,7 @@ to this, but in brief, the variant calling command in its simplest form is:</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>bcftools mpileup -Ou -f reference.fa alignments.bam | bcftools call -mv -Oz -o calls.vcf.gz
+<pre>samtools mpileup -Ou -f reference.fa alignments.bam | bcftools call -mv -Oz -o calls.vcf.gz
 tabix calls.vcf.gz</pre>
 </div>
 </div>

--- a/howtos/consensus-sequence.txt
+++ b/howtos/consensus-sequence.txt
@@ -20,7 +20,7 @@ link:variant-calling.html[another page] which goes deeper and is devoted just
 to this, but in brief, the variant calling command in its simplest form is:
 
 ----
-bcftools mpileup -Ou -f reference.fa alignments.bam | bcftools call -mv -Oz -o calls.vcf.gz
+samtools mpileup -Ou -f reference.fa alignments.bam | bcftools call -mv -Oz -o calls.vcf.gz
 tabix calls.vcf.gz
 ----
 


### PR DESCRIPTION
I believe this is a typo and should have been `samtools` not `bcftools`.