### PR TITLE
Prepare for 64-bit positions

### DIFF
--- a/consensus.c
+++ b/consensus.c
@@ -333,7 +333,7 @@ static void unread_vcf_line(args_t *args, bcf1_t **rec_ptr)
 {
     bcf1_t *rec = *rec_ptr;
     if ( args->vcf_rbuf.n >= args->vcf_rbuf.m )
-        error("FIXME: too many overlapping records near %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+        error("FIXME: too many overlapping records near %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
 
     // Insert the new record in the buffer. The line would be overwritten in
     // the next bcf_sr_next_line call, therefore we need to swap it with an
@@ -397,7 +397,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
         if ( !fmt ) return;
 
         if ( fmt->type!=BCF_BT_INT8 )
-            error("Todo: GT field represented with BCF_BT_INT8, too many alleles at %s:%d?\n",bcf_seqname(args->hdr,rec),rec->pos+1);
+            error("Todo: GT field represented with BCF_BT_INT8, too many alleles at %s:%"PRId64"?\n",bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         uint8_t *ptr = fmt->p + fmt->size*args->isample;
 
         enum { use_hap, use_iupac, pick_one } action = use_hap;
@@ -421,7 +421,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
                 {
                     if ( !warned_haplotype )
                     {
-                        fprintf(stderr, "Can't apply %d-th haplotype at %s:%d. (This warning is printed only once.)\n", args->haplotype,bcf_seqname(args->hdr,rec),rec->pos+1);
+                        fprintf(stderr, "Can't apply %d-th haplotype at %s:%"PRId64". (This warning is printed only once.)\n", args->haplotype,bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
                         warned_haplotype = 1;
                     }
                     return;
@@ -467,7 +467,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
 
             if ( ialt>=0 )
             {
-                if ( rec->n_allele <= ialt || rec->n_allele <= jalt ) error("Invalid VCF, too few ALT alleles at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+                if ( rec->n_allele <= ialt || rec->n_allele <= jalt ) error("Invalid VCF, too few ALT alleles at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
                 if ( ialt!=jalt && !rec->d.allele[ialt][1] && !rec->d.allele[jalt][1] ) // is this a het snp?
                 {
                     char ial = rec->d.allele[ialt][0];
@@ -499,7 +499,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
                 {
                     if ( ptr[i]==(uint8_t)bcf_int8_vector_end ) break;
                     jalt = bcf_gt_allele(ptr[i]);
-                    if ( rec->n_allele <= jalt ) error("Broken VCF, too few alts at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+                    if ( rec->n_allele <= jalt ) error("Broken VCF, too few alts at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
                     if ( args->allele & (PICK_LONG|PICK_SHORT) )
                     {
                         int len = jalt==0 ? rec->rlen : strlen(rec->d.allele[jalt]);
@@ -521,7 +521,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
             }
         }
         if ( !ialt ) return;  // ref allele
-        if ( rec->n_allele <= ialt ) error("Broken VCF, too few alts at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+        if ( rec->n_allele <= ialt ) error("Broken VCF, too few alts at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     }
     else if ( args->output_iupac && !rec->d.allele[0][1] && !rec->d.allele[1][1] )
     {
@@ -554,7 +554,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
 
         if ( overlap )
         {
-            fprintf(stderr,"The site %s:%d overlaps with another variant, skipping...\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            fprintf(stderr,"The site %s:%"PRId64" overlaps with another variant, skipping...\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
             return;
         }
         
@@ -564,7 +564,7 @@ static void apply_variant(args_t *args, bcf1_t *rec)
     int idx = rec->pos - args->fa_ori_pos + args->fa_mod_off;
     if ( idx<0 )
     {
-        fprintf(stderr,"Warning: ignoring overlapping variant starting at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+        fprintf(stderr,"Warning: ignoring overlapping variant starting at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         return;
     }
     if ( rec->rlen > args->fa_buf.l - idx )
@@ -574,17 +574,17 @@ static void apply_variant(args_t *args, bcf1_t *rec)
         if ( alen > rec->rlen )
         {
             rec->d.allele[ialt][rec->rlen] = 0;
-            fprintf(stderr,"Warning: trimming variant starting at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            fprintf(stderr,"Warning: trimming variant starting at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( idx>=args->fa_buf.l ) 
-        error("FIXME: %s:%d .. idx=%d, ori_pos=%d, len=%"PRIu64", off=%d\n",bcf_seqname(args->hdr,rec),rec->pos+1,idx,args->fa_ori_pos,(uint64_t)args->fa_buf.l,args->fa_mod_off);
+        error("FIXME: %s:%"PRId64" .. idx=%d, ori_pos=%d, len=%"PRIu64", off=%d\n",bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,idx,args->fa_ori_pos,(uint64_t)args->fa_buf.l,args->fa_mod_off);
 
     // sanity check the reference base
     if ( rec->d.allele[ialt][0]=='<' )
     {
         if ( strcasecmp(rec->d.allele[ialt], "<DEL>") )
-            error("Symbolic alleles other than <DEL> are currently not supported: %s at %s:%d\n",rec->d.allele[ialt],bcf_seqname(args->hdr,rec),rec->pos+1);
+            error("Symbolic alleles other than <DEL> are currently not supported: %s at %s:%"PRId64"\n",rec->d.allele[ialt],bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         assert( rec->d.allele[0][1]==0 );           // todo: for now expecting strlen(REF) = 1
         len_diff = 1-rec->rlen;
         rec->d.allele[ialt] = rec->d.allele[0];     // according to VCF spec, REF must precede the event
@@ -613,11 +613,11 @@ static void apply_variant(args_t *args, bcf1_t *rec)
                 args->fa_buf.s[idx+rec->rlen] = 0;
             }
             error(
-                    "The fasta sequence does not match the REF allele at %s:%d:\n"
+                    "The fasta sequence does not match the REF allele at %s:%"PRId64":\n"
                     "   .vcf: [%s] <- (REF)\n" 
                     "   .vcf: [%s] <- (ALT)\n" 
                     "   .fa:  [%s]%c%s\n",
-                    bcf_seqname(args->hdr,rec),rec->pos+1, rec->d.allele[0], rec->d.allele[ialt], args->fa_buf.s+idx, 
+                    bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1, rec->d.allele[0], rec->d.allele[ialt], args->fa_buf.s+idx,
                     tmp?tmp:' ',tmp?args->fa_buf.s+idx+rec->rlen+1:""
                  );
         }

--- a/convert.c
+++ b/convert.c
@@ -672,7 +672,7 @@ static void process_gt_to_prob3(convert_t *convert, bcf1_t *line, fmt_t *fmt, in
         // for (i=0; i<convert->nsamples; i++) kputs(" 0.33 0.33 0.33", str);
         // return;
 
-        error("Error parsing GT tag at %s:%d\n", bcf_seqname(convert->header,line),line->pos+1);
+        error("Error parsing GT tag at %s:%"PRId64"\n", bcf_seqname(convert->header,line),(int64_t) line->pos+1);
     }
 
     n /= convert->nsamples;
@@ -723,7 +723,7 @@ static void process_pl_to_prob3(convert_t *convert, bcf1_t *line, fmt_t *fmt, in
         // for (i=0; i<convert->nsamples; i++) kputs(" 0.33 0.33 0.33", str);
         // return;
 
-        error("Error parsing PL tag at %s:%d\n", bcf_seqname(convert->header,line),line->pos+1);
+        error("Error parsing PL tag at %s:%"PRId64"\n", bcf_seqname(convert->header,line),(int64_t) line->pos+1);
     }
 
     n /= convert->nsamples;
@@ -772,7 +772,7 @@ static void process_gp_to_prob3(convert_t *convert, bcf1_t *line, fmt_t *fmt, in
         // for (i=0; i<convert->nsamples; i++) kputs(" 0.33 0.33 0.33", str);
         // return;
 
-        error("Error parsing GP tag at %s:%d\n", bcf_seqname(convert->header,line),line->pos+1);
+        error("Error parsing GP tag at %s:%"PRId64"\n", bcf_seqname(convert->header,line),(int64_t) line->pos+1);
     }
 
     n /= convert->nsamples;
@@ -784,7 +784,7 @@ static void process_gp_to_prob3(convert_t *convert, bcf1_t *line, fmt_t *fmt, in
         {
             if ( ptr[j]==bcf_int32_vector_end ) break;
             if ( ptr[j]==bcf_int32_missing ) { ptr[j]=0; continue; }
-            if ( ptr[j]<0 || ptr[j]>1 ) error("[%s:%d:%f] GP value outside range [0,1]; bcftools convert expects the VCF4.3+ spec for the GP field encoding genotype posterior probabilities", bcf_seqname(convert->header,line),line->pos+1,ptr[j]);
+            if ( ptr[j]<0 || ptr[j]>1 ) error("[%s:%"PRId64":%f] GP value outside range [0,1]; bcftools convert expects the VCF4.3+ spec for the GP field encoding genotype posterior probabilities", bcf_seqname(convert->header,line),(int64_t) line->pos+1,ptr[j]);
             sum+=ptr[j];
         }
         if ( j==line->n_allele )
@@ -827,24 +827,24 @@ static void process_gt_to_hap(convert_t *convert, bcf1_t *line, fmt_t *fmt, int 
 
     int i, gt_id = bcf_hdr_id2int(convert->header, BCF_DT_ID, "GT");
     if ( !bcf_hdr_idinfo_exists(convert->header,BCF_HL_FMT,gt_id) )
-        error("FORMAT/GT tag not present at %s:%d\n", bcf_seqname(convert->header, line), line->pos+1);
+        error("FORMAT/GT tag not present at %s:%"PRId64"\n", bcf_seqname(convert->header, line),(int64_t) line->pos+1);
     if ( !(line->unpacked & BCF_UN_FMT) ) bcf_unpack(line, BCF_UN_FMT);
     bcf_fmt_t *fmt_gt = NULL;
     for (i=0; i<line->n_fmt; i++)
         if ( line->d.fmt[i].id==gt_id ) { fmt_gt = &line->d.fmt[i]; break; }
     if ( !fmt_gt )
-        error("FORMAT/GT tag not present at %s:%d\n", bcf_seqname(convert->header, line), line->pos+1);
+        error("FORMAT/GT tag not present at %s:%"PRId64"\n", bcf_seqname(convert->header, line),(int64_t) line->pos+1);
 
     // Alloc all memory in advance to avoid kput routines. The biggest allowed allele index is 99
     if ( line->n_allele > 100 )
-        error("Too many alleles (%d) at %s:%d\n", line->n_allele, bcf_seqname(convert->header, line), line->pos+1);
+        error("Too many alleles (%d) at %s:%"PRId64"\n", line->n_allele, bcf_seqname(convert->header, line),(int64_t) line->pos+1);
     if ( ks_resize(str, str->l+convert->nsamples*8) != 0 )
         error("Could not alloc %" PRIu64 " bytes\n", (uint64_t)(str->l + convert->nsamples*8));
 
     if ( fmt_gt->type!=BCF_BT_INT8 )    // todo: use BRANCH_INT if the VCF is valid
-        error("Uh, too many alleles (%d) or redundant BCF representation at %s:%d\n", line->n_allele, bcf_seqname(convert->header, line), line->pos+1);
+        error("Uh, too many alleles (%d) or redundant BCF representation at %s:%"PRId64"\n", line->n_allele, bcf_seqname(convert->header, line),(int64_t) line->pos+1);
     if ( fmt_gt->n!=1 && fmt_gt->n!=2 )
-        error("Uh, ploidy of %d not supported, see %s:%d\n", fmt_gt->n, bcf_seqname(convert->header, line), line->pos+1);
+        error("Uh, ploidy of %d not supported, see %s:%"PRId64"\n", fmt_gt->n, bcf_seqname(convert->header, line),(int64_t) line->pos+1);
 
     int8_t *ptr = ((int8_t*) fmt_gt->p) - fmt_gt->n;
     for (i=0; i<convert->nsamples; i++)
@@ -981,22 +981,22 @@ static void process_gt_to_hap2(convert_t *convert, bcf1_t *line, fmt_t *fmt, int
 
     int i, gt_id = bcf_hdr_id2int(convert->header, BCF_DT_ID, "GT");
     if ( !bcf_hdr_idinfo_exists(convert->header,BCF_HL_FMT,gt_id) )
-        error("FORMAT/GT tag not present at %s:%d\n", bcf_seqname(convert->header, line), line->pos+1);
+        error("FORMAT/GT tag not present at %s:%"PRId64"\n", bcf_seqname(convert->header, line),(int64_t) line->pos+1);
     if ( !(line->unpacked & BCF_UN_FMT) ) bcf_unpack(line, BCF_UN_FMT);
     bcf_fmt_t *fmt_gt = NULL;
     for (i=0; i<line->n_fmt; i++)
         if ( line->d.fmt[i].id==gt_id ) { fmt_gt = &line->d.fmt[i]; break; }
     if ( !fmt_gt )
-        error("FORMAT/GT tag not present at %s:%d\n", bcf_seqname(convert->header, line), line->pos+1);
+        error("FORMAT/GT tag not present at %s:%"PRId64"\n", bcf_seqname(convert->header, line),(int64_t)  line->pos+1);
 
     // Alloc all memory in advance to avoid kput routines. The biggest allowed allele index is 99
     if ( line->n_allele > 100 )
-        error("Too many alleles (%d) at %s:%d\n", line->n_allele, bcf_seqname(convert->header, line), line->pos+1);
+        error("Too many alleles (%d) at %s:%"PRId64"\n", line->n_allele, bcf_seqname(convert->header, line),(int64_t) line->pos+1);
     if ( ks_resize(str, str->l+convert->nsamples*8) != 0 )
         error("Could not alloc %" PRIu64 " bytes\n", (uint64_t)(str->l + convert->nsamples*8));
 
     if ( fmt_gt->type!=BCF_BT_INT8 )    // todo: use BRANCH_INT if the VCF is valid
-        error("Uh, too many alleles (%d) or redundant BCF representation at %s:%d\n", line->n_allele, bcf_seqname(convert->header, line), line->pos+1);
+        error("Uh, too many alleles (%d) or redundant BCF representation at %s:%"PRId64"\n", line->n_allele, bcf_seqname(convert->header, line),(int64_t) line->pos+1);
 
     int8_t *ptr = ((int8_t*) fmt_gt->p) - fmt_gt->n;
     for (i=0; i<convert->nsamples; i++)

--- a/filter.c
+++ b/filter.c
@@ -28,6 +28,7 @@ THE SOFTWARE.  */
 #include <errno.h>
 #include <math.h>
 #include <sys/types.h>
+#include <inttypes.h>
 #ifndef _WIN32
 #include <pwd.h>
 #endif
@@ -668,7 +669,7 @@ static void filters_set_info_flag(filter_t *flt, bcf1_t *line, token_t *tok)
 static void filters_set_format_int(filter_t *flt, bcf1_t *line, token_t *tok)
 {
     if ( line->n_sample != tok->nsamples )
-        error("Incorrect number of FORMAT fields at %s:%d .. %s, %d vs %d\n", bcf_seqname(flt->hdr,line),line->pos+1,tok->tag,line->n_sample,tok->nsamples);
+        error("Incorrect number of FORMAT fields at %s:%"PRId64" .. %s, %d vs %d\n", bcf_seqname(flt->hdr,line),(int64_t) line->pos+1,tok->tag,line->n_sample,tok->nsamples);
 
     int nvals;
     if ( (nvals=bcf_get_format_int32(flt->hdr,line,tok->tag,&flt->tmpi,&flt->mtmpi))<0 )
@@ -731,7 +732,7 @@ static void filters_set_format_int(filter_t *flt, bcf1_t *line, token_t *tok)
 static void filters_set_format_float(filter_t *flt, bcf1_t *line, token_t *tok)
 {
     if ( line->n_sample != tok->nsamples )
-        error("Incorrect number of FORMAT fields at %s:%d .. %s, %d vs %d\n", bcf_seqname(flt->hdr,line),line->pos+1,tok->tag,line->n_sample,tok->nsamples);
+        error("Incorrect number of FORMAT fields at %s:%"PRId64" .. %s, %d vs %d\n", bcf_seqname(flt->hdr,line),(int64_t) line->pos+1,tok->tag,line->n_sample,tok->nsamples);
 
     int nvals;
     if ( (nvals=bcf_get_format_float(flt->hdr,line,tok->tag,&flt->tmpf,&flt->mtmpf))<0 )
@@ -794,7 +795,7 @@ static void filters_set_format_float(filter_t *flt, bcf1_t *line, token_t *tok)
 static void filters_set_format_string(filter_t *flt, bcf1_t *line, token_t *tok)
 {
     if ( line->n_sample != tok->nsamples )
-        error("Incorrect number of FORMAT fields at %s:%d .. %s, %d vs %d\n", bcf_seqname(flt->hdr,line),line->pos+1,tok->tag,line->n_sample,tok->nsamples);
+        error("Incorrect number of FORMAT fields at %s:%"PRId64" .. %s, %d vs %d\n", bcf_seqname(flt->hdr,line),(int64_t) line->pos+1,tok->tag,line->n_sample,tok->nsamples);
 
     int i, ndim = tok->str_value.m;
     int nstr = bcf_get_format_char(flt->hdr, line, tok->tag, &tok->str_value.s, &ndim);
@@ -914,7 +915,7 @@ static void _filters_set_genotype(filter_t *flt, bcf1_t *line, token_t *tok, int
         case BCF_BT_INT8:  BRANCH_INT(int8_t,  bcf_int8_vector_end); break;
         case BCF_BT_INT16: BRANCH_INT(int16_t, bcf_int16_vector_end); break;
         case BCF_BT_INT32: BRANCH_INT(int32_t, bcf_int32_vector_end); break;
-        default: error("The GT type is not lineognised: %d at %s:%d\n",fmt->type, bcf_seqname(flt->hdr,line),line->pos+1); break;
+        default: error("The GT type is not lineognised: %d at %s:%"PRId64"\n",fmt->type, bcf_seqname(flt->hdr,line),(int64_t) line->pos+1); break;
     }
 #undef BRANCH_INT
     assert( tok->nsamples == nsmpl );
@@ -1434,8 +1435,8 @@ static int func_binom(filter_t *flt, bcf1_t *line, token_t *rtok, token_t **stac
                 }
                 int idx1 = bcf_gt_allele(ptr[0]);
                 int idx2 = bcf_gt_allele(ptr[1]);
-                if ( idx1>=line->n_allele ) error("Incorrect allele index at %s:%d, sample %s\n", bcf_seqname(flt->hdr,line),line->pos+1,flt->hdr->samples[i]);
-                if ( idx2>=line->n_allele ) error("Incorrect allele index at %s:%d, sample %s\n", bcf_seqname(flt->hdr,line),line->pos+1,flt->hdr->samples[i]);
+                if ( idx1>=line->n_allele ) error("Incorrect allele index at %s:%"PRId64", sample %s\n", bcf_seqname(flt->hdr,line),(int64_t) line->pos+1,flt->hdr->samples[i]);
+                if ( idx2>=line->n_allele ) error("Incorrect allele index at %s:%"PRId64", sample %s\n", bcf_seqname(flt->hdr,line),(int64_t) line->pos+1,flt->hdr->samples[i]);
                 double *vals = tok->values + tok->nval1*i;
                 if ( bcf_double_is_missing_or_vector_end(vals[idx1]) || bcf_double_is_missing_or_vector_end(vals[idx2]) )
                 {
@@ -1455,7 +1456,7 @@ static int func_binom(filter_t *flt, bcf1_t *line, token_t *rtok, token_t **stac
             // the fields given explicitly: binom(AD[:0],AD[:1])
             token_t *tok2 = stack[istack+1];
             if ( tok->nval1!=1 || tok2->nval1!=1 )
-                error("Expected one value per binom() argument, found %d and %d at %s:%d\n",tok->nval1,tok2->nval1, bcf_seqname(flt->hdr,line),line->pos+1);
+                error("Expected one value per binom() argument, found %d and %d at %s:%"PRId64"\n",tok->nval1,tok2->nval1, bcf_seqname(flt->hdr,line),(int64_t) line->pos+1);
             for (i=0; i<rtok->nsamples; i++)
             {
                 if ( !rtok->usmpl[i] ) continue;

--- a/mcall.c
+++ b/mcall.c
@@ -23,6 +23,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/kfunc.h>
 #include <htslib/khash_str2int.h>
 #include "call.h"
@@ -1605,7 +1606,7 @@ int mcall(call_t *call, bcf1_t *rec)
     int out_als, nout;
     if ( nals > 8*sizeof(out_als) )
     { 
-        fprintf(stderr,"Too many alleles at %s:%d, skipping.\n", bcf_seqname(call->hdr,rec),rec->pos+1); 
+        fprintf(stderr,"Too many alleles at %s:%"PRId64", skipping.\n", bcf_seqname(call->hdr,rec),(int64_t) rec->pos+1);
         return 0; 
     }
     nout = mcall_find_best_alleles(call, nals, &out_als);
@@ -1649,7 +1650,7 @@ int mcall(call_t *call, bcf1_t *rec)
         {
             if ( nout>4 ) 
             { 
-                fprintf(stderr,"Too many alleles at %s:%d, skipping.\n", bcf_seqname(call->hdr,rec),rec->pos+1); 
+                fprintf(stderr,"Too many alleles at %s:%"PRId64", skipping.\n", bcf_seqname(call->hdr,rec),(int64_t) rec->pos+1);
                 return 0; 
             }
             mcall_call_trio_genotypes(call, rec, nals,nout,out_als);

--- a/mpileup.c
+++ b/mpileup.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <string.h>
 #include <strings.h>
 #include <limits.h>
+#include <inttypes.h>
 #include <errno.h>
 #include <sys/stat.h>
 #include <getopt.h>
@@ -222,8 +223,8 @@ static int mplp_func(void *data, bam1_t *b)
         if (ma->conf->fai && b->core.tid >= 0) {
             has_ref = mplp_get_ref(ma, b->core.tid, &ref, &ref_len);
             if (has_ref && ref_len <= b->core.pos) { // exclude reads outside of the reference sequence
-                fprintf(stderr,"[%s] Skipping because %d is outside of %d [ref:%d]\n",
-                        __func__, b->core.pos, ref_len, b->core.tid);
+                fprintf(stderr,"[%s] Skipping because %"PRId64" is outside of %d [ref:%d]\n",
+                        __func__, (int64_t) b->core.pos, ref_len, b->core.tid);
                 continue;
             }
         } else {

--- a/plugins/GTisec.c
+++ b/plugins/GTisec.c
@@ -320,7 +320,7 @@ bcf1_t *process(bcf1_t *rec)
     int gte_smp = 0; // number GT array entries per sample (should be 2, one entry per allele)
     if ( (gte_smp = bcf_get_genotypes(args.hdr, rec, &(args.gt_arr), &(args.ngt_arr) ) ) <= 0 )
     {
-        error("GT not present at %s: %d\n", args.hdr->id[BCF_DT_CTG][rec->rid].key, rec->pos+1);
+        error("GT not present at %s: %"PRId64"\n", args.hdr->id[BCF_DT_CTG][rec->rid].key, (int64_t) rec->pos+1);
     }
 
     gte_smp /= args.nsmp; // divide total number of genotypes array entries (= args.ngt_arr) by number of samples

--- a/plugins/GTsubset.c
+++ b/plugins/GTsubset.c
@@ -163,7 +163,7 @@ bcf1_t *process(bcf1_t *rec)
     args.ngt_arr = 0;        /*! hold the number of current GT array entries */
     if ( (gte_smp = bcf_get_genotypes(args.hdr, rec, &(args.gt_arr), &(args.ngt_arr) ) ) <= 0 )
     {
-        error("GT not present at %s: %d\n", args.hdr->id[BCF_DT_CTG][rec->rid].key, rec->pos+1);
+        error("GT not present at %s: %"PRId64"\n", args.hdr->id[BCF_DT_CTG][rec->rid].key, (int64_t) rec->pos+1);
     }
 
     gte_smp /= args.nsmp; // divide total number of genotypes array entries (= args.ngt_arr) by number of samples

--- a/plugins/ad-bias.c
+++ b/plugins/ad-bias.c
@@ -274,9 +274,9 @@ bcf1_t *process(bcf1_t *rec)
         kt_fisher_exact(n11,n12,n21,n22, &left,&right,&fisher);
         if ( fisher >= args.th ) continue;
 
-        printf("FT\t%s\t%s\t%s\t%d\t%s\t%s\t%d\t%d\t%d\t%d\t%e",
+        printf("FT\t%s\t%s\t%s\t%"PRId64"\t%s\t%s\t%d\t%d\t%d\t%d\t%e",
             pair->smpl_name,pair->ctrl_name,
-            bcf_hdr_id2name(args.hdr,rec->rid), rec->pos+1,
+            bcf_hdr_id2name(args.hdr,rec->rid), (int64_t) rec->pos+1,
             rec->d.allele[iref],rec->d.allele[ialt],
             n11,n12,n21,n22, fisher
             );

--- a/plugins/af-dist.c
+++ b/plugins/af-dist.c
@@ -170,12 +170,12 @@ bcf1_t *process(bcf1_t *rec)
         if ( dosage==1 )
         {
             args->prob_dist[iRA]++;
-            if ( list_RA ) printf("GT\t%s\t%d\t%s\t1\t%f\n",chr,rec->pos+1,args->hdr->samples[i],pRA);
+            if ( list_RA ) printf("GT\t%s\t%"PRId64"\t%s\t1\t%f\n",chr,(int64_t) rec->pos+1,args->hdr->samples[i],pRA);
         }
         else if ( dosage==2 )
         {
             args->prob_dist[iAA]++;
-            if ( list_AA ) printf("GT\t%s\t%d\t%s\t2\t%f\n",chr,rec->pos+1,args->hdr->samples[i],pAA);
+            if ( list_AA ) printf("GT\t%s\t%"PRId64"\t%s\t2\t%f\n",chr,(int64_t) rec->pos+1,args->hdr->samples[i],pAA);
         }
     }
 

--- a/plugins/check-ploidy.c
+++ b/plugins/check-ploidy.c
@@ -101,7 +101,7 @@ bcf1_t *process(bcf1_t *rec)
     if ( !fmt_gt ) return NULL;    // no GT tag
 
     if ( args->ndat != rec->n_sample ) 
-        error("Incorrect number of samples at %s:%d .. found %d, expected %d\n",bcf_seqname(args->hdr,rec),rec->pos+1,rec->n_sample,args->ndat);
+        error("Incorrect number of samples at %s:%"PRId64" .. found %d, expected %d\n",bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,rec->n_sample,args->ndat);
 
     if ( args->rid!=rec->rid && args->rid!=-1 )
     {
@@ -143,7 +143,7 @@ bcf1_t *process(bcf1_t *rec)
         case BCF_BT_INT8:  BRANCH_INT(int8_t,  bcf_int8_vector_end); break;
         case BCF_BT_INT16: BRANCH_INT(int16_t, bcf_int16_vector_end); break;
         case BCF_BT_INT32: BRANCH_INT(int32_t, bcf_int32_vector_end); break;
-        default: error("The GT type is not recognised: %d at %s:%d\n",fmt_gt->type, bcf_seqname(args->hdr,rec),rec->pos+1); break;
+        default: error("The GT type is not recognised: %d at %s:%"PRId64"\n",fmt_gt->type, bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1); break;
     }
     #undef BRANCH_INT
 

--- a/plugins/contrast.c
+++ b/plugins/contrast.c
@@ -29,6 +29,7 @@
 #include <getopt.h>
 #include <errno.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -301,7 +302,7 @@ static int process_record(args_t *args, bcf1_t *rec)
             {
                 if ( !warned )
                 {
-                    fprintf(stderr,"Too many alleles (>32) at %s:%d, skipping the site.\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+                    fprintf(stderr,"Too many alleles (>32) at %s:%"PRId64", skipping the site.\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
                     warned = 1;
                 }
                 args->nskipped++;
@@ -340,7 +341,7 @@ static int process_record(args_t *args, bcf1_t *rec)
             {
                 if ( !warned )
                 {
-                    fprintf(stderr,"Too many alleles (>32) at %s:%d, skipping. (todo?)\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+                    fprintf(stderr,"Too many alleles (>32) at %s:%"PRId64", skipping. (todo?)\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
                     warned = 1;
                 }
                 args->nskipped++;

--- a/plugins/dosage.c
+++ b/plugins/dosage.c
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <htslib/vcf.h>
 #include <math.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include "bcftools.h"
 
 
@@ -190,7 +191,7 @@ int calc_dosage_GT(bcf1_t *rec)
         {
             if ( ptr[j]==bcf_int32_vector_end || bcf_gt_is_missing(ptr[j]) ) break;
             int idx = bcf_gt_allele(ptr[j]);
-            if ( idx > rec->n_allele ) error("The allele index is out of range at %s:%d\n", bcf_seqname(in_hdr,rec),rec->pos+1);
+            if ( idx > rec->n_allele ) error("The allele index is out of range at %s:%"PRId64"\n", bcf_seqname(in_hdr,rec),(int64_t) rec->pos+1);
             dsg[idx] += 1;
         }
         if ( !j )
@@ -303,7 +304,7 @@ bcf1_t *process(bcf1_t *rec)
 {
     int i,j, ret;
 
-    printf("%s\t%d\t%s", bcf_seqname(in_hdr,rec),rec->pos+1,rec->d.allele[0]);
+    printf("%s\t%"PRId64"\t%s", bcf_seqname(in_hdr,rec),(int64_t) rec->pos+1,rec->d.allele[0]);
     if ( rec->n_allele == 1 ) printf("\t.");
     else for (i=1; i<rec->n_allele; i++) printf("%c%s", i==1?'\t':',', rec->d.allele[i]);
     if ( rec->n_allele==1 )

--- a/plugins/fill-from-fasta.c
+++ b/plugins/fill-from-fasta.c
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <strings.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <htslib/vcf.h>
 #include <htslib/faidx.h>
 #include <htslib/kseq.h>
@@ -182,7 +183,7 @@ bcf1_t *process(bcf1_t *rec)
     // could be sped up here by fetching the whole chromosome? could assume
     // sorted, but revert to this when non-sorted records found?
     char *fa = faidx_fetch_seq(faidx, bcf_seqname(in_hdr,rec), rec->pos, rec->pos+ref_len-1, &fa_len);
-    if ( !fa ) error("faidx_fetch_seq failed at %s:%d\n", bcf_hdr_id2name(in_hdr,rec->rid), rec->pos+1);
+    if ( !fa ) error("faidx_fetch_seq failed at %s:%"PRId64"\n", bcf_hdr_id2name(in_hdr,rec->rid),(int64_t) rec->pos+1);
     for (i=0; i<fa_len; i++)
         if ( (int)fa[i]>96 ) fa[i] -= 32;
 

--- a/plugins/fill-tags.c
+++ b/plugins/fill-tags.c
@@ -29,6 +29,7 @@
 #include <strings.h>
 #include <getopt.h>
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/kseq.h>
 #include <htslib/vcf.h>
@@ -446,7 +447,7 @@ bcf1_t *process(bcf1_t *rec)
                 nals++; \
                 \
                 if ( idx >= rec->n_allele ) \
-                    error("Incorrect allele (\"%d\") in %s at %s:%d\n",idx,args->in_hdr->samples[i],bcf_seqname(args->in_hdr,rec),rec->pos+1); \
+                    error("Incorrect allele (\"%d\") in %s at %s:%"PRId64"\n",idx,args->in_hdr->samples[i],bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1); \
                 if ( !kbs_exists(args->bset, idx) ) nbits++; \
                 kbs_insert(args->bset, idx); \
             } \
@@ -467,7 +468,7 @@ bcf1_t *process(bcf1_t *rec)
         case BCF_BT_INT8:  BRANCH_INT(int8_t,  bcf_int8_vector_end); break;
         case BCF_BT_INT16: BRANCH_INT(int16_t, bcf_int16_vector_end); break;
         case BCF_BT_INT32: BRANCH_INT(int32_t, bcf_int32_vector_end); break;
-        default: error("The GT type is not recognised: %d at %s:%d\n",fmt_gt->type, bcf_seqname(args->in_hdr,rec),rec->pos+1); break;
+        default: error("The GT type is not recognised: %d at %s:%"PRId64"\n",fmt_gt->type, bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1); break;
     }
     #undef BRANCH_INT
 
@@ -478,7 +479,7 @@ bcf1_t *process(bcf1_t *rec)
             args->str.l = 0;
             ksprintf(&args->str, "NS%s", args->pop[i].suffix);
             if ( bcf_update_info_int32(args->out_hdr,rec,args->str.s,&args->pop[i].ns,1)!=0 )
-                error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( args->tags & SET_AN )
@@ -493,7 +494,7 @@ bcf1_t *process(bcf1_t *rec)
             args->str.l = 0;
             ksprintf(&args->str, "AN%s", args->pop[i].suffix);
             if ( bcf_update_info_int32(args->out_hdr,rec,args->str.s,&an,1)!=0 )
-                error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( args->tags & (SET_AF | SET_MAF) )
@@ -519,7 +520,7 @@ bcf1_t *process(bcf1_t *rec)
                 args->str.l = 0;
                 ksprintf(&args->str, "AF%s", args->pop[i].suffix);
                 if ( bcf_update_info_float(args->out_hdr,rec,args->str.s,args->farr,rec->n_allele-1)!=0 )
-                    error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                    error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
             }
             if ( args->tags & SET_MAF )
             {
@@ -531,7 +532,7 @@ bcf1_t *process(bcf1_t *rec)
                 args->str.l = 0;
                 ksprintf(&args->str, "MAF%s", args->pop[i].suffix);
                 if ( bcf_update_info_float(args->out_hdr,rec,args->str.s,args->farr,rec->n_allele-1)!=0 )
-                    error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                    error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
             }
         }
     }
@@ -549,7 +550,7 @@ bcf1_t *process(bcf1_t *rec)
             args->str.l = 0;
             ksprintf(&args->str, "AC%s", args->pop[i].suffix);
             if ( bcf_update_info_int32(args->out_hdr,rec,args->str.s,args->iarr,rec->n_allele-1)!=0 )
-                error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( args->tags & SET_AC_Het )
@@ -566,7 +567,7 @@ bcf1_t *process(bcf1_t *rec)
             args->str.l = 0;
             ksprintf(&args->str, "AC_Het%s", args->pop[i].suffix);
             if ( bcf_update_info_int32(args->out_hdr,rec,args->str.s,args->iarr,rec->n_allele-1)!=0 )
-                error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( args->tags & SET_AC_Hom )
@@ -583,7 +584,7 @@ bcf1_t *process(bcf1_t *rec)
             args->str.l = 0;
             ksprintf(&args->str, "AC_Hom%s", args->pop[i].suffix);
             if ( bcf_update_info_int32(args->out_hdr,rec,args->str.s,args->iarr,rec->n_allele-1)!=0 )
-                error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( args->tags & SET_AC_Hemi && rec->n_allele > 1 )
@@ -600,7 +601,7 @@ bcf1_t *process(bcf1_t *rec)
             args->str.l = 0;
             ksprintf(&args->str, "AC_Hemi%s", args->pop[i].suffix);
             if ( bcf_update_info_int32(args->out_hdr,rec,args->str.s,args->iarr,rec->n_allele-1)!=0 )
-                error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
         }
     }
     if ( args->tags & (SET_HWE|SET_ExcHet) )
@@ -631,14 +632,14 @@ bcf1_t *process(bcf1_t *rec)
                 args->str.l = 0;
                 ksprintf(&args->str, "HWE%s", args->pop[i].suffix);
                 if ( bcf_update_info_float(args->out_hdr,rec,args->str.s,fhwe,rec->n_allele-1)!=0 )
-                    error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                    error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
             }
             if ( args->tags & SET_ExcHet )
             {
                 args->str.l = 0;
                 ksprintf(&args->str, "ExcHet%s", args->pop[i].suffix);
                 if ( bcf_update_info_float(args->out_hdr,rec,args->str.s,fexc_het,rec->n_allele-1)!=0 )
-                    error("Error occurred while updating %s at %s:%d\n", args->str.s,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                    error("Error occurred while updating %s at %s:%"PRId64"\n", args->str.s,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
             }
         }
     }

--- a/plugins/fixploidy.c
+++ b/plugins/fixploidy.c
@@ -190,7 +190,7 @@ bcf1_t *process(bcf1_t *rec)
         return rec;     // GT field not present
 
     if ( ngts % n_sample )
-        error("Error at %s:%d: wrong number of GT fields\n",bcf_seqname(in_hdr,rec),rec->pos+1);
+        error("Error at %s:%"PRId64": wrong number of GT fields\n",bcf_seqname(in_hdr,rec),(int64_t) rec->pos+1);
 
     if ( force_ploidy==-1 )
         ploidy_query(ploidy, (char*)bcf_seqname(in_hdr,rec), rec->pos, sex2ploidy,NULL,&max_ploidy);
@@ -215,7 +215,7 @@ bcf1_t *process(bcf1_t *rec)
             while ( j<max_ploidy ) { dst[j] = bcf_int32_vector_end; j++; }
         }
         if ( bcf_update_genotypes(out_hdr,rec,gt_arr2,n_sample*max_ploidy) )
-            error("Could not update GT field at %s:%d\n", bcf_seqname(in_hdr,rec),rec->pos+1);
+            error("Could not update GT field at %s:%"PRId64"\n", bcf_seqname(in_hdr,rec),(int64_t) rec->pos+1);
     }
     else if ( ngts!=1 || max_ploidy!=1 )
     {
@@ -232,7 +232,7 @@ bcf1_t *process(bcf1_t *rec)
             while ( j<ngts ) { gts[j] = bcf_int32_vector_end; j++; }
         }
         if ( bcf_update_genotypes(out_hdr,rec,gt_arr,n_sample*ngts) )
-            error("Could not update GT field at %s:%d\n", bcf_seqname(in_hdr,rec),rec->pos+1);
+            error("Could not update GT field at %s:%"PRId64"\n", bcf_seqname(in_hdr,rec),(int64_t) rec->pos+1);
     }
     return rec;
 }

--- a/plugins/fixref.c
+++ b/plugins/fixref.c
@@ -76,6 +76,7 @@
 #include <strings.h>
 #include <getopt.h>
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -281,7 +282,7 @@ static int fetch_ref(args_t *args, bcf1_t *rec)
             args->skip_rid = rec->rid;
             return -2;
         }
-        error("faidx_fetch_seq failed at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+        error("faidx_fetch_seq failed at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     }
     int ir = nt2int(*ref);
     free(ref);
@@ -336,7 +337,7 @@ static bcf1_t *dbsnp_check(args_t *args, bcf1_t *rec, int ir, int ia, int ib)
 
     ref = kh_val(args->i2m, k).ref;
 	if ( ref!=ir ) 
-        error("Reference base mismatch at %s:%d .. %c vs %c\n",bcf_seqname(args->hdr,rec),rec->pos+1,int2nt(ref),int2nt(ir));
+        error("Reference base mismatch at %s:%"PRId64" .. %c vs %c\n",bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,int2nt(ref),int2nt(ir));
 
     if ( ia==ref ) return rec;
     if ( ib==ref ) { args->nswap++; return set_ref_alt(args,rec,int2nt(ib),int2nt(ia),1); }
@@ -414,9 +415,9 @@ bcf1_t *process(bcf1_t *rec)
         if ( !args.unsorted && args.pos > rec->pos )
         {
             fprintf(stderr,
-                "Warning: corrected position(s) results in unsorted VCF, for example %s:%d comes after %s:%d\n"
+                "Warning: corrected position(s) results in unsorted VCF, for example %s:%"PRId64" comes after %s:%d\n"
                 "         The standard unix `sort` or `vcf-sort` from vcftools can be used to fix the order.\n",
-                bcf_seqname(args.hdr,rec),rec->pos+1,bcf_seqname(args.hdr,rec),args.pos);
+                bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1,bcf_seqname(args.hdr,rec),args.pos);
             args.unsorted = 1;
         }
         args.pos = rec->pos;
@@ -428,7 +429,7 @@ bcf1_t *process(bcf1_t *rec)
         if ( ir==ib ) { args.nswap++; return set_ref_alt(&args,rec,int2nt(ib),int2nt(ia),0); }
         if ( ir==revint(ia) ) { args.nflip++; return set_ref_alt(&args,rec,int2nt(revint(ia)),int2nt(revint(ib)),0); }
         if ( ir==revint(ib) ) { args.nflip_swap++; return set_ref_alt(&args,rec,int2nt(revint(ib)),int2nt(revint(ia)),0); }
-        error("FIXME: this should not happen %s:%d\n", bcf_seqname(args.hdr,rec),rec->pos+1);
+        error("FIXME: this should not happen %s:%"PRId64"\n", bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1);
     }
     else if ( args.mode==MODE_FLIP2FWD )
     {
@@ -442,7 +443,7 @@ bcf1_t *process(bcf1_t *rec)
         if ( ir==ib ) { args.nswap++; return set_ref_alt(&args,rec,int2nt(ib),int2nt(ia),1); }
         if ( ir==revint(ia) ) { args.nflip++; return set_ref_alt(&args,rec,int2nt(revint(ia)),int2nt(revint(ib)),0); }
         if ( ir==revint(ib) ) { args.nflip_swap++; return set_ref_alt(&args,rec,int2nt(revint(ib)),int2nt(revint(ia)),1); }
-        error("FIXME: this should not happen %s:%d\n", bcf_seqname(args.hdr,rec),rec->pos+1);
+        error("FIXME: this should not happen %s:%"PRId64"\n", bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1);
     }
     else if ( args.mode==MODE_TOP2FWD )
     {
@@ -471,8 +472,8 @@ bcf1_t *process(bcf1_t *rec)
         {
             int len, win = rec->pos > 100 ? 100 : rec->pos, beg = rec->pos - win, end = rec->pos + win;
             char *ref = faidx_fetch_seq(args.fai, (char*)bcf_seqname(args.hdr,rec), beg,end, &len);
-            if ( !ref ) error("faidx_fetch_seq failed at %s:%d\n", bcf_seqname(args.hdr,rec),rec->pos+1);
-            if ( end - beg + 1 != len ) error("FIXME: check win=%d,len=%d at %s:%d  (%d %d)\n", win,len, bcf_seqname(args.hdr,rec),rec->pos+1, end,beg);
+            if ( !ref ) error("faidx_fetch_seq failed at %s:%"PRId64"\n", bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1);
+            if ( end - beg + 1 != len ) error("FIXME: check win=%d,len=%d at %s:%"PRId64"  (%d %d)\n", win,len, bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1, end,beg);
 
             int i, mid = rec->pos - beg, strand = 0;
             for (i=1; i<=win; i++)

--- a/plugins/guess-ploidy.c
+++ b/plugins/guess-ploidy.c
@@ -387,7 +387,7 @@ void process_region_guess(args_t *args)
             counts->pdip += log(pdip);
             counts->ncount++;
             if ( args->verbose>1 )
-                printf("DBG\t%s\t%d\t%s\t%e\t%e\t%e\t%e\t%e\t%e\n", bcf_seqname(args->hdr,rec),rec->pos+1,bcf_hdr_int2id(args->hdr,BCF_DT_SAMPLE,ismpl),
+                printf("DBG\t%s\t%"PRId64"\t%s\t%e\t%e\t%e\t%e\t%e\t%e\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,bcf_hdr_int2id(args->hdr,BCF_DT_SAMPLE,ismpl),
                     freq[1],tmp[0],tmp[1],tmp[2],phap,pdip);
         }
     }

--- a/plugins/gvcfz.c
+++ b/plugins/gvcfz.c
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <sys/stat.h>
 #include <htslib/vcf.h>
 #include <htslib/vcfutils.h>
@@ -189,18 +190,18 @@ static void flush_block(args_t *args, bcf1_t *rec)
     if ( rec && gvcf->end - 1 >= rec->pos ) gvcf->end = rec->pos; // NB: end is 1-based, rec->pos is 0-based
 
     if ( gvcf->rec->pos+1 < gvcf->end && bcf_update_info_int32(args->hdr_out,gvcf->rec,"END",&gvcf->end,1) != 0 )
-        error("Could not update INFO/END at %s:%d\n", bcf_seqname(args->hdr_out,gvcf->rec),gvcf->rec->pos+1);
+        error("Could not update INFO/END at %s:%"PRId64"\n", bcf_seqname(args->hdr_out,gvcf->rec),(int64_t) gvcf->rec->pos+1);
     if ( bcf_update_format_int32(args->hdr_out,gvcf->rec,"DP",&gvcf->min_dp,1) != 0 )
-        error("Could not update FORMAT/DP at %s:%d\n", bcf_seqname(args->hdr_out,gvcf->rec),gvcf->rec->pos+1);
+        error("Could not update FORMAT/DP at %s:%"PRId64"\n", bcf_seqname(args->hdr_out,gvcf->rec),(int64_t) gvcf->rec->pos+1);
     if ( gvcf->gq_key )
     {
         if ( bcf_update_format_int32(args->hdr_out,gvcf->rec,gvcf->gq_key,&gvcf->gq,1) != 0 )
-            error("Could not update FORMAT/%s at %s:%d\n", gvcf->gq_key, bcf_seqname(args->hdr_out,gvcf->rec),gvcf->rec->pos+1);
+            error("Could not update FORMAT/%s at %s:%"PRId64"\n", gvcf->gq_key, bcf_seqname(args->hdr_out,gvcf->rec),(int64_t) gvcf->rec->pos+1);
     }
     if ( gvcf->pl[0] >=0 )
     {
         if ( bcf_update_format_int32(args->hdr_out,gvcf->rec,"PL",&gvcf->pl,3) != 0 )
-            error("Could not update FORMAT/PL at %s:%d\n", bcf_seqname(args->hdr_out,gvcf->rec),gvcf->rec->pos+1);
+            error("Could not update FORMAT/PL at %s:%"PRId64"\n", bcf_seqname(args->hdr_out,gvcf->rec),(int64_t) gvcf->rec->pos+1);
     }
     if ( gvcf->grp < args->ngrp && args->grp[gvcf->grp].flt_id >= 0 ) 
         bcf_add_filter(args->hdr_out, gvcf->rec, args->grp[gvcf->grp].flt_id);
@@ -226,7 +227,7 @@ static void process_gvcf(args_t *args)
         {
             bcf_unpack(rec, BCF_UN_ALL);
             if ( bcf_trim_alleles(args->hdr_in, rec)<0 )
-                error("Error: Could not trim alleles at %s:%d\n", bcf_seqname(args->hdr_in, rec), rec->pos+1);
+                error("Error: Could not trim alleles at %s:%"PRId64"\n", bcf_seqname(args->hdr_in, rec),(int64_t)  rec->pos+1);
 
             // trim the ref allele if necessary
             if ( rec->d.allele[0][1] )
@@ -264,11 +265,11 @@ static void process_gvcf(args_t *args)
     else if ( bcf_get_format_int32(args->hdr_in,rec,"DP",&args->tmpi,&args->mtmpi)==1 )
         min_dp = args->tmpi[0];
     else
-        error("Expected one FORMAT/MIN_DP or FORMAT/DP value at %s:%d\n", bcf_seqname(args->hdr_in,rec),rec->pos+1);
+        error("Expected one FORMAT/MIN_DP or FORMAT/DP value at %s:%"PRId64"\n", bcf_seqname(args->hdr_in,rec),(int64_t) rec->pos+1);
 
     int32_t pl[3] = {-1,-1,-1};
     ret = bcf_get_format_int32(args->hdr_in,rec,"PL",&args->tmpi,&args->mtmpi);
-    if ( ret>3 ) error("Expected three FORMAT/PL values at %s:%d\n", bcf_seqname(args->hdr_in,rec),rec->pos+1);
+    if ( ret>3 ) error("Expected three FORMAT/PL values at %s:%"PRId64"\n", bcf_seqname(args->hdr_in,rec),(int64_t) rec->pos+1);
     else if ( ret==3 )
     {
         pl[0] = args->tmpi[0];

--- a/plugins/indel-stats.c
+++ b/plugins/indel-stats.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -437,7 +438,7 @@ static inline int parse_genotype(int32_t *arr, int ngt1, int idx, int als[2])
 static inline void update_indel_stats(args_t *args, bcf1_t *rec, stats_t *stats, int ismpl, int *als)
 {
     int j;
-    if ( als[0] >= args->nad1 || als[1] >= args->nad1 ) error("Incorrect GT allele at %s:%d .. %d/%d\n", bcf_seqname(args->hdr,rec),rec->pos+1,als[0],als[1]);
+    if ( als[0] >= args->nad1 || als[1] >= args->nad1 ) error("Incorrect GT allele at %s:%"PRId64" .. %d/%d\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,als[0],als[1]);
     int32_t *ad_ptr = args->ad_arr + ismpl*args->nad1;
 
     // find the allele with most support
@@ -455,7 +456,7 @@ static inline void update_indel_stats(args_t *args, bcf1_t *rec, stats_t *stats,
     int al0 = als[0], al1 = als[1];
     if ( !(bcf_get_variant_type(rec,al0) & VCF_INDEL) )
     {
-        if ( !(bcf_get_variant_type(rec,al1) & VCF_INDEL) ) error("FIXME: this should not happen .. %s:%d .. %d/%d\n", bcf_seqname(args->hdr,rec),rec->pos+1,al0,al1);
+        if ( !(bcf_get_variant_type(rec,al1) & VCF_INDEL) ) error("FIXME: this should not happen .. %s:%"PRId64" .. %d/%d\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,al0,al1);
         al0 = als[1]; al1 = als[0];
     }
     else if ( (bcf_get_variant_type(rec,al1) & VCF_INDEL) && al0!=al1 )
@@ -578,7 +579,7 @@ static void process_record(args_t *args, bcf1_t *rec, flt_stats_t *flt)
             // Get the AD counts
             args->nad = bcf_get_format_int32(args->hdr, rec, "AD", &args->ad_arr, &args->mad_arr);
             args->nad1 = args->nad / rec->n_sample;
-            if ( args->nad>0 && args->nad1 != rec->n_allele ) error("Incorrect number of FORMAT/AD values at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            if ( args->nad>0 && args->nad1 != rec->n_allele ) error("Incorrect number of FORMAT/AD values at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         }
     }
 

--- a/plugins/mendelian.c
+++ b/plugins/mendelian.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/synced_bcf_reader.h>
@@ -460,7 +461,7 @@ static void warn_ploidy(bcf1_t *rec)
 {
     static int warned = 0;
     if ( warned ) return;
-    fprintf(stderr,"Incorrect ploidy at %s:%d, skipping the trio. (This warning is printed only once.)\n", bcf_seqname(args.hdr,rec),rec->pos+1);
+    fprintf(stderr,"Incorrect ploidy at %s:%"PRId64", skipping the trio. (This warning is printed only once.)\n", bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1);
     warned = 1;
 }
 
@@ -565,7 +566,7 @@ bcf1_t *process(bcf1_t *rec)
     }
 
     if ( needs_update && bcf_update_genotypes(args.hdr,rec,args.gt_arr,ngt*bcf_hdr_nsamples(args.hdr)) )
-        error("Could not update GT field at %s:%d\n", bcf_seqname(args.hdr,rec),rec->pos+1);
+        error("Could not update GT field at %s:%"PRId64"\n", bcf_seqname(args.hdr,rec),(int64_t) rec->pos+1);
 
     if ( args.mode&MODE_DELETE ) return rec;
     if ( args.mode&MODE_LIST_GOOD ) return has_bad ? NULL : rec;

--- a/plugins/missing2ref.c
+++ b/plugins/missing2ref.c
@@ -109,7 +109,7 @@ bcf1_t *process(bcf1_t *rec)
             }
         }
         else{
-            fprintf(stderr,"Warning: Could not calculate allele count at position %d\n", rec->pos);
+            fprintf(stderr,"Warning: Could not calculate allele count at position %"PRId64"\n", (int64_t) rec->pos);
             exit(1);
         }
 

--- a/plugins/parental-origin.c
+++ b/plugins/parental-origin.c
@@ -29,6 +29,7 @@
 #include <getopt.h>
 #include <math.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -197,24 +198,24 @@ static void process_record(args_t *args, bcf1_t *rec)
     int nret = bcf_get_format_int32(args->hdr,rec,"AD",&args->ad,&args->mad);
     if ( nret<=0 )
     {
-        printf("The FORMAT/AD tag not present at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+        printf("The FORMAT/AD tag not present at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         return;
     }
     int nad1 = nret/nsmpl;
 
     nret = bcf_get_format_int32(args->hdr,rec,"PL",&args->pl,&args->mpl);
-    if ( nret<=0 ) error("The FORMAT/PL tag not present at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+    if ( nret<=0 ) error("The FORMAT/PL tag not present at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     int npl1 = nret/nsmpl;
     if ( npl1!=rec->n_allele*(rec->n_allele+1)/2 )
     {
-        printf("todo: not a diploid site at %s:%d: %d alleles, %d PLs\n", bcf_seqname(args->hdr,rec),rec->pos+1,rec->n_allele,npl1);
+        printf("todo: not a diploid site at %s:%"PRId64": %d alleles, %d PLs\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,rec->n_allele,npl1);
         return;
     }
 
     nret = bcf_get_genotypes(args->hdr,rec,&args->gt,&args->mgt);
-    if ( nret<=0 ) error("The FORMAT/GT tag not present at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+    if ( nret<=0 ) error("The FORMAT/GT tag not present at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     int ngt1 = nret/nsmpl;
-    if ( ngt1!=2 ) error("Todo: assuming diploid fields for now .. %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+    if ( ngt1!=2 ) error("Todo: assuming diploid fields for now .. %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
 
     // number of ref and alt alleles in the proband
     int32_t ad[6], *adP = ad, *adF = ad+2, *adM = ad+4;
@@ -276,7 +277,7 @@ static void process_record(args_t *args, bcf1_t *rec)
         if ( args->debug )
         {
             // output: position, paternal probability, maternal probability, PLs of child, father, mother
-            printf("DBG\t%d\t%e\t%e\t", rec->pos+1,ppat,pmat);
+            printf("DBG\t%"PRId64"\t%e\t%e\t", (int64_t) rec->pos+1,ppat,pmat);
             for (i=0; i<3; i++)
             {
                 for (j=0; j<3; j++)  printf(" %d",args->pl[npl1*args->trio.idx[i]+j]);
@@ -312,7 +313,7 @@ static void process_record(args_t *args, bcf1_t *rec)
         if ( args->debug )
         {
             // output: position; paternal probability; maternal probability; ADs of child, father,mother; PLs of child, father, mother
-            printf("DBG\t%d\t%e\t%e\t", rec->pos+1,ppat,pmat);
+            printf("DBG\t%"PRId64"\t%e\t%e\t", (int64_t) rec->pos+1,ppat,pmat);
             for (i=0; i<3; i++)
             {
                 printf("%d %d\t",ad[2*i],ad[2*i+1]);

--- a/plugins/remove-overlaps.c
+++ b/plugins/remove-overlaps.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <stdint.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <htslib/vcf.h>
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/vcfutils.h>
@@ -125,7 +126,7 @@ static void flush(args_t *args, int flush_all)
         if ( nbuf>2 || (nbuf>1 && flush_all) )
         {
             args->nrm++;
-            if ( args->verbose ) printf("%s\t%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            if ( args->verbose ) printf("%s\t%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
             if ( args->print_overlaps && bcf_write1(args->out_fh, args->hdr, rec)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
             continue;     // skip overlapping variants
         }

--- a/plugins/setGT.c
+++ b/plugins/setGT.c
@@ -320,7 +320,7 @@ bcf1_t *process(bcf1_t *rec)
         hts_expand(int,rec->n_allele,args->marr,args->arr);
         int ret = bcf_calc_ac(args->in_hdr,rec,args->arr,BCF_UN_FMT);
         if ( ret<= 0 )
-            error("Could not calculate allele count at %s:%d\n", bcf_seqname(args->in_hdr,rec),rec->pos+1);
+            error("Could not calculate allele count at %s:%"PRId64"\n", bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
 
         for(i=0; i < rec->n_allele; ++i)
         {
@@ -353,8 +353,8 @@ bcf1_t *process(bcf1_t *rec)
             int ia = bcf_gt_allele(ptr[0]); 
             int ib = bcf_gt_allele(ptr[1]); 
             if ( ia>=nbinom || ib>=nbinom ) 
-                error("The sample %s has incorrect number of %s fields at %s:%d\n",
-                        args->in_hdr->samples[i],args->binom_tag,bcf_seqname(args->in_hdr,rec),rec->pos+1);
+                error("The sample %s has incorrect number of %s fields at %s:%"PRId64"\n",
+                        args->in_hdr->samples[i],args->binom_tag,bcf_seqname(args->in_hdr,rec),(int64_t) rec->pos+1);
 
             double prob = calc_binom(args->iarr[i*nbinom+ia],args->iarr[i*nbinom+ib]);
             if ( !args->binom_cmp(prob,args->binom_val) ) continue;

--- a/plugins/smpl-stats.c
+++ b/plugins/smpl-stats.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -390,7 +391,7 @@ static void process_record(args_t *args, bcf1_t *rec, flt_stats_t *flt)
             {
                 if ( als[j]==0 || als[j]==star_allele ) continue;
                 if ( als[j] >= rec->n_allele )
-                    error("The GT index is out of range at %s:%d in %s\n", bcf_seqname(args->hdr,rec),rec->pos+1,args->hdr->samples[j]);
+                    error("The GT index is out of range at %s:%"PRId64" in %s\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,args->hdr->samples[j]);
 
                 if ( args->ac[als[j]]==1 ) { stats->nsingleton++; site_singleton = 1; }
 

--- a/plugins/split-vep.c
+++ b/plugins/split-vep.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/bgzf.h>
@@ -569,7 +570,7 @@ static int get_primary_transcript(args_t *args, bcf1_t *rec, cols_t *cols_tr)   
     {
         args->cols_csq = cols_split(cols_tr->off[i], args->cols_csq, '|');
         if ( args->primary_id >= args->cols_csq->n )
-            error("Too few columns at %s:%d .. %d (Consequence) >= %d\n", bcf_seqname(args->hdr,rec),rec->pos+1,args->primary_id,args->cols_csq->n);
+            error("Too few columns at %s:%"PRId64" .. %d (Consequence) >= %d\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,args->primary_id,args->cols_csq->n);
         if ( !strcmp("YES",args->cols_csq->off[args->primary_id]) ) return i;
     }
     return -1;
@@ -581,7 +582,7 @@ static int get_worst_transcript(args_t *args, bcf1_t *rec, cols_t *cols_tr)     
     {
         args->cols_csq = cols_split(cols_tr->off[i], args->cols_csq, '|');
         if ( args->csq_idx >= args->cols_csq->n )
-            error("Too few columns at %s:%d .. %d (Consequence) >= %d\n", bcf_seqname(args->hdr,rec),rec->pos+1,args->csq_idx,args->cols_csq->n);
+            error("Too few columns at %s:%"PRId64" .. %d (Consequence) >= %d\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,args->csq_idx,args->cols_csq->n);
         char *csq = args->cols_csq->off[args->csq_idx];
 
         int min, max;
@@ -660,7 +661,7 @@ static void process_record(args_t *args, bcf1_t *rec)
     {
         args->cols_csq = cols_split(args->cols_tr->off[i], args->cols_csq, '|');
         if ( args->csq_idx >= args->cols_csq->n )
-            error("Too few columns at %s:%d .. %d (Consequence) >= %d\n", bcf_seqname(args->hdr,rec),rec->pos+1,args->csq_idx,args->cols_csq->n);
+            error("Too few columns at %s:%"PRId64" .. %d (Consequence) >= %d\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,args->csq_idx,args->cols_csq->n);
 
         char *csq = args->cols_csq->off[args->csq_idx];
         if ( !csq_severity_pass(args, csq) ) continue;
@@ -673,7 +674,7 @@ static void process_record(args_t *args, bcf1_t *rec)
             {
                 if ( !too_few_fields_warned )
                 {
-                    fprintf(stderr, "Warning: fewer %s fields than expected at %s:%d, filling with dots. This warning is printed only once.\n", args->vep_tag,bcf_seqname(args->hdr,rec),rec->pos+1);
+                    fprintf(stderr, "Warning: fewer %s fields than expected at %s:%"PRId64", filling with dots. This warning is printed only once.\n", args->vep_tag,bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
                     too_few_fields_warned = 1;
                 }
                 annot_append(ann, ".");

--- a/plugins/tag2tag.c
+++ b/plugins/tag2tag.c
@@ -26,6 +26,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdlib.h>
 #include <getopt.h>
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include "bcftools.h"
@@ -217,8 +218,8 @@ bcf1_t *process(bcf1_t *rec)
             }
 
             if ( j!=nals*(nals+1)/2 )
-                error("Wrong number of GP values for diploid genotype at %s:%d, expected %d, found %d\n",
-                    bcf_seqname(in_hdr,rec),rec->pos+1, nals*(nals+1)/2,j);
+                error("Wrong number of GP values for diploid genotype at %s:%"PRId64", expected %d, found %d\n",
+                    bcf_seqname(in_hdr,rec),(int64_t) rec->pos+1, nals*(nals+1)/2,j);
 
             if (ptr[jmax] < 1-thresh)
             {

--- a/plugins/trio-dnm.c
+++ b/plugins/trio-dnm.c
@@ -29,6 +29,7 @@
 #include <getopt.h>
 #include <math.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -298,13 +299,13 @@ static void process_record(args_t *args, bcf1_t *rec)
         nret = bcf_get_format_int32(args->hdr,rec,"AD",&args->ad,&args->mad);
         if ( nret<=0 ) has_fmt_ad = 0;
         else if ( nret != nsmpl * rec->n_allele )
-            error("Incorrect number of fields for FORMAT/AD at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            error("Incorrect number of fields for FORMAT/AD at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     }
     nret = bcf_get_format_int32(args->hdr,rec,"PL",&args->pl,&args->mpl);
-    if ( nret<=0 ) error("The FORMAT/PL tag not present at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+    if ( nret<=0 ) error("The FORMAT/PL tag not present at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     int npl1  = nret/nsmpl;
     if ( npl1!=rec->n_allele*(rec->n_allele+1)/2 )
-        error("fixme: not a diploid site at %s:%d: %d alleles, %d PLs\n", bcf_seqname(args->hdr,rec),rec->pos+1,rec->n_allele,npl1);
+        error("fixme: not a diploid site at %s:%"PRId64": %d alleles, %d PLs\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,rec->n_allele,npl1);
     hts_expand(double,3*npl1,args->mpl3,args->pl3);
     int i, j, k, al0, al1, write_dnm = 0;
     for (i=0; i<nsmpl; i++) args->dnm_qual[i] = bcf_int32_missing;
@@ -338,9 +339,9 @@ static void process_record(args_t *args, bcf1_t *rec)
     if ( write_dnm )
     {
         if ( bcf_update_format_int32(args->hdr_out,rec,"DNM",args->dnm_qual,nsmpl)!=0 )
-            error("Failed to write FORMAT/DNM at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            error("Failed to write FORMAT/DNM at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
         if ( has_fmt_ad && bcf_update_format_int32(args->hdr_out,rec,"VAF",args->vaf,nsmpl)!=0 )
-            error("Failed to write FORMAT/VAF at %s:%d\n", bcf_seqname(args->hdr,rec),rec->pos+1);
+            error("Failed to write FORMAT/VAF at %s:%"PRId64"\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1);
     }
     if ( bcf_write(args->out_fh, args->hdr_out, rec)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
 }

--- a/plugins/trio-stats.c
+++ b/plugins/trio-stats.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>     // for isatty
+#include <inttypes.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
@@ -554,7 +555,7 @@ static void process_record(args_t *args, bcf1_t *rec, flt_stats_t *flt)
             {
                 if ( als[j]==0 || als[j]==star_allele ) continue;
                 if ( als[j] >= rec->n_allele )
-                    error("The GT index is out of range at %s:%d in %s\n", bcf_seqname(args->hdr,rec),rec->pos+1,args->hdr->samples[args->trio[i].idx[j/2]]);
+                    error("The GT index is out of range at %s:%"PRId64" in %s\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,args->hdr->samples[args->trio[i].idx[j/2]]);
                 if ( rec->d.allele[als[j]][1] ) continue;
 
                 int alt = bcf_acgt2int(rec->d.allele[als[j]][0]);
@@ -593,7 +594,7 @@ static void process_record(args_t *args, bcf1_t *rec, flt_stats_t *flt)
                 if ( (!dnm_hom && args->ac[culprit]>1) || (dnm_hom && args->ac[culprit]>2) ) { stats->ndnm_recurrent++; dnm_recurrent = 1; }
 
                 if ( args->verbose & VERBOSE_MENDEL )
-                    fprintf(args->fp_out,"MERR\t%s\t%d\t%s\t%s\t%s\t%s\t%s\n", bcf_seqname(args->hdr,rec),rec->pos+1,
+                    fprintf(args->fp_out,"MERR\t%s\t%"PRId64"\t%s\t%s\t%s\t%s\t%s\n", bcf_seqname(args->hdr,rec),(int64_t) rec->pos+1,
                             args->hdr->samples[args->trio[i].idx[iCHILD]],
                             args->hdr->samples[args->trio[i].idx[iFATHER]],
                             args->hdr->samples[args->trio[i].idx[iMOTHER]],

--- a/vcfcnv.c
+++ b/vcfcnv.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/vcf.h>
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/kstring.h>
@@ -1190,10 +1191,10 @@ static void cnv_next_line(args_t *args, bcf1_t *line)
         args->control_sample.lrr[args->nsites-1] = lrr2;
         args->control_sample.baf[args->nsites-1] = baf2;
         if ( baf2>=0 )  // skip missing values
-            fprintf(args->control_sample.dat_fh,"%s\t%d\t%.3f\t%.3f\n",bcf_hdr_id2name(args->hdr,args->prev_rid), line->pos+1,baf2,lrr2);
+            fprintf(args->control_sample.dat_fh,"%s\t%"PRId64"\t%.3f\t%.3f\n",bcf_hdr_id2name(args->hdr,args->prev_rid), (int64_t) line->pos+1,baf2,lrr2);
     }
     if ( baf1>=0 )  // skip missing values
-        fprintf(args->query_sample.dat_fh,"%s\t%d\t%.3f\t%.3f\n",bcf_hdr_id2name(args->hdr,args->prev_rid), line->pos+1,baf1,lrr1);
+        fprintf(args->query_sample.dat_fh,"%s\t%"PRId64"\t%.3f\t%.3f\n",bcf_hdr_id2name(args->hdr,args->prev_rid), (int64_t) line->pos+1,baf1,lrr1);
 
     if ( baf1>=0 )
     {

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -259,7 +259,7 @@ static void phased_flush(args_t *args)
         {
             if ( !gt_absent_warned )
             {
-                fprintf(stderr,"GT is not present at %s:%d. (This warning is printed only once.)\n", bcf_seqname(ahdr,arec), arec->pos+1);
+                fprintf(stderr,"GT is not present at %s:%"PRId64". (This warning is printed only once.)\n", bcf_seqname(ahdr,arec), (int64_t) arec->pos+1);
                 gt_absent_warned = 1;
             }
             continue;
@@ -270,7 +270,7 @@ static void phased_flush(args_t *args)
         {
             if ( !gt_absent_warned )
             {
-                fprintf(stderr,"GT is not present at %s:%d. (This warning is printed only once.)\n", bcf_seqname(bhdr,brec), brec->pos+1);
+                fprintf(stderr,"GT is not present at %s:%"PRId64". (This warning is printed only once.)\n", bcf_seqname(bhdr,brec), (int64_t) brec->pos+1);
                 gt_absent_warned = 1;
             }
             continue;
@@ -308,7 +308,7 @@ static void phased_flush(args_t *args)
         }
         if ( bcf_write(args->out_fh, args->out_hdr, arec)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
 
-        if ( arec->pos < args->prev_pos_check ) error("FIXME, disorder: %s:%d vs %d  [1]\n", bcf_seqname(args->files->readers[0].header,arec),arec->pos+1,args->prev_pos_check+1);
+        if ( arec->pos < args->prev_pos_check ) error("FIXME, disorder: %s:%"PRId64" vs %d  [1]\n", bcf_seqname(args->files->readers[0].header,arec),(int64_t) arec->pos+1,args->prev_pos_check+1);
         args->prev_pos_check = arec->pos;
     }
     args->nswap = 0;
@@ -358,7 +358,7 @@ static void phased_flush(args_t *args)
         }
         if ( bcf_write(args->out_fh, args->out_hdr, brec)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
 
-        if ( brec->pos < args->prev_pos_check ) error("FIXME, disorder: %s:%d vs %d  [2]\n", bcf_seqname(args->files->readers[1].header,brec),brec->pos+1,args->prev_pos_check+1);
+        if ( brec->pos < args->prev_pos_check ) error("FIXME, disorder: %s:%"PRId64" vs %d  [2]\n", bcf_seqname(args->files->readers[1].header,brec),(int64_t) brec->pos+1,args->prev_pos_check+1);
         args->prev_pos_check = brec->pos;
     }
     args->nbuf = 0;
@@ -367,9 +367,9 @@ static void phased_flush(args_t *args)
 static void phased_push(args_t *args, bcf1_t *arec, bcf1_t *brec)
 {
     if ( arec && arec->errcode )
-        error("Parse error at %s:%d, cannot proceed: %s\n", bcf_seqname(args->files->readers[0].header,arec),arec->pos+1, args->files->readers[0].fname);
+        error("Parse error at %s:%"PRId64", cannot proceed: %s\n", bcf_seqname(args->files->readers[0].header,arec),(int64_t) arec->pos+1, args->files->readers[0].fname);
     if ( brec && brec->errcode )
-        error("Parse error at %s:%d, cannot proceed: %s\n", bcf_seqname(args->files->readers[1].header,brec),brec->pos+1, args->files->readers[1].fname);
+        error("Parse error at %s:%"PRId64", cannot proceed: %s\n", bcf_seqname(args->files->readers[1].header,brec),(int64_t) brec->pos+1, args->files->readers[1].fname);
 
     int i, nsmpl = bcf_hdr_nsamples(args->out_hdr);
     int chr_id = bcf_hdr_name2id(args->out_hdr, bcf_seqname(args->files->readers[0].header,arec));
@@ -400,7 +400,7 @@ static void phased_push(args_t *args, bcf1_t *arec, bcf1_t *brec)
         if ( bcf_write(args->out_fh, args->out_hdr, arec)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
 
         if ( arec->pos < args->prev_pos_check )
-            error("FIXME, disorder: %s:%d in %s vs %d written  [3]\n", bcf_seqname(args->files->readers[0].header,arec), arec->pos+1,args->files->readers[0].fname, args->prev_pos_check+1);
+            error("FIXME, disorder: %s:%"PRId64" in %s vs %d written  [3]\n", bcf_seqname(args->files->readers[0].header,arec), (int64_t) arec->pos+1,args->files->readers[0].fname, args->prev_pos_check+1);
         args->prev_pos_check = arec->pos;
         return;
     }
@@ -459,10 +459,10 @@ static void concat(args_t *args)
                         if ( !site_drop_warned )
                         {
                             fprintf(stderr,
-                                "Warning: Dropping the site %s:%d. The --ligate option is intended for VCFs with perfect\n"
+                                "Warning: Dropping the site %s:%"PRId64". The --ligate option is intended for VCFs with perfect\n"
                                 "         overlap, sites in overlapping regions present in one but missing in other are dropped.\n"
                                 "         This warning is printed only once.\n",
-                                bcf_seqname(bcf_sr_get_header(args->files,1),bcf_sr_get_line(args->files,1)), bcf_sr_get_line(args->files,1)->pos+1
+                                bcf_seqname(bcf_sr_get_header(args->files,1),bcf_sr_get_line(args->files,1)), (int64_t) bcf_sr_get_line(args->files,1)->pos+1
                                 );
                             site_drop_warned = 1;
                         }

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -302,7 +302,7 @@ static int fake_PLs(args_t *args, bcf_hdr_t *hdr, bcf1_t *line)
     int fake_PL = args->no_PLs ? args->no_PLs : 99;    // with 1, discordance is the number of non-matching GTs
     int nsm_gt, i;
     if ( (nsm_gt=bcf_get_genotypes(hdr, line, &args->tmp_arr, &args->ntmp_arr)) <= 0 )
-        error("GT not present at %s:%d?\n", hdr->id[BCF_DT_CTG][line->rid].key, line->pos+1);
+        error("GT not present at %s:%"PRId64"?\n", hdr->id[BCF_DT_CTG][line->rid].key, (int64_t) line->pos+1);
     nsm_gt /= bcf_hdr_nsamples(hdr);
     int npl = line->n_allele*(line->n_allele+1)/2;
     hts_expand(int,npl*bcf_hdr_nsamples(hdr),args->npl_arr,args->pl_arr);
@@ -399,7 +399,7 @@ static void check_gt(args_t *args)
         // Target genotypes
         int ngt, npl;
         if ( (ngt=bcf_get_genotypes(args->gt_hdr, gt_line, &gt_arr, &ngt_arr)) <= 0 )
-            error("GT not present at %s:%d?", args->gt_hdr->id[BCF_DT_CTG][gt_line->rid].key, gt_line->pos+1);
+            error("GT not present at %s:%"PRId64"?", args->gt_hdr->id[BCF_DT_CTG][gt_line->rid].key, (int64_t) gt_line->pos+1);
         ngt /= bcf_hdr_nsamples(args->gt_hdr);
         if ( ngt!=2 ) continue; // checking only diploid genotypes
 
@@ -415,7 +415,7 @@ static void check_gt(args_t *args)
                     npl = fake_PLs(args, args->sm_hdr, sm_line);
                 }
                 else
-                    error("PL not present at %s:%d?\n", args->sm_hdr->id[BCF_DT_CTG][sm_line->rid].key, sm_line->pos+1);
+                    error("PL not present at %s:%"PRId64"?\n", args->sm_hdr->id[BCF_DT_CTG][sm_line->rid].key, (int64_t) sm_line->pos+1);
             }
             else
                 npl /= bcf_hdr_nsamples(args->sm_hdr);
@@ -460,7 +460,7 @@ static void check_gt(args_t *args)
             int a = bcf_gt_allele(gt_ptr[0]);
             int b = bcf_gt_allele(gt_ptr[1]);
             if ( args->hom_only && a!=b ) continue; // heterozygous genotype
-            fprintf(fp, "SC\t%s\t%d", args->gt_hdr->id[BCF_DT_CTG][gt_line->rid].key, gt_line->pos+1);
+            fprintf(fp, "SC\t%s\t%"PRId64, args->gt_hdr->id[BCF_DT_CTG][gt_line->rid].key, (int64_t) gt_line->pos+1);
             for (i=0; i<gt_line->n_allele; i++) fprintf(fp, "%c%s", i==0?'\t':',', gt_line->d.allele[i]);
             fprintf(fp, "\t%s/%s", a>=0 ? gt_line->d.allele[a] : ".", b>=0 ? gt_line->d.allele[b] : ".");
             fprintf(fp, "\t%f", args->lks[query_isample]-prev_lk);

--- a/vcfroh.c
+++ b/vcfroh.c
@@ -832,7 +832,7 @@ int process_line(args_t *args, bcf1_t *line, int ial)
         if ( ret>0 )
             alt_freq = args->AFs[ial-1];
         if ( ret==-2 )
-            error("Type mismatch for INFO/%s tag at %s:%d\n", args->af_tag, bcf_seqname(args->hdr,line), line->pos+1);
+            error("Type mismatch for INFO/%s tag at %s:%"PRId64"\n", args->af_tag, bcf_seqname(args->hdr,line), (int64_t) line->pos+1);
     }
     else if ( args->af_fname ) 
     {

--- a/vcfstats.c
+++ b/vcfstats.c
@@ -1114,7 +1114,7 @@ static void do_sample_stats(args_t *args, stats_t *stats, bcf_sr_t *reader, int 
                 {
                     nmm++;
                     bcf_sr_t *reader = &files->readers[0];
-                    printf("DBG\t%s\t%d\t%s\t%d\t%d\n",reader->header->id[BCF_DT_CTG][reader->buffer[0]->rid].key,reader->buffer[0]->pos+1,files->samples[is],gt,gt2);
+                    printf("DBG\t%s\t%"PRId64"\t%s\t%d\t%d\n",reader->header->id[BCF_DT_CTG][reader->buffer[0]->rid].key,(int64_t) reader->buffer[0]->pos+1,files->samples[is],gt,gt2);
                 }
                 else
                 {
@@ -1123,7 +1123,7 @@ static void do_sample_stats(args_t *args, stats_t *stats, bcf_sr_t *reader, int 
                 }
             }
             float nrd = nrefm+nmm ? 100.*nmm/(nrefm+nmm) : 0;
-            printf("PSD\t%s\t%d\t%d\t%d\t%f\n", reader->header->id[BCF_DT_CTG][reader->buffer[0]->rid].key,reader->buffer[0]->pos+1,nm,nmm,nrd);
+            printf("PSD\t%s\t%"PRId64"\t%d\t%d\t%f\n", reader->header->id[BCF_DT_CTG][reader->buffer[0]->rid].key,(int64_t) reader->buffer[0]->pos+1,nm,nmm,nrd);
         }
     }
 }

--- a/vcfview.c
+++ b/vcfview.c
@@ -32,6 +32,7 @@ THE SOFTWARE.  */
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <math.h>
+#include <inttypes.h>
 #include <htslib/vcf.h>
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/vcfutils.h>
@@ -455,7 +456,7 @@ int subset_vcf(args_t *args, bcf1_t *line)
     if (args->trim_alts)
     {
         int ret = bcf_trim_alleles(args->hsub ? args->hsub : args->hdr, line);
-        if ( ret<0 ) error("Error: Could not trim alleles at %s:%d\n", bcf_seqname(args->hsub ? args->hsub : args->hdr, line), line->pos+1);
+        if ( ret<0 ) error("Error: Could not trim alleles at %s:%"PRId64"\n", bcf_seqname(args->hsub ? args->hsub : args->hdr, line), (int64_t) line->pos+1);
     }
     if (args->phased) {
         int phased = bcf_all_phased(args->hdr, line);


### PR DESCRIPTION
This does not add 64-bit position support, it just ensures bcftools will build without warnings (using gcc/clang -Wall) when built against both 32-bit and 64-bit position branches of HTSlib.

Makes various printf()s use PRId64 for positions.  The values are cast to (int64_t) so both 32-bit and 64-bit versions work.
