### PR TITLE
Fix address sanitizer complaints

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -53,8 +53,8 @@ static int filter_ninit = 0;
 #  define __FUNCTION__ __func__
 #endif
 
-uint64_t bcf_double_missing    = 0x7ff0000000000001;
-uint64_t bcf_double_vector_end = 0x7ff0000000000002;
+static uint64_t bcf_double_missing    = 0x7ff0000000000001;
+static uint64_t bcf_double_vector_end = 0x7ff0000000000002;
 static inline void bcf_double_set(double *ptr, uint64_t value)
 {
     union { uint64_t i; double d; } u;

--- a/plugins/trio-stats.c
+++ b/plugins/trio-stats.c
@@ -391,6 +391,7 @@ static void destroy_data(args_t *args)
     free(args->ac);
     free(args->ac_trio);
     free(args->gt_arr);
+    free(args->dnm_als);
     if ( fclose(args->fp_out)!=0 ) error("Close failed: %s\n", (!args->output_fname || !strcmp("-",args->output_fname)) ? "stdout" : args->output_fname);
     free(args);
 }


### PR DESCRIPTION
Fixes two complaints from address sanitizer:

* A memory leak that appeared in commit 0e79bdc

* A one-definition-rule violation in some of the plugins (notably setGT)

Not sure what's causing the second one, but making the offending symbols static fixes it.  They don't appear to be used outside the one `.c` file.

To reproduce the problems, configure bcftools with:

```
configure CFLAGS='-g -fsanitize=address' LDFLAGS='-fsanitize=address'
```

and then `make && make test`.

Note: Needs a C compiler that supports address sanitizer - either `clang` or a new enough `gcc`.