### PR TITLE
New `merge --no-index` option which allows to merge unindexed files.

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1661,6 +1661,11 @@ For "vertical" merge take a look at *<<concat,bcftools concat>>* or *<<norm,bcft
 -m id     ..  merge by ID
 ----
 
+*--no-index*::
+    the option allows to merge files without indexing them first. In order for this
+    option to work, the user must ensure that the input files have chromosomes in
+    the same order and consistent with the order of sequences in the VCF header.
+
 *--no-version*::
     see *<<common_options,Common Options>>*
 

--- a/test/merge.c.vcf
+++ b/test/merge.c.vcf
@@ -23,6 +23,7 @@
 ##contig=<ID=1,assembly=b37,length=249250621>
 ##contig=<ID=3,assembly=b37,length=198022430>
 ##contig=<ID=4,assembly=b37,length=191154276>
+##contig=<ID=2,assembly=b37,length=191154276>
 ##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
 ##readme=AAAAAA
 ##readme=BBBBBB

--- a/test/merge.noidx.a.vcf
+++ b/test/merge.noidx.a.vcf
@@ -1,0 +1,12 @@
+##fileformat=VCFv4.3
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=1,assembly=b37,length=249250621>
+##contig=<ID=2,assembly=b37,length=249250621>
+##contig=<ID=3,assembly=b37,length=198022430>
+##contig=<ID=4,assembly=b37,length=191154276>
+##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A
+1	3000150	.	C	T	.	.	.	GT	0/0
+2	3000150	.	C	T	.	.	.	GT	0/0
+3	3000150	.	C	T	.	.	.	GT	0/0
+4	3000150	.	C	T	.	.	.	GT	0/0

--- a/test/merge.noidx.abc.out
+++ b/test/merge.noidx.abc.out
@@ -1,0 +1,17 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=1,assembly=b37,length=249250621>
+##contig=<ID=2,assembly=b37,length=249250621>
+##contig=<ID=3,assembly=b37,length=198022430>
+##contig=<ID=4,assembly=b37,length=191154276>
+##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	A	B	C
+1	3000150	.	C	T	.	.	.	GT	0/0	0/1	1/1
+1	3000151	.	C	T	.	.	.	GT	./.	0/1	1/1
+2	3000150	.	C	T	.	.	.	GT	0/0	0/1	1/1
+2	3000151	.	C	T	.	.	.	GT	./.	0/1	1/1
+3	3000150	.	C	T	.	.	.	GT	0/0	0/1	1/1
+3	3000151	.	C	T	.	.	.	GT	./.	0/1	1/1
+4	3000150	.	C	T	.	.	.	GT	0/0	0/1	1/1
+4	3000151	.	C	T	.	.	.	GT	./.	0/1	1/1

--- a/test/merge.noidx.b.vcf
+++ b/test/merge.noidx.b.vcf
@@ -1,0 +1,16 @@
+##fileformat=VCFv4.3
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=1,assembly=b37,length=249250621>
+##contig=<ID=2,assembly=b37,length=249250621>
+##contig=<ID=3,assembly=b37,length=198022430>
+##contig=<ID=4,assembly=b37,length=191154276>
+##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	B
+1	3000150	.	C	T	.	.	.	GT	0/1
+1	3000151	.	C	T	.	.	.	GT	0/1
+2	3000150	.	C	T	.	.	.	GT	0/1
+2	3000151	.	C	T	.	.	.	GT	0/1
+3	3000150	.	C	T	.	.	.	GT	0/1
+3	3000151	.	C	T	.	.	.	GT	0/1
+4	3000150	.	C	T	.	.	.	GT	0/1
+4	3000151	.	C	T	.	.	.	GT	0/1

--- a/test/merge.noidx.c.vcf
+++ b/test/merge.noidx.c.vcf
@@ -1,0 +1,16 @@
+##fileformat=VCFv4.3
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##contig=<ID=1,assembly=b37,length=249250621>
+##contig=<ID=2,assembly=b37,length=249250621>
+##contig=<ID=3,assembly=b37,length=198022430>
+##contig=<ID=4,assembly=b37,length=191154276>
+##reference=file:///lustre/scratch105/projects/g1k/ref/main_project/human_g1k_v37.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	C
+1	3000150	.	C	T	.	.	.	GT	1/1
+1	3000151	.	C	T	.	.	.	GT	1/1
+2	3000150	.	C	T	.	.	.	GT	1/1
+2	3000151	.	C	T	.	.	.	GT	1/1
+3	3000150	.	C	T	.	.	.	GT	1/1
+3	3000151	.	C	T	.	.	.	GT	1/1
+4	3000150	.	C	T	.	.	.	GT	1/1
+4	3000151	.	C	T	.	.	.	GT	1/1

