### PR TITLE
Reformat NEWS to be legible on an 80-column terminal

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,10 +2,11 @@
 
 Changes affecting the whole of bcftools, or multiple commands:
 
-* The output file type (-O, --output-type) needs not to be specified anymore
-  and is determined from the output file name suffix.
+* The output file type is determined from the output file name suffix, where
+  available, so the -O/--output-type option is often no longer necessary.
 
-* Make F_MISSING in filtering expressions work for sites with multiple ALT alleles (#1343)
+* Make F_MISSING in filtering expressions work for sites with multiple
+  ALT alleles (#1343)
 
 
 Changes affecting specific commands:
@@ -14,32 +15,35 @@ Changes affecting specific commands:
 
     - New `--rename-annots` option to help fix broken VCFs (#1335)
 
-    - New -C option allows to read a long list of options from a file to prevent very
-      long command lines.
+    - New -C option allows to read a long list of options from a file to
+      prevent very long command lines.
 
-    - New `append-missing` logic allows annotations to be added for each ALT allele in the
-      same order as they appear in the VCF. Note that this is not bullet proof. In order for
-      this to work:
+    - New `append-missing` logic allows annotations to be added for each ALT
+      allele in the same order as they appear in the VCF. Note that this is
+      not bullet proof. In order for this to work:
 
         - the annotation file must have one line per ALT allele
 
-        - fields must contain a single value as multiple values are appended as they are and
-          would break the correspondence between the alleles and values
+        - fields must contain a single value as multiple values are appended
+          as they are and would break the correspondence between the alleles
+          and values
 
 * bcftools concat:
 
-    - Do not phase genotypes by mistake if they are not already phased with `-l` (#1346)
+    - Do not phase genotypes by mistake if they are not already phased
+      with `-l` (#1346)
 
 * bcftools consensus:
 
-    - New `--mask-with`, `--mark-del`, `--mark-ins`, `--mark-snv` (#1382, #1381, #1170)
+    - New `--mask-with`, `--mark-del`, `--mark-ins`, `--mark-snv` options
+      (#1382, #1381, #1170)
 
-    - Symbolic <DEL> should have only one REF base. If there are multiple, take POS+1
-      as the first deleted base.
+    - Symbolic <DEL> should have only one REF base. If there are multiple,
+      take POS+1 as the first deleted base.
 
-    - Make consensus work when the first base of the reference genome is deleted. In this
-      situation the VCF record has POS=1 and the first REF base cannot precede the event.
-      (#1330)
+    - Make consensus work when the first base of the reference genome is
+      deleted. In this situation the VCF record has POS=1 and the first
+      REF base cannot precede the event. (#1330)
 
 * bcftools +contrast:
 
@@ -47,49 +51,53 @@ Changes affecting specific commands:
 
 * bcftools convert:
 
-    - Make the --hapsample and --hapsample2vcf options consistent with each other
-      and with the documentation.
+    - Make the --hapsample and --hapsample2vcf options consistent with each
+      other and with the documentation.
 
 * bcftools call:
 
-    - Revamp of `call -G`, previously sample grouping by population was not truly independent
-      and could still be influenced by the presence of other sample groups.
-
-    - Explicit --group-samples-tag option instead of the --group-samples TAG:file
-      functionality (#1370)
+    - Revamp of `call -G`, previously sample grouping by population was not
+      truly independent and could still be influenced by the presence of other
+      sample groups.
 
     - Optional addition of INFO/PV4 annotation with `call -a INFO/PV4`
 
-    - Remove generation of useless HOB and ICB annotation; use +fill-tags -- -t HWE,ExcHet` instead
+    - Remove generation of useless HOB and ICB annotation;
+      use `+fill-tags -- -t HWE,ExcHet` instead
 
-    - The `call -f` option was renamed to `-a` to (1) make it consistent with `mpileup` and (2) to indicate
-      that it includes both INFO and FORMAT annotations, not just FORMAT as previously
+    - The `call -f` option was renamed to `-a` to (1) make it consistent with
+      `mpileup` and (2) to indicate that it includes both INFO and FORMAT
+      annotations, not just FORMAT as previously
 
-    - Any sensible Number=R,Type=Integer annotation can be used with -G, such as AD or QS
+    - Any sensible Number=R,Type=Integer annotation can be used with -G,
+      such as AD or QS
 
-    - Don't trim QUAL; although usefuleness of this change is questionable for true probabilistic
-      interpretation (such high precision is unrealistic), using QUAL as a score rather than probability
-      is helpful and permits more fine-grained filtering
+    - Don't trim QUAL; although usefuleness of this change is questionable for
+      true probabilistic interpretation (such high precision is unrealistic),
+      using QUAL as a score rather than probability is helpful and permits more
+      fine-grained filtering
 
-    - Fix a suspected bug in `call -F` in the worst case, for certain improve readability
+    - Fix a suspected bug in `call -F` in the worst case, for certain improve
+      readability
 
     - `call -C trio` is temporarily disabled
 
 * bcftools +fill-tags:
 
-    - MAF definition revised for multiallelic sites, the second most common allele is considered to be the
-      minor allele (#1313)
+    - MAF definition revised for multiallelic sites, the second most common
+      allele is considered to be the minor allele (#1313)
 
-* bcftools gtchecK:
+* bcftools gtcheck:
 
-    - support matching of a single sample against all other samples in the file with
-      `-s qry:sample -s gt:-`. This was previously not possible, either full cross-check mode had to be run or
-      a list of pairs/samples had to be created explicitly
+    - support matching of a single sample against all other samples in the file
+      with `-s qry:sample -s gt:-`. This was previously not possible, either
+      full cross-check mode had to be run or a list of pairs/samples had to
+      be created explicitly
 
 * bcftools merge:
 
-    - Make `merge -R` behavior consistent with other commands and pull in overlapping
-      records with POS outside of the regions (#1374)
+    - Make `merge -R` behavior consistent with other commands and pull in
+      overlapping records with POS outside of the regions (#1374)
 
     - Bug fix (#1353)
 
@@ -117,14 +125,15 @@ Changes affecting specific commands:
 
 * bcftools +trio-dnm2:
 
-    - Major revamp of +trio-dnm plugin, which is now deprecated and replaced with
+    - Major revamp of +trio-dnm plugin, which is now deprecated and replaced by
       +trio-dnm2.
 
       The original trio-dnm calling model used genotype likelihoods (PLs) as the
-      input for calling. However, that is flawed because PLs make assumptions which
-      are unsuitable for de novo calling: PL(RR) can become bigger than PL(RA) even
-      when the ALT allele is present in the parents. Note that this is true also
-      for other programs such as DeNovoGear which rely on the same samtools calculation.
+      input for calling. However, that is flawed because PLs make assumptions
+      which are unsuitable for de novo calling: PL(RR) can become bigger than
+      PL(RA) even when the ALT allele is present in the parents. Note that
+      this is true also for other programs such as DeNovoGear which rely on
+      the same samtools calculation.
 
       The new recommended workflow is
 
@@ -132,11 +141,10 @@ Changes affecting specific commands:
            bcftools call -mv -Ou |
            bcftools +trio-dnm -p proband,father,mother -Oz -o output.vcf.gz
 
-      This new version also implements the DeNovoGear model. The original behavior of trio-dnm
-      is no longer supported.
+      This new version also implements the DeNovoGear model. The original
+      behavior of trio-dnm is no longer supported.
 
       For more details see http://samtools.github.io/bcftools/trio-dnm.pdf
-
 
 
 ## Release 1.11 (22nd September 2020)


### PR DESCRIPTION
Clarify `-O`/`--output-type` entry.
Remove mention of `--group-samples TAG:file` as that was not present in the previous 1.11 release.