### PR TITLE
Use utility function to clamp lookup table index

### DIFF
--- a/vcfroh.c
+++ b/vcfroh.c
@@ -130,6 +130,11 @@ void *smalloc(size_t size)
     return mem;
 }
 
+static inline int max255(int i)
+{
+    return i < 256 ? i : 255;
+}
+
 static void init_data(args_t *args)
 {
     int i;
@@ -749,9 +754,9 @@ int estimate_AF_from_PL(args_t *args, bcf_fmt_t *fmt_pl, int ial, double *alt_fr
                 if ( p[irr]<0 || p[ira]<0 || p[iaa]<0 ) continue;    /* missing value */ \
                 if ( p[irr]==p[ira] && p[irr]==p[iaa] ) continue;    /* all values are the same */ \
                 double prob[3], norm = 0; \
-                prob[0] = p[irr] < 256 ? args->pl2p[ p[irr] ] : args->pl2p[255]; \
-                prob[1] = p[ira] < 256 ? args->pl2p[ p[ira] ] : args->pl2p[255]; \
-                prob[2] = p[iaa] < 256 ? args->pl2p[ p[iaa] ] : args->pl2p[255]; \
+                prob[0] = args->pl2p[ max255(p[irr]) ]; \
+                prob[1] = args->pl2p[ max255(p[ira]) ]; \
+                prob[2] = args->pl2p[ max255(p[iaa]) ]; \
                 for (j=0; j<3; j++) norm += prob[j]; \
                 for (j=0; j<3; j++) prob[j] /= norm; \
                 af += 0.5*prob[1] + prob[2]; \
@@ -779,9 +784,9 @@ int estimate_AF_from_PL(args_t *args, bcf_fmt_t *fmt_pl, int ial, double *alt_fr
                 if ( p[irr]<0 || p[ira]<0 || p[iaa]<0 ) continue;    /* missing value */ \
                 if ( p[irr]==p[ira] && p[irr]==p[iaa] ) continue;    /* all values are the same */ \
                 double prob[3], norm = 0; \
-                prob[0] = p[irr] < 256 ? args->pl2p[ p[irr] ] : args->pl2p[255]; \
-                prob[1] = p[ira] < 256 ? args->pl2p[ p[ira] ] : args->pl2p[255]; \
-                prob[2] = p[iaa] < 256 ? args->pl2p[ p[iaa] ] : args->pl2p[255]; \
+                prob[0] = args->pl2p[ max255(p[irr]) ]; \
+                prob[1] = args->pl2p[ max255(p[ira]) ]; \
+                prob[2] = args->pl2p[ max255(p[iaa]) ]; \
                 for (j=0; j<3; j++) norm += prob[j]; \
                 for (j=0; j<3; j++) prob[j] /= norm; \
                 af += 0.5*prob[1] + prob[2]; \
@@ -926,9 +931,9 @@ int process_line(args_t *args, bcf1_t *line, int ial)
                 type_t *p = (type_t*)fmt_pl->p + fmt_pl->n*ismpl; \
                 if ( p[irr]<0 || p[ira]<0 || p[iaa]<0 ) continue;    /* missing value */ \
                 if ( p[irr]==p[ira] && p[irr]==p[iaa] ) continue;    /* all values are the same */ \
-                pdg[0] = p[irr] < 256 ? args->pl2p[ p[irr] ] : args->pl2p[255]; \
-                pdg[1] = p[ira] < 256 ? args->pl2p[ p[ira] ] : args->pl2p[255]; \
-                pdg[2] = p[iaa] < 256 ? args->pl2p[ p[iaa] ] : args->pl2p[255]; \
+                pdg[0] = args->pl2p[ max255(p[irr]) ]; \
+                pdg[1] = args->pl2p[ max255(p[ira]) ]; \
+                pdg[2] = args->pl2p[ max255(p[iaa]) ]; \
             }
             switch (fmt_pl->type) {
                 case BCF_BT_INT8:  BRANCH(int8_t); break;


### PR DESCRIPTION
Silences the Clang warnings added to _vcfroh.c_ in 26b28453ab5d27c7041e68b3f510f9818220433d.

It seems this function was broken by eaf74ca1625910c0a75d6c391e8e1aac9040af8a, and the recent commit restored the correct behaviour. This year of breakage was not detected by the test suite, so tests exercising this code should be added.

All versions of this code do something unfortunate if `p[irr]` is negative, which presumably could happen given a suitably malicious or fuzzed input. The `max255()` function could be extended to do something appropriate for negative `i` too.