### PR TITLE
Improve support for MSYS environment

### DIFF
--- a/plugins/ad-bias.c
+++ b/plugins/ad-bias.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <math.h>
 #include <htslib/hts.h>

--- a/plugins/contrast.c
+++ b/plugins/contrast.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
+#include <strings.h>
 #include <errno.h>
 #include <unistd.h>     // for isatty
 #include <inttypes.h>

--- a/plugins/mendelian.c
+++ b/plugins/mendelian.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <getopt.h>
 #include <math.h>
 #include <inttypes.h>

--- a/plugins/parental-origin.c
+++ b/plugins/parental-origin.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <math.h>
 #include <unistd.h>     // for isatty

--- a/plugins/split-vep.c
+++ b/plugins/split-vep.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <unistd.h>     // for isatty
 #include <inttypes.h>

--- a/plugins/trio-stats.c
+++ b/plugins/trio-stats.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <unistd.h>     // for isatty
 #include <inttypes.h>

--- a/tabix.c
+++ b/tabix.c
@@ -27,6 +27,7 @@ THE SOFTWARE.  */
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <strings.h>
 #include <htslib/bgzf.h>
 #include <htslib/tbx.h>
 

--- a/vcfplugin.c
+++ b/vcfplugin.c
@@ -158,11 +158,7 @@ static void add_plugin_paths(args_t *args, const char *path)
 {
     while (1)
     {
-#ifdef _WIN32
-        size_t len = strcspn(path, ";"); // Windows style path list delimiter
-#else
-        size_t len = strcspn(path, ":");
-#endif
+        size_t len = strcspn(path, HTS_PATH_SEPARATOR_STR);
 
         if ( len == 0 )
         {
@@ -193,11 +189,7 @@ static void add_plugin_paths(args_t *args, const char *path)
         }
 
         path += len;
-#ifdef _WIN32
-        if ( *path == ';' ) path++;
-#else
-        if ( *path == ':' ) path++;
-#endif
+        if ( *path == HTS_PATH_SEPARATOR_CHAR ) path++;
         else break;
     }
 }

--- a/vcfsort.c
+++ b/vcfsort.c
@@ -29,6 +29,7 @@
 #include <getopt.h>
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fix build warnings for source file containing calls to `strcasecmp`.
Use the newly defined HTSlib macros `HTS_PATH_SEPARATOR_CHAR` and `HTS_PATH_SEPARATOR_STR`.