### PR TITLE
Removed -Wc++-compat from Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CC       = gcc
 AR       = ar
 RANLIB   = ranlib
 CPPFLAGS =
-CFLAGS   = -g -Wall -Wc++-compat -O2
+CFLAGS   = -g -Wall -O2
 LDFLAGS  =
 LIBS     =
 


### PR DESCRIPTION
This just generates bogus warnings with older compilers, eg from gcc
4.6.3:

convert.c: In function 'process_pbinom':
convert.c:1148:49: warning: jump skips variable initialization [-Wjump-misses-init]
convert.c:1186:1: note: label 'invalid' defined here
convert.c:1151:13: note: 'gt' declared here
convert.c:1148:49: warning: jump skips variable initialization [-Wjump-misses-init]
convert.c:1186:1: note: label 'invalid' defined here
convert.c:1150:9: note: 'n' declared here

Those are all pointless warnings, and infact also go away if using gcc
5 onwards too.