### PR TITLE
Update CI test configuration to recurse htslib submodules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,15 +35,15 @@ install:
 clone_script:
   - "sh -lc \"if test x$APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME != x ; then git clone --branch=$APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH https://github.com/$APPVEYOR_PULL_REQUEST_HEAD_REPO_NAME $APPVEYOR_BUILD_FOLDER ; else false ; fi || git clone --branch=$APPVEYOR_REPO_BRANCH https://github.com/$APPVEYOR_REPO_NAME $APPVEYOR_BUILD_FOLDER\""
   - "sh -lc \"git show-branch --sha1-name HEAD"
-  - "sh -lc \"git clone --branch=$APPVEYOR_REPO_BRANCH https://github.com/`echo $APPVEYOR_REPO_NAME|sed 's#/bcftools#/htslib#'`.git $APPVEYOR_BUILD_FOLDER/htslib || git clone https://github.com/samtools/htslib.git $APPVEYOR_BUILD_FOLDER/htslib \""
+  - "sh -lc \"git clone --recurse-submodules --shallow-submodules --branch=$APPVEYOR_REPO_BRANCH https://github.com/`echo $APPVEYOR_REPO_NAME|sed 's#/bcftools#/htslib#'`.git $APPVEYOR_BUILD_FOLDER/htslib || git clone --recurse-submodules --shallow-submodules https://github.com/samtools/htslib.git $APPVEYOR_BUILD_FOLDER/htslib \""
   - "sh -lc \"cd $APPVEYOR_BUILD_FOLDER/htslib && git show-branch --sha1-name HEAD\""
 
 build_script:
   - set HOME=.
   - set MSYSTEM=MINGW64
   - set PATH=C:/msys64/usr/bin;C:/msys64/mingw64/bin;%PATH%
-  - "sh -lc \"(cd htslib; aclocal && autoheader && autoconf)\""
-  - "sh -lc \"aclocal && autoheader && autoconf && ./configure && make -j2\""
+  - "sh -lc \"(cd htslib; autoreconf -i)\""
+  - "sh -lc \"autoreconf -i && ./configure && make -j2\""
 
 test_script:
   - set HOME=.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,8 +32,8 @@ compile_template: &COMPILE
 
   compile_script: |
     if test "$USE_CONFIG" = "yes"; then
-      (cd $HTSDIR && autoreconf)
-      autoreconf
+      (cd $HTSDIR && autoreconf -i)
+      autoreconf -i
       ./configure || (cat config.log; /bin/false)
       make -j3
     else
@@ -89,7 +89,9 @@ ubuntu_task:
   matrix:
     - environment:
        USE_CONFIG: no
-    - environment:
+    - container:
+       memory: 2G
+      environment:
        USE_CONFIG: yes
        CFLAGS: -g -Wall -O3 -fsanitize=address
        LDFLAGS: -fsanitize=address -Wl,-rpath,`pwd`/inst/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ before_script:
 
 script: |
   if test "$USE_CONFIG" = "yes"; then
-    ( cd "$HTSDIR" && autoreconf ) && \
-    autoreconf && \
+    ( cd "$HTSDIR" && autoreconf -i) && \
+    autoreconf -i && \
     ./configure && \
     make && \
     make test

--- a/.travis/clone
+++ b/.travis/clone
@@ -14,4 +14,4 @@ ref=''
 [ -z "$ref" ] && repository='git://github.com/samtools/htslib.git'
 
 set -x
-git clone --depth=1 ${ref:+--branch="$branch"} "$repository" "$localdir"
+git clone --recurse-submodules --shallow-submodules --depth=1 ${ref:+--branch="$branch"} "$repository" "$localdir"


### PR DESCRIPTION
In anticipation of samtools/htslib#929 merge, which adds a submodule.

Also makes everything use autoreconf -i when setting up HTSlib as that will be required for autoconf 2.70.

Increases the memory limit for the address sanitizer cirrus-ci test.  While the average memory used seems to be low, occasionally some test processes may get big enough to trigger an out of memory killer.

Note that both Travis and cirrus-ci use the .travis/clone script.