### PR TITLE
Fix configure option thinko

### DIFF
--- a/config.mk.in
+++ b/config.mk.in
@@ -50,7 +50,8 @@ PERL_LIBS = @PERL_LIBS@
 
 PLATFORM   = @PLATFORM@
 PLUGINS_ENABLED = @enable_bcftools_plugins@
-plugindir = @bcf_plugindir@
+plugindir  = @bcf_plugindir@
+pluginpath = @bcf_pluginpath@
 PLUGIN_EXT = @PLUGIN_EXT@
 
 @Hsource@HTSDIR = @HTSDIR@

--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,7 @@ AC_ARG_WITH([bcf-plugin-path],
      no)  with_bcf_plugin_path= ;;
    esac],
   [with_bcf_plugin_path=$with_bcf_plugin_dir])
-AC_SUBST([PLUGINPATH], $with_bcf_plugin_path)
+AC_SUBST([bcf_pluginpath], $with_bcf_plugin_path)
 
 AC_ARG_ENABLE([perl-filters],
   [AS_HELP_STRING([--enable-perl-filters],


### PR DESCRIPTION
`@PLUGINPATH@` wasn't used anywhere, so `--with-bcf-plugin-path` didn't work.

Fix this by remembering to set make's `$(pluginpath)` from the `AC_SUBST` variable (and rename the variable to follow `@bcf_plugindir@`'s lead).