### PR TITLE
Fix bcftools sort invalid input crash; fix compiler and make warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@
 # DEALINGS IN THE SOFTWARE.
 
 CC       = gcc
-AR     = ar
-RANLIB = ranlib
+AR       = ar
+RANLIB   = ranlib
 CPPFLAGS =
 CFLAGS   = -g -Wall -Wc++-compat -O2
 LDFLAGS  =
@@ -81,11 +81,7 @@ PLUGINM =
 
 ALL_CPPFLAGS = -I. $(HTSLIB_CPPFLAGS) $(CPPFLAGS)
 ALL_LDFLAGS  = $(HTSLIB_LDFLAGS) $(LDFLAGS)
-ifeq "$(shell uname -o)" "Msys"
-ALL_LIBS     = -lz $(LIBS)
-else
-ALL_LIBS     = -lz -ldl $(LIBS)
-endif
+ALL_LIBS     = -lz $(DL_LIBS) $(LIBS)
 
 all: $(PROGRAMS) $(TEST_PROGRAMS) plugins
 
@@ -163,15 +159,18 @@ endif
 ifeq "$(PLATFORM)" "Darwin"
 $(PLUGINS): | bcftools
 PLUGIN_FLAGS = -bundle -bundle_loader bcftools -Wl,-undefined,dynamic_lookup
-else ifeq "$(shell uname -o)" "Msys"
+DL_LIBS =
+else ifneq "$(filter MINGW% MSYS%,$(PLATFORM))" ""
 DYNAMIC_FLAGS =
 $(PLUGINS): | bcftools
 PLUGIN_FLAGS = -fPIC -shared -Wl,-export-all-symbols
 PLUGIN_LIBS = libbcftools.a $(HTSLIB_DLL) $(ALL_LIBS)
 # On windows, plugins need to be fully linked, including bcftools_version() symbol
 # from the application they will be loaded into.
+DL_LIBS =
 else
 PLUGIN_FLAGS = -fPIC -shared
+DL_LIBS = -ldl
 endif
 
 libbcftools.a: $(OBJS)

--- a/plugins/check-sparsity.c
+++ b/plugins/check-sparsity.c
@@ -247,7 +247,7 @@ int run(int argc, char **argv)
                 args->min_sites = strtol(optarg,&tmp,10);
                 if ( *tmp ) error("Could not parse: -n %s\n", optarg);
                 break;
-            case 'R': args->region_is_file = 1; 
+            case 'R': args->region_is_file = 1; // fall-through
             case 'r': args->region = optarg; break; 
             case 'h':
             case '?':

--- a/plugins/guess-ploidy.c
+++ b/plugins/guess-ploidy.c
@@ -444,7 +444,7 @@ int run(int argc, char **argv)
                 else if ( !strcasecmp(optarg,"hg38") ) region = "chrX:2781480-155701381";
                 else error("The argument not recognised, expected --genome b37, b38, hg19 or hg38: %s\n", optarg);
                 break;
-            case 'R': region_is_file = 1; 
+            case 'R': region_is_file = 1; // fall-through
             case 'r': region = optarg; break; 
             case 'v': args->verbose++; break; 
             case 't':

--- a/plugins/parental-origin.c
+++ b/plugins/parental-origin.c
@@ -397,7 +397,8 @@ int run(int argc, char **argv)
 
     int i;
     printf("# bcftools +%s", args->argv[0]);
-    for (i=1; i<args->argc; i++) printf(" %s",args->argv[i]); printf("\n");
+    for (i=1; i<args->argc; i++) printf(" %s",args->argv[i]);
+    printf("\n");
     printf("# [1]type\t[2]predicted_origin\t[3]quality\t[4]nmarkers\n");
     printf("%s\t%s\t%f\t%d\n", args->cnv_type==CNV_DUP ? "dup" : "del", origin, qual, args->ntest);
 

--- a/plugins/prune.c
+++ b/plugins/prune.c
@@ -251,9 +251,9 @@ int run(int argc, char **argv)
                 else if ( !strcasecmp("kb",tmp) ) args->ld_win *= -1000;
                 else error("Could not parse: --window %s\n", optarg);
                 break;
-            case 'T': args->target_is_file = 1; 
+            case 'T': args->target_is_file = 1; // fall-through
             case 't': args->target = optarg; break; 
-            case 'R': args->region_is_file = 1; 
+            case 'R': args->region_is_file = 1; // fall-through
             case 'r': args->region = optarg; break; 
             case 'o': args->output_fname = optarg; break;
             case 'O':

--- a/plugins/remove-overlaps.c
+++ b/plugins/remove-overlaps.c
@@ -176,9 +176,9 @@ int run(int argc, char **argv)
             case 'v': args->verbose = 1; break;
             case 'e': args->filter_str = optarg; args->filter_logic |= FLT_EXCLUDE; break;
             case 'i': args->filter_str = optarg; args->filter_logic |= FLT_INCLUDE; break;
-            case 'T': args->target_is_file = 1; 
+            case 'T': args->target_is_file = 1; // fall-through
             case 't': args->target = optarg; break; 
-            case 'R': args->region_is_file = 1; 
+            case 'R': args->region_is_file = 1; // fall-through
             case 'r': args->region = optarg; break; 
             case 'o': args->output_fname = optarg; break;
             case 'O':

