### PR TITLE
NEWS line-wrapping and gff2gff.py tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ INSTALL_SCRIPT  = $(INSTALL_PROGRAM)
 PROGRAMS = bcftools
 MISC_SCRIPTS = \
     misc/color-chrs.pl \
+    misc/gff2gff.py \
     misc/guess-ploidy.py \
     misc/plot-vcfstats \
     misc/plot-roh.py \

--- a/NEWS
+++ b/NEWS
@@ -5,20 +5,21 @@ Changes affecting the whole of bcftools, or multiple commands:
 * Filtering -i/-e expressions
 
     - Breaking change in -i/-e expressions on the FILTER column.  Originally
-    it was possible to query only a subset of filters, but not an exact match.
-    The new behavior is:
+      it was possible to query only a subset of filters, but not an exact match.
+      The new behavior is:
 
         FILTER="A"          .. exact match, for example "A;B" does not pass
         FILTER!="A"         .. exact match, for example "A;B" does pass
         FILTER~"A"          .. both "A" and "A;B" pass
         FILTER!~"A"         .. neither "A" nor "A;B" pass
 
-    - Fix in commutative comparison operators, in some cases reversing sides would
-    produce incorrect results (#1224; #1266)
+    - Fix in commutative comparison operators, in some cases reversing sides
+      would produce incorrect results (#1224; #1266)
 
     - Better support for filtering on sample subsests
 
-    - Add SMPL_*/S* family of functions that evaluate within rather than across all samples. (#1180)
+    - Add SMPL_*/S* family of functions that evaluate within rather than across
+      all samples. (#1180)
 
 * Improvements in the build system
 
@@ -27,19 +28,21 @@ Changes affecting specific commands:
 
 * bcftools annotate:
 
-    - Previously it was not possible to use `--columns =TAG` with INFO tags and the `--merge-logic`
-    feature was restricted to tab files with BEG,END columns, now extended to work also
-    with REF,ALT.
+    - Previously it was not possible to use `--columns =TAG` with INFO tags
+      and the `--merge-logic` feature was restricted to tab files with BEG,END
+      columns, now extended to work also with REF,ALT.
 
     - Make `annotate -TAG/+TAG` work also with FORMAT fields. (#1259)
 
-    - ID and FILTER can be transferred to INFO and ID can be populated from INFO.  However,
-    the FILTER column still cannot be populated from an INFO tag because all possible FILTER
-    values must be known at the time of writing the header (#947; #1187)
+    - ID and FILTER can be transferred to INFO and ID can be populated from
+      INFO.  However, the FILTER column still cannot be populated from an INFO
+      tag because all possible FILTER values must be known at the time of
+      writing the header (#947; #1187)
 
 * bcftools consensus:
 
-    - Fix in handling symbolic deletions and overlapping variants. (#1149; #1155; #1295)
+    - Fix in handling symbolic deletions and overlapping variants.
+      (#1149; #1155; #1295)
 
     - Fix `--iupac-codes` crash on REF-only positions with `ALT="."`. (#1273)
 
@@ -47,8 +50,8 @@ Changes affecting specific commands:
 
     - Preserve the case of the genome reference. (#1150)
 
-    - Add new `-a, --absent` option which allows to set positions with no supporting evidence
-    to "N" (or any other character). (#848; #940)
+    - Add new `-a, --absent` option which allows to set positions with no
+      supporting evidence to "N" (or any other character). (#848; #940)
 
 * bcftools convert:
 
@@ -58,9 +61,9 @@ Changes affecting specific commands:
 
 * bcftools csq:
 
-    - Add `misc/gff2gff.py` script for conversion between various flavors of GFF
-    files. The initial commit supports only one type and was contributed by @flashton2003.
-    (#530)
+    - Add `misc/gff2gff.py` script for conversion between various flavors of
+      GFF files. The initial commit supports only one type and was contributed
+      by @flashton2003. (#530)
 
     - Add missing consequence types. (PR #1203; #1292)
 
@@ -72,79 +75,87 @@ Changes affecting specific commands:
 
 * bcftools filter:
 
-    - Make `--SnpGap` optionally filter also SNPs close to other variant types. (#1126)
+    - Make `--SnpGap` optionally filter also SNPs close to other variant types.
+      (#1126)
 
 * bcftools gtcheck:
 
-    - Complete revamp of the command. The new version is faster and allows N:M sample
-    comparisons, not just 1:N or NxN comparisons. Some functionality was lost (plotting
-    and clustering) but may be added back on popular demand.
+    - Complete revamp of the command. The new version is faster and allows
+      N:M sample comparisons, not just 1:N or NxN comparisons.
+      Some functionality was lost (plotting and clustering) but may be added
+      back on popular demand.
 
 * bcftools +mendelian:
 
-    - Revamp of user options, output VCFs with mendelian errors annotation, read PED files
-    (thanks to Giulio Genovese).
+    - Revamp of user options, output VCFs with mendelian errors annotation,
+      read PED files (thanks to Giulio Genovese).
 
 * bcftools merge:
 
-    -  Update headers when appropriate with the '--info-rules *:join' INFO rule. (#1282)
+    - Update headers when appropriate with the '--info-rules *:join' INFO rule.
+      (#1282)
 
-    -  Local alleles merging that produce LAA and LPL when requested, a draft implementation
-    of https://github.com/samtools/hts-specs/pull/434 (#1138)
+    - Local alleles merging that produce LAA and LPL when requested, a draft
+      implementation of https://github.com/samtools/hts-specs/pull/434 (#1138)
 
-    - New `--no-index` which allows to merge unindexed files. Requires the input files to
-    have chromosomes in th same order and consistent with the order of sequences in the header.
-    (PR #1253; samtools/htslib#1089)
+    - New `--no-index` which allows to merge unindexed files. Requires the input
+      files to have chromosomes in th same order and consistent with the order
+      of sequences in the header. (PR #1253; samtools/htslib#1089)
 
     - Fixes in gVCF merging. (#1127; #1164)
 
 * bcftools norm:
 
-    - Fixes in `--check-ref s` reference setting features with non-ACGT bases (#473; #1300)
+    - Fixes in `--check-ref s` reference setting features with non-ACGT bases.
+      (#473; #1300)
 
-    - New `--keep-sum` switch to keep vector sum constant when splitting multiallelics. (#360)
+    - New `--keep-sum` switch to keep vector sum constant when splitting
+      multiallelics. (#360)
 
 * bcftools +prune:
 
-    - Extend to allow annotating with various LD metrics: r^2, Lewontin's D' (PMID:19433632),
-    or Ragsdale's D (PMID:31697386).
+    - Extend to allow annotating with various LD metrics: r^2,
+      Lewontin's D' (PMID:19433632), or Ragsdale's D (PMID:31697386).
 
 * bcftools query:
 
-    - New `%N_PASS()` formatting expression to output the number of samples that pass the filtering
-    expression. 
+    - New `%N_PASS()` formatting expression to output the number of samples
+      that pass the filtering expression.
 
 * bcftools reheader:
 
-    - Improved error reporting to prevent user mistakes (#1288)
+    - Improved error reporting to prevent user mistakes. (#1288)
 
 * bcftools roh:
 
     - Several fixes and improvements
-        - the `--AF-file` description incorrectly suggested "REF\tALT" instead of the correct "REF,ALT". (#1142)
+        - the `--AF-file` description incorrectly suggested "REF\tALT" instead
+          of the correct "REF,ALT". (#1142)
         - RG lines could have negative length. (#1144)
         - new `--include-noalt` option to allow also ALT=. records. (#1137)
 
 * bcftools scatter:
 
-    - New plugin intended as a convenient inverse to `concat` (thanks to Giulio Genovese, PR #1249)
+    - New plugin intended as a convenient inverse to `concat`
+      (thanks to Giulio Genovese, PR #1249)
 
 * bcftools +split:
 
-    - New `--groups-file` option for more flexibility of defining desired output. (#1240)
+    - New `--groups-file` option for more flexibility of defining desired
+      output. (#1240)
 
-    - New `--hts-opts` option to reduce required memory by reusing one output header and allow
-    overriding the default hFile's block size with `--hts-opts block_size=XXX`. On some file
-    systems (lustre) the default size can be 4M which becomes a problem when splitting files with 10+
-    samples.
+    - New `--hts-opts` option to reduce required memory by reusing one
+      output header and allow overriding the default hFile's block size
+      with `--hts-opts block_size=XXX`. On some file systems (lustre) the
+      default size can be 4M which becomes a problem when splitting files
+      with 10+ samples.
 
     - Add support for multisample output and sample renaming
 
 * bcftools +split-vep:
 
-    - Add default types (Integer, Float, String) for VEP subfields and make `--columns -` extract
-    all subfields into INFO tags in one go.
-
+    - Add default types (Integer, Float, String) for VEP subfields and make
+      `--columns -` extract all subfields into INFO tags in one go.
 
 
 ## Release 1.10.2 (19th December 2019)
@@ -403,7 +414,7 @@ previous deliverables.
 * New `sort` command.
 
 * New options added to the `consensus` command. Note that the `-i, --iupac`
-  option has been renamed to `-I, --iupac`, in favor of the standard 
+  option has been renamed to `-I, --iupac`, in favor of the standard
   `-i, --include`.
 
 * Filtering expressions (`-i/-e`): support for `GT=<type>` expressions and

--- a/misc/gff2gff.py
+++ b/misc/gff2gff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This is script was contributed by Philip Ashton (https://github.com/flashton2003)
 # with the intention to convert from the many GFF flavours to the Ensembl GFF3 format


### PR DESCRIPTION
Rewrap new NEWS lines to 80 columns for legibility on narrower windows, and indent them similarly to previous entries.

Add _misc/gff2gff.py_ to `$(MISC_SCRIPTS)` so that it is installed alongside the other misc scripts (most of them, anyway).

Change _misc/gff2gff.py_ to be executable, and change its `#!` line as it uses some Python 3 syntax. This new script is also missing the usual copyright message and licensing boilerplate, but this PR doesn't address that.