### PR TITLE
Fix premature loop termination in bam_smpl_add_bam()

### DIFF
--- a/bam_sample.c
+++ b/bam_sample.c
@@ -167,10 +167,14 @@ int bam_smpl_add_bam(bam_smpl_t *bsmpl, char *bam_hdr, const char *fname)
     void *bam_smpls = khash_str2int_init();
     int first_smpl = -1, nskipped = 0;
     const char *p = bam_hdr, *q, *r;
-    while ((q = strstr(p, "@RG")) != 0) 
+    while (p != NULL && (q = strstr(p, "@RG")) != 0)
     {
+        char *eol = strchr(q + 3, '\n');
+        if (q > bam_hdr && *(q - 1) != '\n') { // @RG must be at start of line
+            p = eol;
+            continue;
+        }
         p = q + 3;
-        r = q = 0;
         if ((q = strstr(p, "\tID:")) != 0) q += 4;
         if ((r = strstr(p, "\tSM:")) != 0) r += 4;
         if (r && q)
@@ -220,7 +224,7 @@ int bam_smpl_add_bam(bam_smpl_t *bsmpl, char *bam_hdr, const char *fname)
         }
         else
             break;
-        p = q > r ? q : r;
+        p = eol;
     }
     int nsmpls = khash_str2int_size(bam_smpls);
     khash_str2int_destroy_free(bam_smpls);


### PR DESCRIPTION
If the sample name was mapped to a different value in bsmpl_keep_readgroup(), variable `r` could end up pointing outside the header, which made the comparison `p = q > r ? q : r;` invalid. Depending on where `r` ended up pointing, the loop through the header could terminate before all the @RG lines were processed. Fix this by finding out where the line ends and setting `p` to that instead.

Add a check to ensure that found @RG strings are either at the start of the header or immediately after a newline, to ensure what is being scanned really is a read group header.

Found when testing bcftools on alpine linux, which uses musl instead of glibc.