### PR TITLE
Out of region requested when piling up the first base in a contig

### DIFF
--- a/mpileup.c
+++ b/mpileup.c
@@ -310,7 +310,7 @@ static int mpileup_reg(mplp_conf_t *conf, uint32_t beg, uint32_t end)
 
     while ( (ret=bam_mplp_auto(conf->iter, &tid, &pos, conf->n_plp, conf->plp)) > 0) 
     {
-        if ( end && (pos<beg || pos>end) ) continue;
+        if (pos<beg || pos>end) continue;
         if ( conf->bed && tid >= 0 )
         {
             int overlap = regidx_overlap(conf->bed, hdr->target_name[tid], pos, pos, NULL);


### PR DESCRIPTION
Unrelated to #935, there is another issue when attempting to pileup just the first base of a given contig.

To pileup POS1 and POS2, this works as expected:

```
$ bcftools mpileup -f LVXS01064584.1.fa -r LVXS01064584.1:1-2 test.bam 2>/dev/null | grep -v "^#"
LVXS01064584.1	1	.	A	<*>	0	.	DP=1;I16=0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0;QS=0,0;MQ0F=0	PL	0,0,0
LVXS01064584.1	2	.	C	<*>	0	.	DP=1;I16=1,0,0,0,22,484,0,0,60,3600,0,0,1,1,0,0;QS=1,0;MQ0F=0	PL	0,3,22
```

However, to pileup just POS1, it looks like we get all possible positions:

```
$ bcftools mpileup -f LVXS01064584.1.fa -r LVXS01064584.1:1-1 test.bam 2>/dev/null | grep -v "^#"
LVXS01064584.1	1	.	A	<*>	0	.	DP=1;I16=0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0;QS=0,0;MQ0F=0	PL	0,0,0
LVXS01064584.1	2	.	C	<*>	0	.	DP=1;I16=1,0,0,0,22,484,0,0,60,3600,0,0,1,1,0,0;QS=1,0;MQ0F=0	PL	0,3,22
LVXS01064584.1	3	.	A	<*>	0	.	DP=1;I16=1,0,0,0,35,1225,0,0,60,3600,0,0,2,4,0,0;QS=1,0;MQ0F=0	PL	0,3,35
LVXS01064584.1	4	.	T	<*>	0	.	DP=1;I16=1,0,0,0,37,1369,0,0,60,3600,0,0,3,9,0,0;QS=1,0;MQ0F=0	PL	0,3,37
LVXS01064584.1	5	.	G	<*>	0	.	DP=1;I16=1,0,0,0,37,1369,0,0,60,3600,0,0,4,16,0,0;QS=1,0;MQ0F=0	PL	0,3,37
LVXS01064584.1	6	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,5,25,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	7	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,6,36,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	8	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,7,49,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	9	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,8,64,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	10	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,9,81,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	11	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,10,100,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	12	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,11,121,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	13	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,12,144,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	14	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,13,169,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	15	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,14,196,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	16	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,15,225,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	17	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,16,256,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	18	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,17,289,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	19	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,18,324,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	20	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,19,361,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	21	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,20,400,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	22	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,21,441,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	23	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,22,484,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	24	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,23,529,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	25	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,24,576,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	26	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	27	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	28	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	29	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	30	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	31	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	32	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	33	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	34	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	35	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	36	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	37	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	38	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	39	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	40	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	41	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	42	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	43	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	44	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	45	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	46	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	47	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	48	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	49	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	50	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	51	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	52	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	53	.	C	G,<*>	0	.	DP=1;I16=0,0,1,0,0,0,41,1681,0,0,60,3600,0,0,25,625;QS=0,1,0;SGB=-0.379885;MQ0F=0	PL	41,3,0,41,3,41
LVXS01064584.1	54	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	55	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	56	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	57	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	58	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	59	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	60	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	61	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	62	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	63	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	64	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	65	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	66	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	67	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	68	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	69	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	70	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	71	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	72	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	73	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	74	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	75	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	76	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,25,625,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	77	.	G	<*>	0	.	DP=1;I16=1,0,0,0,37,1369,0,0,60,3600,0,0,24,576,0,0;QS=1,0;MQ0F=0	PL	0,3,37
LVXS01064584.1	78	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,23,529,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	79	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,22,484,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	80	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,21,441,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	81	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,20,400,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	82	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,19,361,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	83	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,18,324,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	84	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,17,289,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	85	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,16,256,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	86	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,15,225,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	87	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,14,196,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	88	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,13,169,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	89	.	G	A,<*>	0	.	DP=1;I16=0,0,1,0,0,0,41,1681,0,0,60,3600,0,0,12,144;QS=0,1,0;SGB=-0.379885;MQ0F=0	PL	41,3,0,41,3,41
LVXS01064584.1	90	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,11,121,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	91	.	C	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,10,100,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	92	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,9,81,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	93	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,8,64,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	94	.	G	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,7,49,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	95	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,6,36,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	96	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,5,25,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	97	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,4,16,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	98	.	A	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,3,9,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	99	.	T	<*>	0	.	DP=1;I16=1,0,0,0,41,1681,0,0,60,3600,0,0,2,4,0,0;QS=1,0;MQ0F=0	PL	0,3,41
LVXS01064584.1	100	.	G	<*>	0	.	DP=1;I16=1,0,0,0,36,1296,0,0,60,3600,0,0,1,1,0,0;QS=1,0;MQ0F=0	PL	0,3,36
LVXS01064584.1	101	.	G	<*>	0	.	DP=1;I16=1,0,0,0,32,1024,0,0,60,3600,0,0,0,0,0,0;QS=1,0;MQ0F=0	PL	0,3,32
```

```
$ cat LVXS01064584.1.fa
>LVXS01064584.1
ACATGGAAAATGAGAAACATCCACTTGACGACTTGAAAAATGACGAAATCACCAAAATAC
ATGAAAAATGAGAAATGCGCACTGAAGGGCCTGGAATATGGCGAGAAAACTGAAAATCAC
GGAAAATAATAAATACACACTTTAGGAAGTGAAATATGGCGAGGAAAACTGAAAACGGTG
GAAAATTTAGAAATGTCCACTAATGAGNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNAAAATCATGGAAAATG
AGAAACGTCCACTTGACGACTTGAAAAAAGACGAAATCACTGAAAAACATGTAAAATGAG
AAATGCACACTGTAGGACCTGGAATATGGCAAGAAAACTGAAAATCACGGAAAATGAGAT
ATACATACGTTAGGACGTGAAATATGGCACGGAAAACTGAAAAAGTTGGAAAGTTTAGAA
ATGTCCACTTTAGGACATGGAATATGGCAAGAAAACTGAAAATCACGGATAATGAGAAAA
ACA
```

```
$ samtools view -h test.bam
@HD	VN:1.6	SO:coordinate
@SQ	SN:LVXS01064584.1	LN:4743
test	99	LVXS01064584.1	1	60	101M	=	56	156	TCATGGAAAATGAGAAACATCCACTTGACGACTTGAAAAATGACGAAATCACGAAAATACATGAAAAATGAGAAATGCGCACTGAAGGACCTGGAATATGG	<AFFFJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJFJJJJJJJJJJJJJJJJJJJJJJJJ	NM:i:3	MD:Z:0A51C35G12	AS:i:90	XS:i:81	MQ:i:60	MC:Z:101M
test	147	LVXS01064584.1	56	60	101M	=	1	-156	AATACATGAAAAATGAGAAATGCGCACTGAAGGACCTGGAATATGGCAAGAAAACTGAAAATCACGGAAAATAATAAATACACACTTTAGGAAGTGAAATA	JFJJJJFJJJJJJFFJAJJJFAF7AJ7JFJFAFJ7F<<FJJFJJF7JJJJJFJJFJJJJJF<JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJFFAAA	NM:i:2	MD:Z:33G13G53	AS:i:91	XS:i:70	MQ:i:60	MC:Z:101M
```