### PR TITLE
Add #include <assert.h> and spelling corrections [minor]

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -61,7 +61,7 @@ If you have a full GNU autotools install, you can alternatively run:
     autoreconf
 
 Warnings like "AC_CONFIG_SUBDIRS: you should use literals" can be ignored
-or supressed using 'autoconf -Wno-syntax'.
+or suppressed using 'autoconf -Wno-syntax'.
 
 
 Compilation

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ print-version:
 	$(CC) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CPPFLAGS) -c -o $@ $<
 
 # The polysomy command is not compiled by default because it brings dependency
-# on libgsl. The command can be compiled wth `make USE_GPL=1`. See the INSTALL
+# on libgsl. The command can be compiled with `make USE_GPL=1`. See the INSTALL
 # and LICENSE documents to understand license implications.
 ifdef USE_GPL
     main.o : EXTRA_CPPFLAGS += -DUSE_GPL

--- a/NEWS
+++ b/NEWS
@@ -217,7 +217,7 @@ previous deliverables.
 ## Release 1.7 (February 2018)
 
 * `-i, -e` filtering: Major revamp, improved filtering by FORMAT fields
-  and missing values. New GT=ref,alt,mis etc keywords, check the documenation
+  and missing values. New GT=ref,alt,mis etc keywords, check the documentation
   for details.
 
 * `query`: Only matching expression are printed when both the -f and -i/-e
@@ -308,10 +308,10 @@ previous deliverables.
 * New `+prune` plugin for pruning sites by LD (R2) or maximum number of
   records within a window.
 
-* New N_MISSING, F_MISSING (number and fraction misssing) filtering
+* New N_MISSING, F_MISSING (number and fraction missing) filtering
   expressions.
 
-* Fix HMM initilization in `roh` when snapshots are used in multiple
+* Fix HMM initialization in `roh` when snapshots are used in multiple
   chromosome VCF.
 
 * Fix buffer overflow (#607) in `filter`.
@@ -372,7 +372,7 @@ Two new commands - `mpileup` and `csq`:
     `-O, --output-type` option common to other bcftools commands.
 
   - The `-f, --fasta-ref` option is now required by default to help avoid user
-    errors. Can be diabled using `--no-reference`.
+    errors. Can be disabled using `--no-reference`.
 
   - The option `-d, --depth .. max per-file depth` now behaves as expected
     and according to the documentation, and prints a meaningful diagnostics.

--- a/bin.c
+++ b/bin.c
@@ -25,6 +25,7 @@
  */
 
 #include <stdio.h>
+#include <assert.h>
 #include "bcftools.h"
 #include "bin.h"
 

--- a/ccall.c
+++ b/ccall.c
@@ -24,6 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
 #include <math.h>
+#include <assert.h>
 #include <htslib/kfunc.h>
 #include "call.h"
 #include "kmin.h"

--- a/consensus.c
+++ b/consensus.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include <assert.h>
 #include <errno.h>
 #include <getopt.h>
 #include <unistd.h>

--- a/convert.c
+++ b/convert.c
@@ -25,6 +25,7 @@ THE SOFTWARE.  */
 #include <stdio.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>

--- a/csq.c
+++ b/csq.c
@@ -136,6 +136,7 @@
  
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <getopt.h>
 #include <math.h>
 #include <inttypes.h>

--- a/filter.c
+++ b/filter.c
@@ -25,6 +25,7 @@ THE SOFTWARE.  */
 #include <ctype.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <assert.h>
 #include <errno.h>
 #include <math.h>
 #include <sys/types.h>

--- a/hclust.c
+++ b/hclust.c
@@ -27,6 +27,7 @@
 #include <htslib/hts.h>
 #include <htslib/kstring.h>
 #include <stdlib.h>
+#include <assert.h>
 #include "bcftools.h"
 #include "hclust.h"
 

--- a/mcall.c
+++ b/mcall.c
@@ -22,6 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.  */
 
+#include <assert.h>
 #include <math.h>
 #include <inttypes.h>
 #include <htslib/kfunc.h>

--- a/plugins/fill-from-fasta.c
+++ b/plugins/fill-from-fasta.c
@@ -25,6 +25,7 @@ DEALINGS IN THE SOFTWARE.  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <assert.h>
 #include <getopt.h>
 #include <inttypes.h>
 #include <htslib/vcf.h>

--- a/plugins/fixploidy.c
+++ b/plugins/fixploidy.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <assert.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <ctype.h>

--- a/plugins/fixref.c
+++ b/plugins/fixref.c
@@ -74,6 +74,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <assert.h>
 #include <getopt.h>
 #include <math.h>
 #include <inttypes.h>

--- a/plugins/isecGT.c
+++ b/plugins/isecGT.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <stdint.h>

--- a/plugins/split.c
+++ b/plugins/split.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <strings.h>
+#include <assert.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <unistd.h>

--- a/plugins/trio-dnm.c
+++ b/plugins/trio-dnm.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 #include <getopt.h>
 #include <math.h>
 #include <unistd.h>     // for isatty

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -26,6 +26,7 @@ THE SOFTWARE.  */
 #include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>

--- a/vcfbuf.c
+++ b/vcfbuf.c
@@ -24,6 +24,7 @@
 
  */
 
+#include <assert.h>
 #include <htslib/vcf.h>
 #include <htslib/vcfutils.h>
 #include "bcftools.h"

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -25,6 +25,7 @@ THE SOFTWARE.  */
 #include <stdarg.h>
 #include <string.h>
 #include <strings.h>
+#include <assert.h>
 #include <errno.h>
 #include <unistd.h>
 #include <getopt.h>

--- a/vcfcnv.c
+++ b/vcfcnv.c
@@ -32,6 +32,7 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <assert.h>
 #include <getopt.h>
 #include <math.h>
 #include <inttypes.h>

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -26,6 +26,7 @@ THE SOFTWARE.  */
 #include <unistd.h>
 #include <getopt.h>
 #include <string.h>
+#include <assert.h>
 #include <errno.h>
 #include <math.h>
 #include <inttypes.h>

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -25,6 +25,7 @@ THE SOFTWARE.  */
 #include <stdio.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -26,6 +26,7 @@ THE SOFTWARE.  */
 #include <stdarg.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -25,6 +25,7 @@ THE SOFTWARE.  */
 #include <stdio.h>
 #include <string.h>
 #include <strings.h>
+#include <assert.h>
 #include <errno.h>
 #include <unistd.h>
 #include <getopt.h>

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -26,6 +26,7 @@ THE SOFTWARE.  */
 #include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>

--- a/vcfsom.c
+++ b/vcfsom.c
@@ -25,6 +25,7 @@ THE SOFTWARE.  */
 #include <stdio.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>

--- a/vcfstats.c
+++ b/vcfstats.c
@@ -31,6 +31,7 @@ THE SOFTWARE.  */
 #include <stdarg.h>
 #include <unistd.h>
 #include <getopt.h>
+#include <assert.h>
 #include <math.h>
 #include <htslib/vcf.h>
 #include <htslib/synced_bcf_reader.h>


### PR DESCRIPTION
Add `#include <assert.h>` to the rest of the source files that use `assert()` — currently they get it as a byproduct of `#include "htslib/vcf.h"`. This is in preparation for an upcoming HTSlib PR that proposes, amongst other things, to reduce the inclusion of unneeded system includes (such as `<assert.h>`) from _htslib/*.h_.

Particularly for something like `<assert.h>` which gets controlled by `NDEBUG` at the point of each `#include` it's best for it to be visible in each source file and for public HTSlib headers not to include it.

Also some spelling fixes in user-visible documentation files.