### PR TITLE
Fix convert bug and avoid other new Clang warnings

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -785,8 +785,8 @@ static void process_gp_to_prob3(convert_t *convert, bcf1_t *line, fmt_t *fmt, in
         int j;
         for (j=0; j<n; j++)
         {
-            if ( ptr[j]==bcf_int32_vector_end ) break;
-            if ( ptr[j]==bcf_int32_missing ) { ptr[j]=0; continue; }
+            if ( bcf_float_is_vector_end(ptr[j]) ) break;
+            if ( bcf_float_is_missing(ptr[j]) ) { ptr[j]=0; continue; }
             if ( ptr[j]<0 || ptr[j]>1 ) error("[%s:%"PRId64":%f] GP value outside range [0,1]; bcftools convert expects the VCF4.3+ spec for the GP field encoding genotype posterior probabilities", bcf_seqname(convert->header,line),(int64_t) line->pos+1,ptr[j]);
             sum+=ptr[j];
         }

--- a/test/test-regidx.c
+++ b/test/test-regidx.c
@@ -172,9 +172,9 @@ void test_custom_payload(void)
 
 void get_random_region(uint32_t min, uint32_t max, uint32_t *beg, uint32_t *end)
 {
-    long int b = random(), e = random();
-    *beg = min + (float)b * (max-min) / RAND_MAX;
-    *end = *beg + (float)e * (max-*beg) / RAND_MAX;
+    uint64_t b = random(), e = random();
+    *beg = min + (b * (max-min)) / INT32_MAX;
+    *end = *beg + (e * (max-*beg)) / INT32_MAX;
 }
 
 void test_random(int nregs, uint32_t min, uint32_t max)

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -1423,7 +1423,7 @@ static void merge_format_string(args_t *args, bcf1_t **lines, int nlines, bcf_fm
         for (i=0; i<nlines; i++)
         {
             int nret = bcf_get_format_char(args->hdr,lines[i],tag,&args->tmp_arr1,&args->ntmp_arr1);
-            if (nret<0) continue; /* format tag does not exist in this record, skip */ \
+            if (nret<0) continue; /* format tag does not exist in this record, skip */
             nret /= nsmpl;
             for (k=0; k<nsmpl; k++)
             {
@@ -1470,7 +1470,7 @@ static void merge_format_string(args_t *args, bcf1_t **lines, int nlines, bcf_fm
             if ( i ) // we already have a copy
             {
                 nret = bcf_get_format_char(args->hdr,lines[i],tag,&args->tmp_arr1,&args->ntmp_arr1);
-                if (nret<0) continue; /* format tag does not exist in this record, skip */ \
+                if (nret<0) continue; /* format tag does not exist in this record, skip */
                 nret /= nsmpl;
             }
             for (k=0; k<nsmpl; k++)


### PR DESCRIPTION
Compiling bcftools with Clang **master** (the upcoming release 11) produces:

```
vcfnorm.c:1427:13: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
            nret /= nsmpl;
            ^
vcfnorm.c:1426:13: note: previous statement is here
            if (nret<0) continue; /* format tag does not exist in this record, skip */ \
            ^
vcfnorm.c:1474:17: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
                nret /= nsmpl;
                ^
vcfnorm.c:1473:17: note: previous statement is here
                if (nret<0) continue; /* format tag does not exist in this record, skip */ \
                ^


convert.c:788:26: warning: implicit conversion from 'int' to 'float' changes value from -2147483647 to -2147483648 [-Wimplicit-const-int-float-conversion]
            if ( ptr[j]==bcf_int32_vector_end ) break;
                       ~~^~~~~~~~~~~~~~~~~~~~
../htslib/htslib/vcf.h:1291:31: note: expanded from macro 'bcf_int32_vector_end'
#define bcf_int32_vector_end (-2147483647)  /* INT32_MIN + 1 */
                              ^~~~~~~~~~~


test/test-regidx.c:176:41: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
    *beg = min + (float)b * (max-min) / RAND_MAX;
                                      ~ ^~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdlib.h:105:18: note: expanded from macro 'RAND_MAX'
#define RAND_MAX        0x7fffffff
                        ^~~~~~~~~~
test/test-regidx.c:177:43: warning: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Wimplicit-const-int-float-conversion]
    *end = *beg + (float)e * (max-*beg) / RAND_MAX;
                                        ~ ^~~~~~~~
```

The _vcfnorm.c_ warnings are trivially fixed.

The _convert.c_ warning indicates a bug, as `ptr[j]` is float data, not integer.

The `random()` stuff is similar to that addressed in samtools/htslib#1083, except that `random()` ranges up to 2<sup>31</sup>-1 not `RAND_MAX`. This is a bug fix on Windows, where `RAND_MAX` is much smaller.