### PR TITLE
Appveyor updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,11 +5,6 @@ version: 'vers.{build}'
 
 # branches to build
 branches:
-    # Whitelist
-    only:
-      - develop
-
-    # Blacklist
     except:
       - gh-pages
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,9 @@ skip_tags: true
 #    - docs/*
 #    - '**/*.html'
 
+# Appveyor Windows images are based on Visual studio version
+image: Visual Studio 2019
+
 # We use Mingw/Msys, so use pacman for installs
 install:
   - set HOME=.


### PR DESCRIPTION
Upgrade the image used by Appveyor.  This is necessary to get the new keys and pacman version required for MSYS2.

Also remove a restriction that made it only build the develop branch, so that other branches can be checked before turning them into pull requests.