--- a/test/test.pl
+++ b/test/test.pl
@@ -66,8 +66,8 @@ test_vcf_merge($opts,in=>['merge.2.a','merge.2.b'],out=>'merge.2.all.out',args=>
 test_vcf_merge($opts,in=>['merge.3.a','merge.3.b'],out=>'merge.3.out',args=>'--force-samples -i TR:sum,TA:sum,TG:sum');
 test_vcf_merge($opts,in=>['merge.4.a','merge.4.b'],out=>'merge.4.out',args=>'--force-samples -m id');
 test_vcf_merge($opts,in=>['gvcf.merge.1','gvcf.merge.2','gvcf.merge.3'],out=>'gvcf.merge.1.out',args=>'--gvcf -');
-test_vcf_merge($opts,in=>['merge.gvcf.2.a','merge.gvcf.2.b','merge.gvcf.2.c'],out=>'merge.gvcf.2.out',args=>'--gvcf -');
-test_vcf_merge($opts,in=>['merge.gvcf.3.a','merge.gvcf.3.b'],out=>'merge.gvcf.3.out',args=>'--gvcf - -i SRC:join');
+test_vcf_merge($opts,in=>['merge.gvcf.2.a','merge.gvcf.2.b','merge.gvcf.2.c'],out=>'merge.gvcf.2.out',args=>'--gvcf -',types=>['vcf']);
+test_vcf_merge($opts,in=>['merge.gvcf.3.a','merge.gvcf.3.b'],out=>'merge.gvcf.3.out',args=>'--gvcf - -i SRC:join',types=>['vcf']);
 test_vcf_merge($opts,in=>['merge.gvcf.4.a','merge.gvcf.4.b'],out=>'merge.gvcf.4.out',args=>'--gvcf -');
 test_vcf_merge($opts,in=>['merge.5.a','merge.5.b'],out=>'merge.5.out');
 test_vcf_merge($opts,in=>['merge.6.a','merge.6.b'],out=>'merge.6.out');
@@ -84,6 +84,8 @@ test_vcf_merge($opts,in=>['merge.gvcf.10.a','merge.gvcf.10.b'],out=>'merge.gvcf.
 test_vcf_merge($opts,in=>['merge.gvcf.10.a','merge.gvcf.10.b'],out=>'merge.gvcf.10.4.out',args=>'-g {PATH}/merge.gvcf.10.fa -m none');
 test_vcf_merge($opts,in=>['merge.gvcf.10.b','merge.gvcf.10.a'],out=>'merge.gvcf.10.5.out',args=>'-g {PATH}/merge.gvcf.10.fa');
 test_vcf_merge($opts,in=>['merge.gvcf.10.b','merge.gvcf.10.a'],out=>'merge.gvcf.10.4.out',args=>'-g {PATH}/merge.gvcf.10.fa -m none');
+test_vcf_merge($opts,in=>['merge.noidx.a','merge.noidx.b','merge.noidx.c'],out=>'merge.noidx.abc.out',args=>'');
+test_vcf_merge($opts,in=>['merge.noidx.a','merge.noidx.b','merge.noidx.c'],out=>'merge.noidx.abc.out',args=>'--no-index',noidx=>1);
 # test_vcf_merge_big($opts,in=>'merge_big.1',out=>'merge_big.1.1',nsmpl=>79000,nfiles=>79,nalts=>486,args=>'');   # commented out for speed
 test_vcf_query($opts,in=>'query.string',out=>'query.string.1.out',args=>q[-f '%CHROM\\t%POS\\t%CLNREVSTAT\\n' -i'CLNREVSTAT="criteria_provided,_conflicting_interpretations"']);
 test_vcf_query($opts,in=>'query.string',out=>'query.string.1.out',args=>q[-f '%CHROM\\t%POS\\t%CLNREVSTAT\\n' -i'CLNREVSTAT="criteria_provided" || CLNREVSTAT="_conflicting_interpretations"']);
@@ -962,17 +964,47 @@ sub test_vcf_stats
 sub test_vcf_merge
 {
     my ($opts,%args) = @_;
-    my @files;
-    for my $file (@{$args{in}})
+    my @types = exists($args{types}) ? @{$args{types}} : (qw(vcf bcf));
+    for my $type (@types)
     {
-        bgzip_tabix_vcf($opts,$file);
-        push @files, "$$opts{tmp}/$file.vcf.gz";
+        my @files;
+        if ( $args{noidx} )
+        {
+            for my $file (@{$args{in}})
+            {
+                if ( $type eq 'vcf' )
+                {
+                    push @files, "$$opts{path}/$file.vcf";
+                }
+                else
+                {
+                    cmd("$$opts{bin}/bcftools view --no-version -Ob -o $$opts{tmp}/$file.bcf $$opts{path}/$file.vcf");
+                    push @files, "$$opts{tmp}/$file.bcf";
+                }
+            }
+        }
+        else
+        {
+            for my $file (@{$args{in}})
+            {
+                if ( $type eq 'vcf' )
+                {
+                    bgzip_tabix_vcf($opts,$file);
+                    push @files, "$$opts{tmp}/$file.vcf.gz";
+                }
+                else
+                {
+                    cmd("$$opts{bin}/bcftools view --no-version -Ob -o $$opts{tmp}/$file.bcf $$opts{path}/$file.vcf && $$opts{bin}/bcftools index -f $$opts{tmp}/$file.bcf");
+                    push @files, "$$opts{tmp}/$file.bcf";
+                }
+            }
+        }
+        my $args  = exists($args{args}) ? $args{args} : '';
+        $args     =~ s/{PATH}/$$opts{path}/g;
+        my $files = join(' ',@files);
+        test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools merge --no-version $args $files", exp_fix=>1);
+        test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools merge -Ob $args $files | $$opts{bin}/bcftools view | grep -v ^##bcftools_", exp_fix => 1);
     }
-    my $args  = exists($args{args}) ? $args{args} : '';
-    $args     =~ s/{PATH}/$$opts{path}/g;
-    my $files = join(' ',@files);
-    test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools merge --no-version $args $files", exp_fix=>1);
-    test_cmd($opts,%args,cmd=>"$$opts{bin}/bcftools merge -Ob $args $files | $$opts{bin}/bcftools view | grep -v ^##bcftools_", exp_fix => 1);
 }
 sub test_vcf_isec
 {

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -142,7 +142,7 @@ typedef struct
     maux_t *maux;
     regidx_t *regs;    // apply regions only after the blocks are expanded
     regitr_t *regs_itr;
-    int header_only, collapse, output_type, force_samples, merge_by_id, do_gvcf, filter_logic, missing_to_ref;
+    int header_only, collapse, output_type, force_samples, merge_by_id, do_gvcf, filter_logic, missing_to_ref, no_index;
     char *header_fname, *output_fname, *regions_list, *info_rules, *file_list;
     faidx_t *gvcf_fai;
     info_rule_t *rules;
@@ -2614,6 +2614,7 @@ static void usage(void)
     fprintf(stderr, "    -i, --info-rules <tag:method,..>   rules for merging INFO fields (method is one of sum,avg,min,max,join) or \"-\" to turn off the default [DP:sum,DP4:sum]\n");
     fprintf(stderr, "    -l, --file-list <file>             read file names from the file\n");
     fprintf(stderr, "    -m, --merge <string>               allow multiallelic records for <snps|indels|both|all|none|id>, see man page for details [both]\n");
+    fprintf(stderr, "        --no-index                     merge unindexed files, the same chromosomal order is required and -r/-R are not allowed\n");
     fprintf(stderr, "        --no-version                   do not append version and command line to the header\n");
     fprintf(stderr, "    -o, --output <file>                write output to a file [standard output]\n");
     fprintf(stderr, "    -O, --output-type <b|u|z|v>        'b' compressed BCF; 'u' uncompressed BCF; 'z' compressed VCF; 'v' uncompressed VCF [v]\n");
@@ -2655,6 +2656,7 @@ int main_vcfmerge(int argc, char *argv[])
         {"regions-file",required_argument,NULL,'R'},
         {"info-rules",required_argument,NULL,'i'},
         {"no-version",no_argument,NULL,8},
+        {"no-index",no_argument,NULL,10},
         {"filter-logic",required_argument,NULL,'F'},
         {NULL,0,NULL,0}
     };
@@ -2705,6 +2707,7 @@ int main_vcfmerge(int argc, char *argv[])
             case  3 : args->force_samples = 1; break;
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
+            case 10 : args->no_index = 1; break;
             case 'h':
             case '?': usage(); break;
             default: error("Unknown argument: %s\n", optarg);
@@ -2713,7 +2716,13 @@ int main_vcfmerge(int argc, char *argv[])
     if ( argc==optind && !args->file_list ) usage();
     if ( argc-optind<2 && !args->file_list ) usage();
 
-    args->files->require_index = 1;
+    if ( args->no_index )
+    {
+        if ( args->regions_list ) error("Error: cannot combine --no-index with -r/-R\n");
+        bcf_sr_set_opt(args->files,BCF_SR_REQUIRE_IDX_WARN);
+    }
+    else
+        bcf_sr_set_opt(args->files,BCF_SR_REQUIRE_IDX);
     if ( args->regions_list )
     {
         if ( bcf_sr_set_regions(args->files, args->regions_list, regions_is_file)<0 )


### PR DESCRIPTION
In order for this to work, the input files have chromosomes in the
same order and consistent with the order of sequences in the header.

Depends on https://github.com/samtools/htslib/pull/1089 and supersedes #1223.