--- a/reheader.c
+++ b/reheader.c
@@ -682,7 +682,7 @@ int main_reheader(int argc, char *argv[])
             case 'o': args->output_fname = optarg; break;
             case 's': args->samples_fname = optarg; break;
             case 'h': args->header_fname = optarg; break;
-            case '?': usage(args);
+            case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -1511,7 +1511,7 @@ int main_vcfconvert(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case 10 : args->record_cmd_line = 0; break;
             case 11 : args->sex_fname = optarg; break;
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -502,7 +502,7 @@ int main_vcffilter(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 'h':
-            case '?': usage(args);
+            case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -788,7 +788,7 @@ int main_vcfgtcheck(int argc, char *argv[])
             case 't': targets = optarg; break;
             case 'T': targets = optarg; targets_is_file = 1; break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfisec.c
+++ b/vcfisec.c
@@ -577,7 +577,7 @@ int main_vcfisec(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -2485,7 +2485,7 @@ void merge_vcf(args_t *args)
         int i;
         for (i=0; i<args->files->nreaders; i++)
         {
-            char buf[10]; snprintf(buf,10,"%d",i+1);
+            char buf[24]; snprintf(buf,sizeof buf,"%d",i+1);
             merge_headers(args->out_hdr, args->files->readers[i].header,buf,args->force_samples);
         }
         if (args->record_cmd_line) bcf_hdr_append_version(args->out_hdr, args->argc, args->argv, "bcftools_merge");
@@ -2652,7 +2652,7 @@ int main_vcfmerge(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -348,7 +348,7 @@ static int realign(args_t *args, bcf1_t *line)
         if ( has_non_acgtn(line->d.allele[i],line->shared.l) )
         {
             if ( args->check_ref==CHECK_REF_EXIT )
-                error("Non-ACGTN alternate allele at %s:%d .. REF_SEQ:'%s' vs VCF:'%s'\n", bcf_seqname(args->hdr,line),line->pos+1,ref,line->d.allele[i]);
+                error("Non-ACGTN alternate allele at %s:%d .. VCF:'%s'\n", bcf_seqname(args->hdr,line),line->pos+1,line->d.allele[i]);
             if ( args->check_ref & CHECK_REF_WARN )
                 fprintf(stderr,"NON_ACGTN_ALT\t%s\t%d\t%s\n", bcf_seqname(args->hdr,line),line->pos+1,line->d.allele[i]);
             return ERR_REF_MISMATCH;
@@ -1962,7 +1962,7 @@ int main_vcfnorm(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfquery.c
+++ b/vcfquery.c
@@ -307,7 +307,7 @@ int main_vcfquery(int argc, char *argv[])
             case 's': args->sample_list = optarg; break;
             case 'S': args->sample_list = optarg; args->sample_is_file = 1; break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfsom.c
+++ b/vcfsom.c
@@ -696,7 +696,7 @@ int main_vcfsom(int argc, char *argv[])
             case 't': args->action = SOM_TRAIN; break;
             case 'c': args->action = SOM_CLASSIFY; break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfsort.c
+++ b/vcfsort.c
@@ -163,6 +163,7 @@ void sort_blocks(args_t *args)
     htsFile *in = hts_open(args->fname, "r");
     if ( !in ) clean_files_and_throw(args, "Could not read %s\n", args->fname);
     args->hdr = bcf_hdr_read(in);
+    if ( !args->hdr) clean_files_and_throw(args, "Could not read VCF/BCF headers from %s\n", args->fname);
 
     while ( 1 )
     {
@@ -335,8 +336,8 @@ int main_sort(int argc, char *argv[])
                           default: error("The output type \"%s\" not recognised\n", optarg);
                       };
                       break;
-            case 'h': usage(args);
-            case '?': usage(args);
+            case 'h':
+            case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfstats.c
+++ b/vcfstats.c
@@ -1799,7 +1799,7 @@ int main_vcfstats(int argc, char *argv[])
             case 'i': args->filter_str = optarg; args->filter_logic |= FLT_INCLUDE; break;
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case 'h':
-            case '?': usage();
+            case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }

--- a/vcfview.c
+++ b/vcfview.c
@@ -697,7 +697,7 @@ int main_vcfview(int argc, char *argv[])
             }
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
-            case '?': usage(args);
+            case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);
         }
     }


### PR DESCRIPTION
Given an empty file _empty.vcf_ (or piped input from a program that failed, which is more likely), bcftools sort crashes due to not checking the return code from `bcf_hdr_read()`:

```
$ bcftools sort empty.vcf 
Writing to /tmp/bcftools-sort.QZKQj3
[E::bcf_hdr_read] Input is not detected as bcf or vcf format
Segmentation fault: 11
```

This fixes that to produce an error message and clean up instead.

Also suppress a number of `gcc-9` and/or `-Wextra` warnings. 

And avoid using `uname -o` in the Makefile, as that option does not exist on macOS or (some) BSDs. Instead check for `uname -s` values corresponding to -o "Msys", namely (according to [Wikipedia](https://en.wikipedia.org/wiki/Uname#Examples)) stuff matching /^(MINGW|MSYS).*$/. @valeriuo may wish to check that this still builds as expected on Windows platforms.