### PR TITLE
Make .travis.yml more readable with YAML block "|" syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,11 @@ addons:
 
 # For MacOSX systems
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install xz gsl ; fi
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      brew update && \
+      brew install xz gsl
+    fi
 
 before_script:
   # Clone samtools/htslib (or another repository, as specified by a Travis CI
@@ -53,4 +56,14 @@ before_script:
   # same name, if any, or otherwise the default branch.
   - .travis/clone ${HTSREPO:-git://github.com/samtools/htslib.git} $HTSDIR $TRAVIS_BRANCH
 
-script: if test "$USE_CONFIG" = "yes" ; then ( cd "$HTSDIR" && autoreconf ) && autoreconf && ./configure --enable-libgsl && make && make test ; else make plugindir=$TRAVIS_BUILD_DIR/plugins -e && make -e test-plugins ; fi
+script: |
+  if test "$USE_CONFIG" = "yes"; then
+    ( cd "$HTSDIR" && autoreconf ) && \
+    autoreconf && \
+    ./configure --enable-libgsl && \
+    make && \
+    make test
+  else
+    make plugindir=$TRAVIS_BUILD_DIR/plugins -e && \
+    make -e test-plugins
+  fi


### PR DESCRIPTION
This PR makes us read `.travis.yml` easier.
The YAML block syntax has already been used for htslib.
https://github.com/samtools/htslib/blob/develop/.travis.yml#L60
https://github.com/samtools/htslib/blob/develop/.travis.yml#L83
