### PR TITLE
Improve the Mann Whitney U test.

### DIFF
--- a/bam2bcf.h
+++ b/bam2bcf.h
@@ -41,6 +41,10 @@ DEALINGS IN THE SOFTWARE.  */
 #define CDF_MWU_TESTS 0
 #endif
 
+// Use calc_mwu_biasZ as a sd-normalised score centred on 0 instead of the
+// old method with values in the range 0 to 1.
+//#define MWU_ZSCORE
+
 #define B2B_INDEL_NULL 10000
 
 #define B2B_FMT_DP      (1<<0)

--- a/mpileup.c
+++ b/mpileup.c
@@ -546,11 +546,19 @@ static int mpileup(mplp_conf_t *conf)
     bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=DP,Number=1,Type=Integer,Description=\"Raw read depth\">");
     if ( conf->fmt_flag&B2B_INFO_VDB )
         bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=VDB,Number=1,Type=Float,Description=\"Variant Distance Bias for filtering splice-site artefacts in RNA-seq data (bigger is better)\",Version=\"3\">");
+#ifdef MWU_ZSCORE
+    if ( conf->fmt_flag&B2B_INFO_RPB )
+        bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=RPBZ,Number=1,Type=Float,Description=\"Mann-Whitney U-z test of Read Position Bias (closer to 0 is better)\">");
+    bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=MQBZ,Number=1,Type=Float,Description=\"Mann-Whitney U-z test of Mapping Quality Bias (closer to 0 is better)\">");
+    bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=BQBZ,Number=1,Type=Float,Description=\"Mann-Whitney U-z test of Base Quality Bias (closer to 0 is better)\">");
+    bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=MQSBZ,Number=1,Type=Float,Description=\"Mann-Whitney U-z test of Mapping Quality vs Strand Bias (closer to 0 is better)\">");
+#else
     if ( conf->fmt_flag&B2B_INFO_RPB )
         bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=RPB,Number=1,Type=Float,Description=\"Mann-Whitney U test of Read Position Bias (bigger is better)\">");
     bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=MQB,Number=1,Type=Float,Description=\"Mann-Whitney U test of Mapping Quality Bias (bigger is better)\">");
     bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=BQB,Number=1,Type=Float,Description=\"Mann-Whitney U test of Base Quality Bias (bigger is better)\">");
     bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=MQSB,Number=1,Type=Float,Description=\"Mann-Whitney U test of Mapping Quality vs Strand Bias (bigger is better)\">");
+#endif
 #if CDF_MWU_TESTS
     bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=RPB2,Number=1,Type=Float,Description=\"Mann-Whitney U test of Read Position Bias [CDF] (bigger is better)\">");
     bcf_hdr_append(conf->bcf_hdr,"##INFO=<ID=MQB2,Number=1,Type=Float,Description=\"Mann-Whitney U test of Mapping Quality Bias [CDF] (bigger is better)\">");


### PR DESCRIPTION
There are several main changes here.

1. A new implementation of the Mann Whitney U test.  The new code was
based on Wikipedia and reading of the GATK source (which very strongly
matches the Wikipedia article).  So far I am uncertain what the impact
of this has.

2. The U score is turned to a probability from 0 to 1 based on how
similar the distributions in a and b are.  However some tests are
asymmetric. Mapping Quality Bias (MQB) will have higher MQ for REF
than ALT as obviously sequencing differences reduce MQ.  In the code,
any absolute difference between U and mean reduces p towards 0,
however for MQB U substantially above mean is usually correct and U
substantially below is usually incorrect.  We have a function option
to avoid returning p values for U > mean.

3. An optional Z score alternative to U.  This returns the number of
standard deviations that U is away from mean, as either a +ve or
negative score.  This permits filters to explicitly test one or both
ends, eg -e "MQB < -4 || RPB < -5 || RPB > +5".  The numbers are also
an easier range to grasp than needing tiny numbers (eg "MQB < 1e-5 ||
RPB < 1e-6").

Currently the Z-score variant is #ifdefed out.  If enabled it will
generate new tags named MQBZ, BQBZ, RPBZ and MQSBZ.