### PR TITLE
Add Travis build status badge to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/samtools/bcftools.svg?branch=develop)](https://travis-ci.org/samtools/bcftools)
+
 This is the official development repository for BCFtools. It contains all the vcf* commands
 which previously lived in the htslib repository (such as vcfcheck, vcfmerge, vcfisec, etc.)
 and the samtools BCF calling from bcftools subdirectory of samtools. 


### PR DESCRIPTION
Shall we add the Travis build status badge to `README.md` like [htslib/README.md](https://github.com/samtools/htslib/blob/develop/README.md) and [samtools/README.md](https://github.com/samtools/samtools/blob/develop/README.md)?

The modified `README.md` is here.
https://github.com/junaruga/bcftools/blob/feature/travis-badge/README.md

For AppVeyor, as maybe I do not have an access to see the badge URL at https://ci.appveyor.com/project/samtools/bcftools , I could not add it to `README.md`.

Thank you.
