### PR TITLE
Assorted bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
     - os: osx
       compiler: clang
       env: USE_CONFIG=yes
+    # An optimised build with address, leak and undefined behavior checking
+    - os: linux
+      compiler: clang
+      sudo: required
+      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address" USE_CONFIG=yes
 
 env:
   global:

--- a/mcall.c
+++ b/mcall.c
@@ -1466,20 +1466,19 @@ static int mcall_constrain_alleles(call_t *call, bcf1_t *rec, int *unseen)
         if (nret<=0) continue;
         int nsmpl = bcf_hdr_nsamples(call->hdr);
         int size1 = sizeof(float);
-
+        hts_expand(float, nsmpl * nals, ntmp_new, tmp_new);
         for (j=0; j<nsmpl; j++)
         {
-            void *ptr_ori = tmp_ori + j*size1*fmt->n;
-            void *ptr_new = tmp_new + j*nals*size1;
+            uint8_t *ptr_ori = (uint8_t *) tmp_ori + j*size1*fmt->n;
+            uint8_t *ptr_new = (uint8_t *) tmp_new + j*nals*size1;
             for (k=0; k<nals; k++)
             {
-                void *dst = ptr_new + size1*k;
-                void *src = ptr_ori + size1*call->als_map[k]; 
+                uint8_t *dst = ptr_new + size1*k;
+                uint8_t *src = ptr_ori + size1*call->als_map[k];
                 memcpy(dst,src,size1);
             }
         }
-        ntmp_new = nsmpl*rec->n_allele;
-        nret = bcf_update_format(call->hdr, rec, key, tmp_new, ntmp_new, type);
+        nret = bcf_update_format(call->hdr, rec, key, tmp_new, nsmpl*nals, type);
         assert( nret==0 );
     }
     call->PLs    = (int32_t*) tmp_new;

--- a/plugins/indel-stats.c
+++ b/plugins/indel-stats.c
@@ -51,7 +51,7 @@ static inline int len2bin(int len)
     if ( len > MAX_LEN ) return 2*MAX_LEN;
     return MAX_LEN + len;
 }
-static inline int bin2len(int bin)
+HTS_UNUSED static inline int bin2len(int bin)
 {
     return bin - MAX_LEN;
 }
@@ -59,7 +59,7 @@ static inline int vaf2bin(float vaf)
 {
     return vaf*(NVAF-1);
 }
-static inline float bin2vaf(int bin)
+HTS_UNUSED static inline float bin2vaf(int bin)
 {
     return (float)bin/(NVAF-1);
 }

--- a/polysomy.c
+++ b/polysomy.c
@@ -70,7 +70,7 @@ static void init_dist(args_t *args, dist_t *dist, int verbose)
 
     // smooth the distribution, this is just to find the peaks
     double *tmp = (double*) malloc(sizeof(double)*n);
-    int win  = args->smooth ? fabs(args->smooth)*2 + 1 : 7;   // must be an odd number
+    int win  = args->smooth ? abs(args->smooth)*2 + 1 : 7;   // must be an odd number
     int hwin = win/2;
     double avg = tmp[0] = dist->yvals[0];
     for (i=1; i<hwin; i++)

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -310,7 +310,7 @@ static void set_samples(args_t *args, const char *fn, int is_file)
         if ( ismpl < 0 ) { fprintf(stderr,"Warning: No such sample in the VCF: %s\n",ss); continue; }
         if ( old2new[ismpl] != -1 ) { fprintf(stderr,"Warning: The sample is listed multiple times: %s\n",ss); continue; }
 
-        ss = se+1;
+        ss = se+(x != '\0');
         while ( *ss && isspace(*ss) ) ss++;
         if ( !*ss ) ss = "2";   // default ploidy
         se = ss;


### PR DESCRIPTION
Fixes two warnings from `clang`.

Fix accidental read beyond the end of a string in vcfcall.c `set_samples()` when the line only contains the sample name.  If the program didn't crash and depending on what followed, this may have caused ploidy to be set incorrectly in some cases.

Add missing call to `hts_expand()` in mcall.c `mcall_constrain_alleles()` to fix an invalid write beyond the allocated region.  Also fix illegal pointer arithmetic.

Also adds an address sanitizer check to travis so problems like these can be detected more quickly.  It would help if the test harness didn't discard `stderr` quite so much though - you can tell that a test failed, but not why.  One solution to this might be to capture it into a file, and then print out the contents if the test happens to fail.