### PR TITLE
Replaced "Phred scaled" with "Phred-scaled"

### DIFF
--- a/plugins/tag2tag.c
+++ b/plugins/tag2tag.c
@@ -115,7 +115,7 @@ int init(int argc, char **argv, bcf_hdr_t *in, bcf_hdr_t *out)
     if ( mode==GP_TO_GL )
         init_header(out_hdr,drop_source_tag?"GP":NULL,BCF_HL_FMT,"##FORMAT=<ID=GL,Number=G,Type=Float,Description=\"Genotype Likelihoods\">");
     else if ( mode==GL_TO_PL )
-        init_header(out_hdr,drop_source_tag?"GL":NULL,BCF_HL_FMT,"##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"Phred scaled genotype likelihoods\">");
+        init_header(out_hdr,drop_source_tag?"GL":NULL,BCF_HL_FMT,"##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"Phred-scaled genotype likelihoods\">");
     else if ( mode==PL_TO_GL )
         init_header(out_hdr,drop_source_tag?"PL":NULL,BCF_HL_FMT,"##FORMAT=<ID=GL,Number=G,Type=Float,Description=\"Genotype likelihoods\">");
     else if ( mode==GP_TO_GT ) {


### PR DESCRIPTION
Replaced "Phred scaled" with "Phred-scaled" as the latter (with the hyphen) is used everywhere else in Samtools, and consistency makes parsing the files easier.