### PR TITLE
Use bgzf_open() to read FASTA file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ polysomy.o: polysomy.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(bcftools_
 peakfit.o: peakfit.c peakfit.h $(htslib_hts_h) $(htslib_kstring_h)
 bin.o: bin.c $(bin_h)
 regidx.o: regidx.c $(htslib_hts_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) regidx.h
-consensus.o: consensus.c $(htslib_hts_h) $(htslib_kseq_h) rbuf.h $(bcftools_h) regidx.h
+consensus.o: consensus.c $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_bgzf_h) rbuf.h $(bcftools_h) regidx.h
 mpileup.o: mpileup.c $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_khash_str2int_h) regidx.h $(bcftools_h) $(call_h) $(bam2bcf_h) $(bam_sample_h)
 bam_sample.o: $(bam_sample_h) $(htslib_hts_h) $(htslib_khash_str2int_h)
 version.o: version.h version.c

--- a/consensus.c
+++ b/consensus.c
@@ -36,6 +36,7 @@
 #include <htslib/kstring.h>
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/kseq.h>
+#include <htslib/bgzf.h>
 #include "regidx.h"
 #include "bcftools.h"
 #include "rbuf.h"
@@ -672,10 +673,10 @@ static void mask_region(args_t *args, char *seq, int len)
 
 static void consensus(args_t *args)
 {
-    htsFile *fasta = hts_open(args->ref_fname, "rb");
+    BGZF *fasta = bgzf_open(args->ref_fname, "r");
     if ( !fasta ) error("Error reading %s\n", args->ref_fname);
     kstring_t str = {0,0,0};
-    while ( hts_getline(fasta, KS_SEP_LINE, &str) > 0 )
+    while ( bgzf_getline(fasta, '\n', &str) > 0 )
     {
         if ( str.s[0]=='>' )
         {
@@ -752,7 +753,7 @@ static void consensus(args_t *args)
         destroy_chain(args);
     }
     flush_fa_buffer(args, 0);
-    hts_close(fasta);
+    bgzf_close(fasta);
     free(str.s);
 }
 


### PR DESCRIPTION
Avoid `hts_open()` as that is documented as being for SAM/BAM/CRAM or VCF/BCF files.

See discussion in samtools/htslib#721 for context.