### PR TITLE
Fix Makefile dependencies for new gtcheck code

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -126,7 +126,7 @@ need to be built with
 
 Note that when compiling on MacOS, the default options for linking with Perl
 provided by the system sometimes do not work. It was reported that removing
-the occurance of -arch i386 from config.mk solved the problem.
+the occurrence of -arch i386 from config.mk solved the problem.
 
 
 Optional Compilation with GSL

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ vcfcall.o: vcfcall.c $(htslib_vcf_h) $(htslib_kfunc_h) $(htslib_synced_bcf_reade
 vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_thread_pool_h) $(bcftools_h)
 vcfconvert.o: vcfconvert.c $(htslib_faidx_h) $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kseq_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
 vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h
-vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) hclust.h extsort.h
+vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kbitset_h) $(bcftools_h) extsort.h
 vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(bcftools_h)
 vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(bcftools_h) $(filter_h)
 vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_faidx_h) regidx.h $(bcftools_h) vcmp.h $(htslib_khash_h)
@@ -278,7 +278,7 @@ version.o: version.h version.c
 hclust.o: hclust.c $(htslib_hts_h) $(htslib_kstring_h) $(bcftools_h) hclust.h
 HMM.o: HMM.c $(htslib_hts_h) HMM.h
 vcfbuf.o: vcfbuf.c $(htslib_vcf_h) $(htslib_vcfutils_h) $(bcftools_h) $(vcfbuf_h) rbuf.h
-extsort.o: extsort.c extsort.h $(htslib_kbitset_h)
+extsort.o: extsort.c $(bcftools_h) extsort.h kheap.h
 smpl_ilist.o: smpl_ilist.c $(bcftools_h) $(smpl_ilist_h)
 csq.o: csq.c $(htslib_hts_h) $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_khash_h) $(htslib_khash_str2int_h) $(htslib_kseq_h) $(htslib_faidx_h) $(bcftools_h) $(filter_h) regidx.h kheap.h $(smpl_ilist_h) rbuf.h
 

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -256,9 +256,9 @@ The program ignores the first column and the last indicates sex (1=male, 2=femal
     and *-t* discards positions which are not in the targets. Unlike *-r*, targets
     can be prefixed with "&#94;" to request logical complement. For example, "&#94;X,Y,MT"
     indicates that sequences X, Y and MT should be skipped.
-    Yet another difference between the *-t/-T* and *-r/-R* is that *-r/-R* checks for 
+    Yet another difference between the *-t/-T* and *-r/-R* is that *-r/-R* checks for
     proper overlaps and considers both POS and the end position of an indel, while *-t/-T*
-    consideres the POS coordinate only. Note that *-t* cannot be used in combination with *-T*.
+    considers the POS coordinate only. Note that *-t* cannot be used in combination with *-T*.
 
 *-T, --targets-file* \[&#94;]'FILE'::
     Same *-t, --targets*, but reads regions from a file. Note that *-T*


### PR DESCRIPTION
Correct the _Makefile_ additions from PR #1244. With the new gtcheck code merged, _hclust.c_ and _hclust.h_ are currently unused. If they are likely to remain unused, these files and remaining references to them in _Makefile_ could also be removed.

Also fix recently added user-visible typos.