### PR TITLE
fix not removing "@" from filenames in filtering expressions

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -1791,7 +1791,7 @@ static int filters_init1(filter_t *filter, char *str, int len, token_t *tok)
         tok->tag = (char*) calloc(len+1,sizeof(char));
         memcpy(tok->tag,str,len);
         tok->tag[len] = 0;
-        char *fname = expand_path(tok->tag);
+        char *fname = expand_path(tok->tag+1);
         int i, n;
         char **list = hts_readlist(fname, 1, &n);
         if ( !list ) error("Could not read: %s\n", fname);


### PR DESCRIPTION
There is a silly bug introduced recently: the "@" from filtering expressions was not removed, so for example this fails:

> bcftools view --include ID!=@list.txt input.vcf

like that:

> Could not read: @list.txt                                                                                                                                                    

I compared the code to older versions, and I believe this was missed when changing path expansion functions in filter.c.  Fix is pretty simple.