### PR TITLE
Rename bam_mpileup() to avoid clash with samtools's equivalent

### DIFF
--- a/main.c
+++ b/main.c
@@ -58,7 +58,7 @@ int main_plugin(int argc, char *argv[]);
 #endif
 int main_consensus(int argc, char *argv[]);
 int main_csq(int argc, char *argv[]);
-int bam_mpileup(int argc, char *argv[]);
+int main_mpileup(int argc, char *argv[]);
 int main_sort(int argc, char *argv[]);
 
 typedef struct
@@ -164,7 +164,7 @@ static cmd_t cmds[] =
       .alias = "gtcheck",
       .help  = "check sample concordance, detect sample swaps and contamination"
     },
-    { .func  = bam_mpileup,
+    { .func  = main_mpileup,
         .alias = "mpileup",
         .help  = "multi-way pileup producing genotype likelihoods"
     },

--- a/mpileup.c
+++ b/mpileup.c
@@ -918,7 +918,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
     free(tmp_filter);
 }
 
-int bam_mpileup(int argc, char *argv[])
+int main_mpileup(int argc, char *argv[])
 {
     int c;
     const char *file_list = NULL;


### PR DESCRIPTION
Rename to `main_mpileup()`, similar to the other main functions.

This fixes Pysam issue pysam-developers/pysam#928: Pysam provides access to both samtools and bcftools subcommands so includes code from both, and on Linux `pysam.bcftools.mpileup()` was invoking the wrong `bam_mpileup()` function.