### PR TITLE
Updated the list of OS packages.

### DIFF
--- a/howtos/install.html
+++ b/howtos/install.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.2">
+<meta name="generator" content="Asciidoctor 2.0.11.dev">
 <title>Installation</title>
 <link rel="stylesheet" href="./index.css">
 </head>
@@ -129,7 +129,10 @@ is not needed - see HTSlib&#8217;s INSTALL file for details.</p>
 <div class="content">
 <pre>zlib1g-dev
 libbz2-dev
-liblzma-dev</pre>
+liblzma-dev
+libcurl4-gnutls-dev or libcurl4-openssl-dev
+libssl-dev
+libncurses5-dev</pre>
 </div>
 </div>
 <div class="paragraph">
@@ -139,8 +142,12 @@ are:</p>
 <div class="listingblock">
 <div class="content">
 <pre>zlib-devel
+bzip2
 bzip2-devel
-xz-devel</pre>
+xz-devel
+curl-devel
+openssl-devel
+ncurses-devel</pre>
 </div>
 </div>
 <div class="paragraph">
@@ -321,7 +328,7 @@ to which you have installed bcftools et al.</p>
 <div class="sect2">
 <h3 id="_feedback">Feedback</h3>
 <div class="paragraph">
-<p>We welcome your feedback, please help us improve this page by
+<p>We welcome your feedback, please help us improve this page by 
 either opening an issue on github or editing it directly and sending
 a pull request.</p>
 </div>

--- a/howtos/install.txt
+++ b/howtos/install.txt
@@ -44,6 +44,9 @@ Packages for dpkg-based Linux distributions (Debian / Ubuntu) are:
 zlib1g-dev
 libbz2-dev
 liblzma-dev
+libcurl4-gnutls-dev or libcurl4-openssl-dev
+libssl-dev
+libncurses5-dev
 ----
 
 Packages for rpm or yum-based Linux distributions (RedHat / Fedora / CentOS)
@@ -51,8 +54,12 @@ are:
 
 ----
 zlib-devel
+bzip2
 bzip2-devel
 xz-devel
+curl-devel
+openssl-devel
+ncurses-devel
 ----
 
 Packages on MacOS, assuming Xcode is installed:


### PR DESCRIPTION
See https://github.com/samtools/www.htslib.org/issues/24

I haven't updated the OSX ones as it was incomplete before.  I don't know which are standard OS packages and what package management tool was being recommended.  I assume MacOS people will just look at the other OSes and use whichever homebrew type equivalent system they wish, given there's not a standard package manager for the OS.