### PR TITLE
Fix typos in the documentation

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -366,12 +366,12 @@ Add or remove annotations.
     *<<expressions,EXPRESSIONS>>*.
 
 *-k, --keep-sites*::
-    keep sites wich do not pass *-i* and *-e* expressions instead of discarding them
+    keep sites which do not pass *-i* and *-e* expressions instead of discarding them
 
 *-l, --merge-logic* 'tag':'first'|'append'|'unique'|'sum'|'avg'|'min'|'max'[,...]::
     if multiple regions overlap a single record, the option defines how treat the multiple
     annotation values when setting the tag 'tag' in the destination file: use the first encountered ignoring
-    the rest ('first'); append allowing duplicities ('append'); append discarding duplicate values ('unique');
+    the rest ('first'); append allowing duplicates ('append'); append discarding duplicate values ('unique');
     sum the values ('sum', numeric fields only); average the values ('avg'); use the minimum value ('min') or
     the maximum ('max').
     +
@@ -445,7 +445,7 @@ Add or remove annotations.
 
     # Annotate from a tab-delimited file with regions (1-based coordinates, inclusive)
     tabix -s1 -b2 -e3 annots.tab.gz
-    bcftools annotate -a annots.tab.gz -h annots.hdr -c CHROM,FROM,TO,TAG inut.vcf
+    bcftools annotate -a annots.tab.gz -h annots.hdr -c CHROM,FROM,TO,TAG input.vcf
 
     # Annotate from a bed file (0-based coordinates, half-closed, half-open intervals)
     bcftools annotate -a annots.bed.gz -h annots.hdr -c CHROM,FROM,TO,TAG input.vcf
@@ -586,7 +586,7 @@ demand. The original calling model can be invoked with the *-c* option.
             *-s, --samples* and *-n, --novel-rate*.
 
 *-m, --multiallelic-caller*::
-    alternative modelfor multiallelic and rare-variant calling designed to
+    alternative model for multiallelic and rare-variant calling designed to
     overcome known limitations in *-c* calling model (conflicts with *-c*)
 
 *-n, --novel-rate* 'float'[,...]::
@@ -651,7 +651,7 @@ loss), 0 (complete loss), 3 (single-copy gain).
     see *<<common_options,Common Options>>*
 
 *-s, --query-sample* 'string'::
-    query samply name
+    query sample name
 
 *-t, --targets* 'LIST'::
     see *<<common_options,Common Options>>*
@@ -1066,7 +1066,7 @@ The output VCF is annotated with INFO/BCSQ and FORMAT/BCSQ tag (configurable
 with the *-c* option). The latter is a bitmask of indexes to INFO/BCSQ, with
 interleaved haplotypes. See the usage examples below for using the %TBCSQ
 converter in *query* for extracting a more human readable form from this
-bitmask. The contruction of the bitmask limits the number of consequences
+bitmask. The construction of the bitmask limits the number of consequences
 that can be referenced in the FORMAT/BCSQ tags. By default this is 16, but
 if more are required, see the *--ncsq* option.
 
@@ -1211,7 +1211,7 @@ output VCF and are ignored for the prediction analysis.
     #   %TBCSQ    .. print consequences in all haplotypes in separate columns
     #   %TBCSQ{0} .. print the first haplotype only
     #   %TBCSQ{1} .. print the second haplotype only
-    #   %TBCSQ{*} .. print a list of unique consquences present in either haplotype
+    #   %TBCSQ{*} .. print a list of unique consequences present in either haplotype
     bcftools query -f'[%CHROM\t%POS\t%SAMPLE\t%TBCSQ\n]' out.bcf
 ----
 
@@ -1560,7 +1560,7 @@ For "vertical" merge take a look at *<<concat,bcftools concat>>* or *<<norm,bcft
 
 *--force-samples*::
     if the merged files contain duplicate samples names, proceed anyway.
-    Duplicate sample names will be resolved by prepending index of the file
+    Duplicate sample names will be resolved by prepending the index of the file
     as it appeared on the command line to the conflicting sample name (see
     '2:S3' in the above example).
 
@@ -1676,7 +1676,7 @@ multiple regions and many alignment files are processed.
 *-C, --adjust-MQ* 'INT'::
     Coefficient  for  downgrading mapping quality for reads containing
     excessive mismatches. Given a read with a phred-scaled probability q of
-    being generated from the mapped posi- tion, the new mapping quality is
+    being generated from the mapped position, the new mapping quality is
     about sqrt((INT-q)/INT)*INT. A zero value disables this functionality; if
     enabled, the recommended value for BWA is 50. [0]
 
@@ -2319,7 +2319,7 @@ Extracts fields from VCF or BCF files and outputs them in user-defined format.
 
     %CHROM          The CHROM column (similarly also other columns: POS, ID, REF, ALT, QUAL, FILTER)
     %END            End position of the REF allele
-    %END0           End position of the REF allele in 0-based cordinates
+    %END0           End position of the REF allele in 0-based coordinates
     %FIRST_ALT      Alias for %ALT{0}
     %FORMAT         Prints all FORMAT fields or a subset of samples with -s or -S
     %GT             Genotype (e.g. 0/1)
@@ -2361,7 +2361,7 @@ Extracts fields from VCF or BCF files and outputs them in user-defined format.
     # Print all samples at sites with at least one alternate genotype
     bcftools view -i'GT="alt"' file.bcf -Ou | bcftools query -f'[%CHROM:%POS %SAMPLE %GT\n]'
 
-    # Print phred-scaled binomial probablity from FORMAT/AD tag for all heterozygous genotypes
+    # Print phred-scaled binomial probability from FORMAT/AD tag for all heterozygous genotypes
     bcftools query -i'GT="het"' -f'[%CHROM:%POS %SAMPLE %GT %pbinom(AD)\n]' file.vcf
 
     # Print the second value of AC field if bigger than 10. Note the (unfortunate) difference in


### PR DESCRIPTION
This fixes a number of typos in the man page.