### PR TITLE
Add support for Cygwin plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 bcftools
 *.o
+*.a
+*.exe
 /version.h
 plugins/*.so
 plugins/*.dSYM
 plugins/*.P
 plugins/*.dll
+plugins/*.cygdll
 
 aclocal.m4
 autom4te.cache

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,11 @@ ifeq "$(PLATFORM)" "Darwin"
 $(PLUGINS): | bcftools
 PLUGIN_FLAGS = -bundle -bundle_loader bcftools -Wl,-undefined,dynamic_lookup
 DL_LIBS =
+else ifeq "$(PLATFORM)" "CYGWIN"
+$(PLUGINS): | bcftools
+PLUGIN_FLAGS = -fPIC -shared
+PLUGIN_LIBS = libbcftools.a $(HTSLIB_DLL) $(ALL_LIBS)
+DL_LIBS = -ldl
 else ifneq "$(filter MINGW% MSYS%,$(PLATFORM))" ""
 DYNAMIC_FLAGS =
 $(PLUGINS): | bcftools
@@ -177,7 +182,7 @@ libbcftools.a: $(OBJS)
 
 vcfplugin.o: EXTRA_CPPFLAGS += -DPLUGINPATH='"$(pluginpath)"'
 
-%.dll: %.c version.h version.c libbcftools.a $(HTSLIB_DLL)
+%.dll %.cygdll: %.c version.h version.c libbcftools.a $(HTSLIB_DLL)
 	$(CC) $(PLUGIN_FLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CPPFLAGS) $(LDFLAGS) -o $@ version.c $< $(PLUGIN_LIBS)
 %.so: %.c version.h version.c
 	$(CC) $(PLUGIN_FLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CPPFLAGS) $(LDFLAGS) -o $@ version.c $< $(LIBS)

--- a/config.mk.in
+++ b/config.mk.in
@@ -59,7 +59,7 @@ PLUGIN_EXT = @PLUGIN_EXT@
 @Hsource@include $(HTSDIR)/htslib_static.mk
 @Hsource@HTSLIB = $(HTSDIR)/libhts.a
 @Hsource@HTSLIB_LIB = $(HTSLIB) $(HTSLIB_static_LIBS)
-@Hsource@HTSLIB_DLL = $(HTSDIR)/hts.dll.a
+@Hsource@HTSLIB_DLL = $(HTSDIR)/@HTSLIB_DLL@
 @Hsource@HTSLIB_LDFLAGS = $(HTSLIB_static_LDFLAGS)
 @Hsource@BGZIP = $(HTSDIR)/bgzip
 @Hsource@TABIX = $(HTSDIR)/tabix

--- a/configure.ac
+++ b/configure.ac
@@ -121,12 +121,14 @@ AS_IF([test "$enable_bcftools_plugins" != "no"], [dnl
       host_result="Cygwin DLL"
       PLATFORM=CYGWIN
       PLUGIN_EXT=.cygdll
+      HTSLIB_DLL=libhts.dll.a
 	  ],
 
     [*-msys* | *-MSYS* | *-mingw* | *-MINGW*],[dnl
       host_result="MSYS dll"
       PLATFORM=MSYS
       PLUGIN_EXT=.dll
+      HTSLIB_DLL=hts.dll.a
 	  # This also sets __USE_MINGW_ANSI_STDIO which in turn makes PRId64,
       # %lld and %z printf formats work.  It also enforces the snprintf to
       # be C99 compliant so it returns the correct values (in kstring.c).
@@ -146,6 +148,7 @@ AS_IF([test "$enable_bcftools_plugins" != "no"], [dnl
   AC_SUBST([PLUGIN_EXT])
   AC_DEFINE_UNQUOTED([PLUGIN_EXT], ["$PLUGIN_EXT"],
                      [Platform-dependent plugin filename extension.])
+  AC_SUBST([HTSLIB_DLL])
   AC_DEFINE([ENABLE_BCF_PLUGINS], 1,
             [Define if BCFtools should enable plugins.])
 


### PR DESCRIPTION
Plug-ins can now be compiled and loaded on Cygwin, as `.cygdll`.
Fixes https://github.com/samtools/bcftools/issues/1108