### PR TITLE
Fix warnings due to function attributes added in htslib

### DIFF
--- a/bcftools.h
+++ b/bcftools.h
@@ -39,7 +39,15 @@ THE SOFTWARE.  */
 #define FT_STDIN (1<<3)
 
 char *bcftools_version(void);
+
+/// Report an error and exit -1
 void error(const char *format, ...) HTS_NORETURN HTS_FORMAT(HTS_PRINTF_FMT, 1, 2);
+
+/// Report an error and exit -1.  If errno != 0, appends strerror(errno).
+//  Note: unlike error() above, the message should not end with "\n" as a
+//  newline will be added by the function.
+void error_errno(const char *format, ...) HTS_NORETURN HTS_FORMAT(HTS_PRINTF_FMT, 1, 2);
+
 void bcf_hdr_append_version(bcf_hdr_t *hdr, int argc, char **argv, const char *cmd);
 const char *hts_bcf_wmode(int file_type);
 

--- a/csq.c
+++ b/csq.c
@@ -1353,7 +1353,8 @@ void init_data(args_t *args)
         if ( args->output_type==FT_TAB_TEXT ) 
         {
             // significant speedup for plain VCFs
-            bcf_hdr_set_samples(args->hdr,NULL,0);
+            if (bcf_hdr_set_samples(args->hdr,NULL,0) < 0)
+                error_errno("[%s] Couldn't build sample filter", __func__);
         }
         args->phase = PHASE_DROP_GT;
     }

--- a/plugins/fill-from-fasta.c
+++ b/plugins/fill-from-fasta.c
@@ -132,7 +132,8 @@ int init(int argc, char **argv, bcf_hdr_t *in, bcf_hdr_t *out)
         }
         hts_close(file);
         free(str.s);
-        bcf_hdr_sync(out_hdr);
+        if (bcf_hdr_sync(out_hdr) < 0)
+            error_errno("[%s] Failed to update header", __func__);
     }
     if (!strcasecmp("REF", column)) anno = ANNO_REF;
     else {

--- a/plugins/gvcfz.c
+++ b/plugins/gvcfz.c
@@ -138,7 +138,8 @@ static void init_groups(args_t *args)
         if ( strcmp(flt,"PASS") ) 
         {
             bcf_hdr_printf(args->hdr_out, "##FILTER=<ID=%s,Description=\"%s\">", flt, hdr_str);
-            bcf_hdr_sync(args->hdr_out);
+            if (bcf_hdr_sync(args->hdr_out) < 0)
+                error_errno("[%s] Failed to update header", __func__);
         }
         args->ngrp++;
         args->grp = (grp_t*) realloc(args->grp,sizeof(grp_t)*args->ngrp);

--- a/reheader.c
+++ b/reheader.c
@@ -491,12 +491,14 @@ static bcf_hdr_t *strip_header(bcf_hdr_t *src, bcf_hdr_t *dst)
             if ( j>=0 )
             {
                 j = atoi(src_hrec->vals[j]);
-                hrec_add_idx(tmp, j);
+                if (hrec_add_idx(tmp, j) < 0)
+                    error_errno("[%s] Failed to add IDX header", __func__);
             }
             bcf_hdr_add_hrec(out, tmp);
         }
     }
-    bcf_hdr_sync(out);
+    if (bcf_hdr_sync(out) < 0)
+        error_errno("[%s] Failed to update header", __func__);
     for (i=0; i<dst->nhrec; i++)
     {
         // finally add new structured fields

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -223,7 +223,10 @@ static void remove_hdr_lines(bcf_hdr_t *hdr, int type)
             memmove(&hdr->hrec[i],&hdr->hrec[i+1],(hdr->nhrec-i)*sizeof(bcf_hrec_t*));
         bcf_hrec_destroy(hrec);
     }
-    if ( nrm ) bcf_hdr_sync(hdr);
+    if ( nrm ) {
+        if (bcf_hdr_sync(hdr) < 0)
+            error_errno("[%s] Failed to update header", __func__);
+    }
 }
 
 static void init_remove_annots(args_t *args)
@@ -364,7 +367,8 @@ static void init_remove_annots(args_t *args)
     }
     khash_str2int_destroy_free(keep);
     if ( !args->nrm ) error("No matching tag in -x %s\n", args->remove_annots);
-    bcf_hdr_sync(args->hdr_out);
+    if (bcf_hdr_sync(args->hdr_out) < 0)
+        error_errno("[%s] Failed to update header", __func__);
 }
 static void init_header_lines(args_t *args)
 {
@@ -378,8 +382,10 @@ static void init_header_lines(args_t *args)
     }
     if ( hts_close(file)!=0 ) error("[%s] Error: close failed .. %s\n", __func__,args->header_fname);
     free(str.s);
-    bcf_hdr_sync(args->hdr_out);
-    bcf_hdr_sync(args->hdr);
+    if (bcf_hdr_sync(args->hdr_out) < 0)
+        error_errno("[%s] Failed to update output header", __func__);
+    if (bcf_hdr_sync(args->hdr) < 0)
+        error_errno("[%s] Failed to update input header", __func__);
 }
 static int setter_filter(args_t *args, bcf1_t *line, annot_col_t *col, void *data)
 {
@@ -1740,7 +1746,8 @@ static void init_columns(args_t *args)
                     bcf_hrec_format(hrec, &tmp);
                     bcf_hdr_append(args->hdr_out, tmp.s);
                 }
-                bcf_hdr_sync(args->hdr_out);
+                if (bcf_hdr_sync(args->hdr_out) < 0)
+                    error_errno("[%s] Failed to update header", __func__);
             }
         }
         else if ( !strcasecmp("QUAL",str.s) )
