### PR TITLE
Fix bcftools build on OpenBSD and Illumos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ test check: test-no-plugins
 endif  # PLUGINS_ENABLED
 
 bcftools: $(OBJS) $(HTSLIB)
-	$(CC) $(DYNAMIC_FLAGS) -pthread $(ALL_LDFLAGS) -o $@ $(OBJS) $(HTSLIB_LIB) -lm $(ALL_LIBS) $(GSL_LIBS) $(PERL_LIBS)
+	$(CC) $(DYNAMIC_FLAGS) $(ALL_LDFLAGS) -o $@ $(OBJS) $(HTSLIB_LIB) -lm $(ALL_LIBS) $(GSL_LIBS) $(PERL_LIBS) -lpthread
 
 plugins: $(PLUGINS)
 

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,12 @@ PLUGIN_LIBS = $(W32_PLUGIN_LIBS)
 DL_LIBS =
 else
 PLUGIN_FLAGS = -fPIC -shared
+ifeq "$(PLATFORM)" "default"
+# Configure was used and has already added -ldl to $(LIBS) if necessary
+DL_LIBS =
+else
 DL_LIBS = -ldl
+endif
 endif
 
 libbcftools.a: $(OBJS)

--- a/misc/run-roh.pl
+++ b/misc/run-roh.pl
@@ -127,7 +127,7 @@ sub cmd
     else 
     {      
         # child
-        exec('/bin/bash', '-o','pipefail','-c', $cmd) or error("Failed to run the command [/bin/sh -o pipefail -c $cmd]: $!");
+        exec('bash', '-o','pipefail','-c', $cmd) or error("Failed to run the command [bash -o pipefail -c $cmd]: $!");
     }
 
     if ( exists($args{exit_on_error}) && !$args{exit_on_error} ) { return @out; }

--- a/test/test.pl
+++ b/test/test.pl
@@ -665,7 +665,7 @@ sub _cmd
     else
     {
         # child
-        exec('/bin/bash', '-o','pipefail','-c', $cmd) or error("Cannot execute the command [/bin/sh -o pipefail -c $cmd]: $!");
+        exec('bash', '-o','pipefail','-c', $cmd) or error("Cannot execute the command [bash -o pipefail -c $cmd]: $!");
     }
     return ($? >> 8, join('',@out));
 }
@@ -677,7 +677,7 @@ sub _cmd3
     my $pid = fork();
     if ( !$pid )
     {
-        exec('/bin/bash', '-o','pipefail','-c', "($cmd) 2>$tmp.e >$tmp.o");
+        exec('bash', '-o','pipefail','-c', "($cmd) 2>$tmp.e >$tmp.o");
     }
     waitpid($pid,0);
 

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -612,7 +612,7 @@ static void init_data(args_t *args)
     // Open files for input and output, initialize structures
     if ( args->targets )
     {
-        args->tgt_idx = regidx_init(args->targets, tgt_parse, args->aux.flag&CALL_CONSTR_ALLELES ? tgt_free : NULL, sizeof(tgt_als_t), args->aux.flag&CALL_CONSTR_ALLELES ? args : NULL);
+        args->tgt_idx = regidx_init(args->targets, tgt_parse, args->aux.flag&CALL_CONSTR_ALLELES ? tgt_free : (regidx_free_f) NULL, sizeof(tgt_als_t), args->aux.flag&CALL_CONSTR_ALLELES ? args : NULL);
         args->tgt_itr = regitr_init(args->tgt_idx);
         args->tgt_itr_tmp = regitr_init(args->tgt_idx);
     }


### PR DESCRIPTION
Minor fixes needed to make bcftools build on these minor platforms. BCFtools companion to similar previous PRs samtools/htslib#1011, samtools/samtools#1151, and samtools/samtools#1165.