@@ -1771,7 +1778,8 @@ static void init_columns(args_t *args)
                 tmp.l = 0;
                 bcf_hrec_format(hrec, &tmp);
                 bcf_hdr_append(args->hdr_out, tmp.s);
-                bcf_hdr_sync(args->hdr_out);
+                if (bcf_hdr_sync(args->hdr_out) < 0)
+                    error_errno("[%s] Failed to update header", __func__);
                 int hdr_id = bcf_hdr_id2int(args->hdr_out, BCF_DT_ID, hrec->vals[k]);
                 args->ncols++; args->cols = (annot_col_t*) realloc(args->cols,sizeof(annot_col_t)*args->ncols);
                 annot_col_t *col = &args->cols[args->ncols-1];
@@ -1805,7 +1813,8 @@ static void init_columns(args_t *args)
                 tmp.l = 0;
                 bcf_hrec_format(hrec, &tmp);
                 bcf_hdr_append(args->hdr_out, tmp.s);
-                bcf_hdr_sync(args->hdr_out);
+                if (bcf_hdr_sync(args->hdr_out) < 0)
+                    error_errno("[%s] Failed to update header", __func__);
                 int hdr_id = bcf_hdr_id2int(args->hdr_out, BCF_DT_ID, hrec->vals[k]);
                 args->ncols++; args->cols = (annot_col_t*) realloc(args->cols,sizeof(annot_col_t)*args->ncols);
                 annot_col_t *col = &args->cols[args->ncols-1];
@@ -1847,7 +1856,8 @@ static void init_columns(args_t *args)
                 tmp.l = 0;
                 bcf_hrec_format_rename(hrec, key_dst, &tmp);
                 bcf_hdr_append(args->hdr_out, tmp.s);
-                bcf_hdr_sync(args->hdr_out);
+                if (bcf_hdr_sync(args->hdr_out) < 0)
+                    error_errno("[%s] Failed to update header", __func__);
             }
             int hdr_id = bcf_hdr_id2int(args->hdr_out, BCF_DT_ID, key_dst);
             if ( !bcf_hdr_idinfo_exists(args->hdr_out,BCF_HL_FMT,hdr_id) )
@@ -1927,7 +1937,8 @@ static void init_columns(args_t *args)
                     tmp.l = 0;
                     bcf_hrec_format_rename(hrec, key_dst, &tmp);
                     bcf_hdr_append(args->hdr_out, tmp.s);
-                    bcf_hdr_sync(args->hdr_out);
+                    if (bcf_hdr_sync(args->hdr_out) < 0)
+                        error_errno("[%s] Failed to update header", __func__);
                     hdr_id = bcf_hdr_id2int(args->hdr_out, BCF_DT_ID, key_dst);
                 }
                 else

--- a/vcfview.c
+++ b/vcfview.c
@@ -85,11 +85,14 @@ static void init_data(args_t *args)
 
     if (args->calc_ac && args->update_info)
     {
-        bcf_hdr_append(args->hdr,"##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count in genotypes\">");
-        bcf_hdr_append(args->hdr,"##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Total number of alleles in called genotypes\">");
+        if (bcf_hdr_append(args->hdr,"##INFO=<ID=AC,Number=A,Type=Integer,Description=\"Allele count in genotypes\">") < 0)
+            error_errno("[%s] Failed to add \"AC\" INFO header", __func__);
+        if (bcf_hdr_append(args->hdr,"##INFO=<ID=AN,Number=1,Type=Integer,Description=\"Total number of alleles in called genotypes\">") < 0)
+            error_errno("[%s] Failed to add \"AN\" INFO header", __func__);
     }
     if (args->record_cmd_line) bcf_hdr_append_version(args->hdr, args->argc, args->argv, "bcftools_view");
-    else bcf_hdr_sync(args->hdr);
+    else if (bcf_hdr_sync(args->hdr) < 0)
+        error_errno("[%s] Failed to update header", __func__);
 
     // setup sample data
     if (args->sample_names)

--- a/version.c
+++ b/version.c
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
 #include <htslib/hts.h>
 #include "bcftools.h"
 #include "version.h"
@@ -43,6 +44,21 @@ void error(const char *format, ...)
     va_end(ap);
     exit(-1);
 }
+
+void error_errno(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+    if (errno) {
+        fprintf(stderr, " : %s\n", strerror(errno));
+    } else {
+        fprintf(stderr, "\n");
+    }
+    exit(-1);
+}
+
 
 const char *hts_bcf_wmode(int file_type)
 {

--- a/version.c
+++ b/version.c
@@ -48,11 +48,12 @@ void error(const char *format, ...)
 void error_errno(const char *format, ...)
 {
     va_list ap;
+    int e = errno;
     va_start(ap, format);
     vfprintf(stderr, format, ap);
     va_end(ap);
-    if (errno) {
-        fprintf(stderr, " : %s\n", strerror(errno));
+    if (e) {
+        fprintf(stderr, ": %s\n", strerror(e));
     } else {
         fprintf(stderr, "\n");
     }


### PR DESCRIPTION
HTSlib commit [fe9c2f8f](https://github.com/samtools/htslib/commit/fe9c2f8fb301b3fca3db204b4147c1d37f83d594) added HTS_RESULT_USED to bcf_hdr_sync(), bcf_hrec_add_key(), bcf_hrec_set_val() and hrec_add_idx().  The last three were also changed to return int instead of void.

This adds checks on the return values to fix the warnings in bcftools caused by the htslib update.
