### PR TITLE
Add new --atomize and --old-rec-tag options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ OBJS     = main.o vcfindex.o tabix.o \
            vcfcnv.o HMM.o consensus.o ploidy.o bin.o hclust.o version.o \
            regidx.o smpl_ilist.o csq.o vcfbuf.o \
            mpileup.o bam2bcf.o bam2bcf_indel.o bam_sample.o \
-           vcfsort.o cols.o extsort.o dist.o \
+           vcfsort.o cols.o extsort.o dist.o abuf.o \
            ccall.o em.o prob1.o kmin.o
 PLUGIN_OBJS = vcfplugin.o
 
@@ -229,6 +229,7 @@ ploidy_h = ploidy.h regidx.h
 prob1_h = prob1.h $(htslib_vcf_h) $(call_h)
 smpl_ilist_h = smpl_ilist.h $(htslib_vcf_h)
 vcfbuf_h = vcfbuf.h $(htslib_vcf_h)
+abuf_h = abuf.h $(htslib_vcf_h)
 bam2bcf_h = bam2bcf.h $(htslib_hts_h) $(htslib_vcf_h)
 bam_sample_h = bam_sample.h $(htslib_sam_h)
 
@@ -243,7 +244,7 @@ vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htsli
 vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(bcftools_h)
 vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(bcftools_h) $(filter_h)
 vcfmerge.o: vcfmerge.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_faidx_h) regidx.h $(bcftools_h) vcmp.h $(htslib_khash_h)
-vcfnorm.o: vcfnorm.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_faidx_h) $(htslib_khash_str2int_h) $(bcftools_h) rbuf.h
+vcfnorm.o: vcfnorm.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_faidx_h) $(htslib_khash_str2int_h) $(bcftools_h) rbuf.h abuf.h
 vcfquery.o: vcfquery.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_khash_str2int_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h)
 vcfroh.o: vcfroh.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(bcftools_h) HMM.h $(smpl_ilist_h) $(filter_h)
 vcfcnv.o: vcfcnv.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kstring_h) $(htslib_kfunc_h) $(htslib_khash_str2int_h) $(bcftools_h) HMM.h rbuf.h
@@ -280,6 +281,7 @@ version.o: version.h version.c
 hclust.o: hclust.c $(htslib_hts_h) $(htslib_kstring_h) $(bcftools_h) hclust.h
 HMM.o: HMM.c $(htslib_hts_h) HMM.h
 vcfbuf.o: vcfbuf.c $(htslib_vcf_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(bcftools_h) $(vcfbuf_h) rbuf.h
+abuf.o: abuf.c $(htslib_vcf_h) $(bcftools_h) rbuf.h abuf.h
 extsort.o: extsort.c $(bcftools_h) extsort.h kheap.h
 smpl_ilist.o: smpl_ilist.c $(bcftools_h) $(smpl_ilist_h)
 csq.o: csq.c $(htslib_hts_h) $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_khash_h) $(htslib_khash_str2int_h) $(htslib_kseq_h) $(htslib_faidx_h) $(bcftools_h) $(filter_h) regidx.h kheap.h $(smpl_ilist_h) rbuf.h

--- a/NEWS
+++ b/NEWS
@@ -119,6 +119,13 @@ Changes affecting specific commands:
 
     - Add new optional tag `mpileup -a FORMAT/QS`
 
+* bcftools norm:
+
+    - New `-a, --atomize` functionality to decompose complex variants,
+      for example MNVs into consecutive SNVs
+
+    - New option `--old-rec-tag` to indicate the original variant
+
 * bcftools +prune:
 
     - New options --random-seed and --nsites-per-win-mode (#1050)

--- a/abuf.c
+++ b/abuf.c
@@ -1,0 +1,665 @@
+/* The MIT License
+
+   Copyright (c) 2021 Genome Research Ltd.
+
+   Author: Petr Danecek <pd3@sanger.ac.uk>
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+ */
+
+#include <assert.h>
+#include <strings.h>
+#include <htslib/vcf.h>
+#include <ctype.h>
+#include "bcftools.h"
+#include "abuf.h"
+#include "rbuf.h"
+
+typedef struct
+{
+    kstring_t ref, alt;
+    int ial;        // the index of the original ALT allele, 1-based
+    int beg, end;   // 0-based inclusive offsets to ref,alt
+}
+atom_t;
+
+typedef struct
+{
+    bcf1_t *rec;
+    int nori, nout;     // number of ALTs in the input, and VCF rows on output
+    uint8_t *tbl;       // nori columns, nout rows
+    uint8_t *overlaps;  // is the star allele needed for this variant?
+    atom_t **atoms;
+    int matoms, mtbl, moverlaps;
+    char *info_tag;
+}
+split_t;
+
+struct _abuf_t
+{
+    abuf_opt_t mode;
+    split_t split;
+    atom_t *atoms;
+    int natoms, matoms;
+    const bcf_hdr_t *hdr;
+    bcf_hdr_t *out_hdr;
+    bcf1_t **vcf;       // dimensions stored in rbuf
+    rbuf_t rbuf;
+
+    kstring_t tmps;
+    void *tmp, *tmp2;
+    int32_t *gt, *tmpi;
+    int ngt, mgt, ntmpi, mtmpi, mtmp, mtmp2;
+    int star_allele;
+};
+
+abuf_t *abuf_init(const bcf_hdr_t *hdr, abuf_opt_t mode)
+{
+    if ( mode!=SPLIT ) error("todo\n");
+    abuf_t *buf = (abuf_t*) calloc(1,sizeof(abuf_t));
+    buf->hdr  = hdr;
+    buf->out_hdr = (bcf_hdr_t*) hdr;
+    buf->mode = mode;
+    buf->star_allele = 1;
+    rbuf_init(&buf->rbuf, 0);
+    return buf;
+}
+
+void abuf_destroy(abuf_t *buf)
+{
+    int i;
+    for (i=0; i<buf->matoms; i++)
+    {
+        free(buf->atoms[i].ref.s);
+        free(buf->atoms[i].alt.s);
+    }
+    free(buf->atoms);
+    free(buf->split.atoms);
+    free(buf->split.overlaps);
+    free(buf->split.tbl);
+    for (i=0; i<buf->rbuf.m; i++)
+        if ( buf->vcf[i] ) bcf_destroy(buf->vcf[i]);
+    free(buf->vcf);
+    free(buf->gt);
+    free(buf->tmpi);
+    free(buf->tmp);
+    free(buf->tmp2);
+    free(buf->tmps.s);
+    free(buf);
+}
+
+void abuf_set(abuf_t *buf, abuf_opt_t key, void *value)
+{
+    if ( key==BCF_HDR ) { buf->out_hdr = *((bcf_hdr_t**)value); return; }
+    if ( key==INFO_TAG )
+    {
+        buf->split.info_tag = *((char**)value);
+        bcf_hdr_printf(buf->out_hdr,"##INFO=<ID=%s,Number=1,Type=String,Description=\"Original variant. Format: CHR|POS|REF|ALT|USED_ALT_IDX\">",buf->split.info_tag); 
+        return;
+    }
+    if ( key==STAR_ALLELE ) { buf->star_allele = *((int*)value); return; }
+}
+
+/*
+    Split alleles into primitivs, e.g.
+        CC>TT  becomes  C>T,C>T
+        GCGT>GTGA  becomes C>T,T>A
+
+    There is no sequence alignment, just trimming and hungry matching
+    from left side.
+*/
+static void _atomize_allele(abuf_t *buf, bcf1_t *rec, int ial)
+{
+    // Trim identical sequence from right
+    char *ref = rec->d.allele[0];
+    char *alt = rec->d.allele[ial];
+    int rlen = strlen(ref);
+    int alen = strlen(alt);
+    while ( rlen>1 && alen>1 && ref[rlen-1]==alt[alen-1] ) rlen--, alen--;
+    int Mlen = rlen > alen ? rlen : alen;
+
+    atom_t *atom = NULL; 
+    int i;
+    for (i=0; i<Mlen; i++)
+    {
+        char refb = i<rlen ? ref[i] : '-';
+        char altb = i<alen ? alt[i] : '-';
+        if ( refb!=altb )
+        {
+            if ( refb=='-' || altb=='-' )
+            {
+                assert(atom);
+                if ( altb!='-' ) kputc(altb, &atom->alt);
+                if ( refb!='-' ) { kputc(refb, &atom->ref); atom->end++; }
+            }
+            else
+            {
+                buf->natoms++;
+                hts_expand0(atom_t,buf->natoms,buf->matoms,buf->atoms);
+                atom = &buf->atoms[buf->natoms-1];
+                atom->ref.l = 0;
+                atom->alt.l = 0;
+                kputc(refb, &atom->ref);
+                kputc(altb, &atom->alt);
+                atom->beg = atom->end = i;
+                atom->ial = ial;
+            }
+            continue;
+        }
+        if ( i+1>=rlen || i+1>=alen )   // is the next base a deletion?
+        {
+            buf->natoms++;
+            hts_expand0(atom_t,buf->natoms,buf->matoms,buf->atoms);
+            atom = &buf->atoms[buf->natoms-1];
+            atom->ref.l = 0;
+            atom->alt.l = 0;
+            kputc(refb, &atom->ref);
+            kputc(altb, &atom->alt);
+            atom->beg = atom->end = i;
+            atom->ial = ial;
+        }
+    }
+}
+static int _atoms_inconsistent(const atom_t *a, const atom_t *b)
+{
+    if ( a->beg < b->beg ) return -1;
+    if ( a->beg > b->beg ) return 1;
+    int rcmp = strcasecmp(a->ref.s,b->ref.s);
+    if ( rcmp ) return rcmp;
+    return strcasecmp(a->alt.s,b->alt.s);
+}
+/*
+    For reproducibility of tests on different platforms, we need to guarantee the same order of identical
+    atoms originating from different source ALTs.  Even though they are consistent, different values can be
+    picked for VCF annotations as currently the values from the one that comes first are used.
+*/
+static int _cmp_atoms(const void *aptr, const void *bptr)
+{
+    const atom_t *a = (const atom_t*) aptr;
+    const atom_t *b = (const atom_t*) bptr;
+    int rcmp = _atoms_inconsistent(a,b);
+    if ( rcmp ) return rcmp;
+    if ( a->ial < b->ial ) return -1;
+    if ( a->ial > b->ial ) return 1;
+    return 0;
+}
+static void _split_table_init(abuf_t *buf, bcf1_t *rec, int natoms)
+{
+    buf->split.rec  = rec;
+    buf->split.nori = rec->n_allele - 1;
+    buf->split.nout = 0;
+    hts_expand(uint8_t,buf->split.nori*natoms,buf->split.mtbl,buf->split.tbl);
+    hts_expand(atom_t*,natoms,buf->split.matoms,buf->split.atoms);
+    hts_expand(uint8_t,natoms,buf->split.moverlaps,buf->split.overlaps);
+    memset(buf->split.overlaps,0,sizeof(*buf->split.overlaps)*natoms);
+}
+static void _split_table_new(abuf_t *buf, atom_t *atom)
+{
+    int i, iout = buf->split.nout++;
+    buf->split.atoms[iout] = atom;
+    uint8_t *ptr = buf->split.tbl + iout*buf->split.nori;
+    for (i=0; i<buf->split.nori; i++) ptr[i] = 0;
+    ptr[atom->ial-1] = 1;
+}
+static void _split_table_overlap(abuf_t *buf, int iout, atom_t *atom)
+{
+    uint8_t *ptr = buf->split.tbl + iout*buf->split.nori;
+    ptr[atom->ial-1] = _atoms_inconsistent(atom,buf->split.atoms[iout]) ? 2 : 1;
+    buf->split.overlaps[iout] = 1;
+}
+#if 0
+static void _split_table_print(abuf_t *buf)
+{
+    int i,j;
+    for (i=0; i<buf->split.nout; i++)
+    {
+        atom_t *atom = buf->split.atoms[i];
+        uint8_t *ptr = buf->split.tbl + i*buf->split.nori;
+        fprintf(stderr,"%d\t%s\t%s",(int)buf->split.rec->pos+1+atom->beg,atom->ref.s,atom->alt.s);
+        for (j=0; j<buf->split.nori; j++) fprintf(stderr,"\t%d",(int)ptr[j]);
+        fprintf(stderr,"\n");
+    }
+}
+static void _split_table_print_atoms(abuf_t *buf)
+{
+    int i;
+    for (i=0; i<buf->natoms; i++)
+    {
+        atom_t *atom = &buf->atoms[i];
+        fprintf(stderr,"atom%d %p: ialt=%d %s>%s %d-%d\n",i,atom,atom->ial,atom->ref.s,atom->alt.s,atom->beg,atom->end);
+    }
+}
+#endif
+static inline uint8_t _has_star_allele(abuf_t *buf, int iout)
+{
+    if ( !buf->star_allele ) return 0;
+    return buf->split.overlaps[iout];
+}
+static inline int _split_table_get_ial(abuf_t *buf, int irow, int ial)
+{
+    if ( !ial ) return ial;
+    return buf->split.tbl[irow*buf->split.nori + ial - 1];
+}
+static void _split_table_set_chrom_qual(abuf_t *buf)
+{
+    int iout,j;
+    bcf1_t *rec = buf->split.rec;
+    for (iout=0; iout<buf->split.nout; iout++)
+    {
+        rbuf_expand0(&buf->rbuf, bcf1_t*, buf->rbuf.n+1, buf->vcf);
+        j = rbuf_append(&buf->rbuf);
+        if ( !buf->vcf[j] ) buf->vcf[j] = bcf_init1();
+        bcf1_t *out = buf->vcf[j];
+        bcf_clear1(out);
+
+        atom_t *atom = buf->split.atoms[iout];
+        out->rid = rec->rid;
+        out->pos = rec->pos + atom->beg;
+        bcf_update_id(buf->out_hdr, out, rec->d.id);
+
+        const char *als[3];
+        als[0] = atom->ref.s;
+        als[1] = atom->alt.s;
+        als[2] = "*";
+        int nals = _has_star_allele(buf,iout) ? 3 : 2;
+        bcf_update_alleles(buf->out_hdr, out, als, nals);
+
+        if ( bcf_float_is_missing(rec->qual) )
+            bcf_float_set_missing(out->qual);
+        else
+            out->qual = rec->qual;
+
+        bcf_update_filter(buf->out_hdr, out, rec->d.flt, rec->d.n_flt);
+    }
+}
+static void _split_table_set_info(abuf_t *buf, bcf_info_t *info)
+{
+    const char *tag = bcf_hdr_int2id(buf->hdr,BCF_DT_ID,info->key);
+    int type = bcf_hdr_id2type(buf->hdr,BCF_HL_INFO,info->key);
+    int len  = bcf_hdr_id2length(buf->hdr,BCF_HL_INFO,info->key);
+    if ( len==BCF_VL_G ) return;                                                // todo: Number=G INFO tags
+    if ( type==BCF_HT_STR && len!=BCF_VL_FIXED && len!=BCF_VL_VAR ) return;     // todo: Number=A,R,G for strings
+    if ( type==BCF_HT_LONG ) return;                                            // todo: 64bit integers
+
+    bcf1_t *rec = buf->split.rec;
+    int mtmp = ( type==BCF_HT_INT || type==BCF_HT_REAL ) ? buf->mtmp/4 : buf->mtmp;
+    int nval = bcf_get_info_values(buf->hdr,rec,tag,&buf->tmp,&mtmp,type);
+    if ( type==BCF_HT_INT || type==BCF_HT_REAL ) buf->mtmp = mtmp*4;
+
+    if ( (len==BCF_VL_A && nval != rec->n_allele - 1) || (len==BCF_VL_R && nval != rec->n_allele) )
+        error("Incorrect number of values at %s:%"PRIhts_pos" .. tag=INFO/%s Number=%c nAlleles=%d nValues=%d\n",
+                bcf_seqname(buf->hdr,rec),rec->pos+1,tag,len==BCF_VL_A?'A':'R',rec->n_allele,nval);
+
+    if ( buf->mtmp2 < buf->mtmp )
+    {
+        buf->tmp2  = realloc(buf->tmp2, buf->mtmp);
+        if ( !buf->tmp2 ) error("Failed to alloc %d bytes\n", buf->mtmp);
+        buf->mtmp2 = buf->mtmp;
+    }
+    
+    int32_t missing = bcf_int32_missing;
+    void *missing_ptr = (void*)&missing;
+    if ( type==BCF_HT_REAL ) bcf_float_set_missing(*((float*)missing_ptr));
+
+    int iout;
+    for (iout=0; iout<buf->split.nout; iout++)
+    {
+        bcf1_t *out = buf->vcf[rbuf_kth(&buf->rbuf,iout)];
+        int star_allele = _has_star_allele(buf,iout);
+        int ret = 0;
+        if ( len==BCF_VL_FIXED || len==BCF_VL_VAR )
+            ret = bcf_update_info(buf->out_hdr, out, tag, buf->tmp, nval, type);
+        else if ( len==BCF_VL_A )
+        {
+            int iori = buf->split.atoms[iout]->ial - 1;
+            assert( iori<nval );
+            memcpy(buf->tmp2,buf->tmp+4*iori,4);
+            if ( star_allele )
+                memcpy(buf->tmp2+4,missing_ptr,4);
+            ret = bcf_update_info(buf->out_hdr, out, tag, buf->tmp2, 1 + star_allele, type);
+        }
+        else if ( len==BCF_VL_R )
+        {
+            int iori = buf->split.atoms[iout]->ial;
+            assert( iori < nval );
+            memcpy(buf->tmp2,buf->tmp,4);
+            memcpy(buf->tmp2+4,buf->tmp+4*iori,4);
+            if ( star_allele )
+                memcpy(buf->tmp2+8,missing_ptr,4);
+            ret = bcf_update_info(buf->out_hdr, out, tag, buf->tmp2, 2 + star_allele, type);
+        }
+        if ( ret!=0 ) error("An error occurred while updating INFO/%s\n",tag);
+    }
+}
+static void _split_table_set_history(abuf_t *buf)
+{
+    int i,j;
+    bcf1_t *rec = buf->split.rec;
+    buf->tmps.l = 0;
+    ksprintf(&buf->tmps,"%s|%"PRIhts_pos"|%s|",bcf_seqname(buf->hdr,rec),rec->pos+1,rec->d.allele[0]);
+    for (i=1; i<rec->n_allele; i++)
+    {
+        kputs(rec->d.allele[i],&buf->tmps);
+        if ( i+1<rec->n_allele ) kputc(',',&buf->tmps);
+        else kputc(',',&buf->tmps);
+    }
+    int len = buf->tmps.l;
+    buf->tmps.s[buf->tmps.l-1] = '|';
+
+    for (i=0; i<buf->split.nout; i++)
+    {
+        buf->tmps.l = len;
+        bcf1_t *out = buf->vcf[rbuf_kth(&buf->rbuf,i)];
+        uint8_t *ptr = buf->split.tbl + i*buf->split.nori;
+        for (j=0; j<buf->split.nori; j++)
+        {
+            if ( ptr[j]!=1 ) continue;
+            kputw(j+1,&buf->tmps);
+            kputc(',',&buf->tmps);
+        }
+        buf->tmps.s[--buf->tmps.l] = 0;
+        if ( (bcf_update_info_string(buf->out_hdr, out, buf->split.info_tag, buf->tmps.s))!=0 )
+            error("An error occurred while updating INFO/%s\n",buf->split.info_tag);
+    }
+}
+static void _split_table_set_gt(abuf_t *buf)
+{
+    int nsmpl = bcf_hdr_nsamples(buf->hdr);
+    if ( !nsmpl ) return;
+
+    bcf1_t *rec = buf->split.rec;
+    buf->ngt = bcf_get_genotypes(buf->hdr, rec, &buf->gt, &buf->mgt);
+    if ( buf->ngt<=0 ) return;
+    else
+        hts_expand(int32_t,buf->ngt,buf->mtmpi,buf->tmpi);
+
+    int iout,i,j;
+    for (iout=0; iout<buf->split.nout; iout++)
+    {
+        bcf1_t *out = buf->vcf[rbuf_kth(&buf->rbuf,iout)];
+        int star_allele = _has_star_allele(buf,iout);
+        int max_ploidy = buf->ngt/nsmpl;
+        int32_t *src = buf->gt, *dst = buf->tmpi;
+        for (i=0; i<nsmpl; i++)
+        {
+            for (j=0; j<max_ploidy; j++)
+            {
+                if ( src[j]==bcf_int32_vector_end || bcf_gt_is_missing(src[j]) )
+                {
+                    dst[j] = src[j];
+                    continue;
+                }
+                int iori = bcf_gt_allele(src[j]);
+                if ( iori<0 || iori>=rec->n_allele )
+                    error("Out-of-bounds genotypes at %s:%"PRIhts_pos"\n",bcf_seqname(buf->hdr,rec),rec->pos+1);
+                int ial = _split_table_get_ial(buf,iout,iori);
+                if ( ial==2 && !star_allele )
+                    dst[j] = bcf_gt_missing;
+                else
+                    dst[j] = bcf_gt_is_phased(src[j]) ? bcf_gt_phased(ial) : bcf_gt_unphased(ial);
+            }
+            src += max_ploidy;
+            dst += max_ploidy;
+        }
+        bcf_update_genotypes(buf->out_hdr,out,buf->tmpi,buf->ngt);
+    }
+}
+static void _split_table_set_format(abuf_t *buf, bcf_fmt_t *fmt)
+{
+    int nsmpl = bcf_hdr_nsamples(buf->hdr);
+    if ( !nsmpl ) return;
+
+    const char *tag = bcf_hdr_int2id(buf->hdr,BCF_DT_ID,fmt->id);
+    if ( tag[0]=='G' && tag[1]=='T' && !tag[2] )        // FORMAT/GT
+    {
+        _split_table_set_gt(buf);
+        return;
+    }
+
+    int type = bcf_hdr_id2type(buf->hdr,BCF_HL_FMT,fmt->id);
+    int len  = bcf_hdr_id2length(buf->hdr,BCF_HL_FMT,fmt->id);
+    if ( type==BCF_HT_STR && len!=BCF_VL_FIXED && len!=BCF_VL_VAR ) return;     // todo: Number=A,R,G for strings
+    if ( type==BCF_HT_LONG ) return;                                            // todo: 64bit integers
+
+    const int num_size = 4;
+    assert( num_size==sizeof(int32_t) && num_size==sizeof(float) );
+    int32_t missing = bcf_int32_missing;
+    void *missing_ptr = (void*)&missing;
+    if ( type==BCF_HT_REAL ) bcf_float_set_missing(*((float*)missing_ptr));
+
+    bcf1_t *rec = buf->split.rec;
+    int mtmp = ( type==BCF_HT_INT || type==BCF_HT_REAL ) ? buf->mtmp/num_size : buf->mtmp;
+    int nval = bcf_get_format_values(buf->hdr,rec,tag,&buf->tmp,&mtmp,type);
+    if ( type==BCF_HT_INT || type==BCF_HT_REAL ) buf->mtmp = mtmp*num_size;
+
+    if ( len==BCF_VL_G && nval!=nsmpl*rec->n_allele && nval!=nsmpl*rec->n_allele*(rec->n_allele+1)/2 ) return;      // not haploid nor diploid
+
+    if ( (len==BCF_VL_A && nval != nsmpl*(rec->n_allele - 1)) || (len==BCF_VL_R && nval != nsmpl*rec->n_allele) )
+        error("Incorrect number of values at %s:%"PRIhts_pos" .. tag=FORMAT/%s Number=%c nAlleles=%d nValues=%d\n",
+                bcf_seqname(buf->hdr,rec),rec->pos+1,tag,len==BCF_VL_A?'A':'R',rec->n_allele,nval);
+
+    // Increase buffer size to accommodate star allele
+    mtmp = buf->mtmp;
+    if ( (len==BCF_VL_A || len==BCF_VL_R) && mtmp < num_size*(nval+nsmpl) ) mtmp = num_size*(nval+nsmpl);
+    else if ( len==BCF_VL_G && mtmp < num_size*(nval+nsmpl*3) ) mtmp = num_size*(nval+nsmpl*3);
+
+    if ( buf->mtmp2 < mtmp )
+    {
+        buf->tmp2  = realloc(buf->tmp2, mtmp);
+        if ( !buf->tmp2 ) error("Failed to alloc %d bytes\n", mtmp);
+        buf->mtmp2 = mtmp;
+    }
+
+    int nval1 = nval / nsmpl;
+    int iout, i, j;
+    for (iout=0; iout<buf->split.nout; iout++)
+    {
+        int star_allele = _has_star_allele(buf,iout);
+        bcf1_t *out = buf->vcf[rbuf_kth(&buf->rbuf,iout)];
+        int ret = 0; 
+        if ( len==BCF_VL_FIXED || len==BCF_VL_VAR )
+            ret = bcf_update_format(buf->out_hdr, out, tag, buf->tmp, nval, type);
+        else if ( len==BCF_VL_A )
+        {
+            int iori = buf->split.atoms[iout]->ial - 1;
+            assert( iori<nval );
+            for (i=0; i<nsmpl; i++)
+            {
+                void *src = buf->tmp  + nval1*num_size*i;
+                void *dst = buf->tmp2 + num_size*i*(star_allele+1);
+                memcpy(dst,src+iori*num_size,num_size);
+                if ( star_allele )
+                    memcpy(dst+num_size,missing_ptr,num_size);
+            }
+            ret = bcf_update_format(buf->out_hdr, out, tag, buf->tmp2, nsmpl*(star_allele+1), type);
+        }
+        else if ( len==BCF_VL_R )
+        {
+            int iori = buf->split.atoms[iout]->ial - 1;
+            assert( iori<nval );
+            for (i=0; i<nsmpl; i++)
+            {
+                void *src = buf->tmp  + nval1*num_size*i;
+                void *dst = buf->tmp2 + num_size*i*(star_allele+2);
+                memcpy(dst,src,num_size);
+                memcpy(dst+num_size,src+iori*num_size,num_size);
+                if ( star_allele )
+                    memcpy(dst+num_size*2,missing_ptr,num_size);
+            }
+            ret = bcf_update_format(buf->out_hdr, out, tag, buf->tmp2, nsmpl*(star_allele+2), type);
+        }
+        else if ( len==BCF_VL_G )
+        {
+            int iori = buf->split.atoms[iout]->ial;
+            int i01  = bcf_alleles2gt(0,iori);
+            int i11  = bcf_alleles2gt(iori,iori);
+            assert( iori<nval );
+            #define BRANCH(type_t, is_missing, is_vector_end, set_missing, set_vector_end) { \
+                for (i=0; i<nsmpl; i++) \
+                { \
+                    type_t *src = (type_t*)buf->tmp + i*nval1; \
+                    type_t *dst = (type_t*)buf->tmp2 + i*3*(1+star_allele); \
+                    int n=0; /* determine ploidy of this genotype */ \
+                    while ( n<nval1 && !(is_vector_end) ) { n++; src++; } \
+                    src = (type_t*)buf->tmp + i*nval1; \
+                    memcpy(dst++,src,sizeof(type)); \
+                    int nmiss = 0, nend = 0; \
+                    if ( n==rec->n_allele ) /* haploid */ \
+                    { \
+                        memcpy(dst++,src+iori,sizeof(type)); \
+                        if ( star_allele ) { nmiss = 1; nend = 3; } \
+                        else nend = 1; \
+                    } \
+                    else if ( n==nval1 ) \
+                    { \
+                        memcpy(dst++,src+i01,sizeof(type)); \
+                        memcpy(dst++,src+i11,sizeof(type)); \
+                        if ( star_allele ) nmiss = 3; \
+                    } \
+                    else if ( n==1 && is_missing ) \
+                    { \
+                        if ( star_allele ) nend = 5; \
+                        else nend = 2; \
+                    } \
+                    else  \
+                        error("Incorrect number of values at %s:%"PRIhts_pos" .. tag=FORMAT/%s Number=G nAlleles=%d nValues=%d, %d-th sample\n", \
+                                bcf_seqname(buf->hdr,rec),rec->pos+1,tag,rec->n_allele,n,i+1); \
+                    for (j=0; j<nmiss; j++) { set_missing; dst++; } \
+                    for (j=0; j<nend; j++) { set_vector_end; dst++; } \
+                } \
+            }
+            switch (type)
+            {
+                case BCF_HT_INT:  BRANCH(int32_t, *src==bcf_int32_missing, *src==bcf_int32_vector_end, *dst=bcf_int32_missing, *dst=bcf_int32_vector_end); break;
+                case BCF_HT_REAL: BRANCH(float, bcf_float_is_missing(*src), bcf_float_is_vector_end(*src), bcf_float_set_missing(*dst), bcf_float_set_vector_end(*dst)); break;
+                default: error("Unexpected case: %d\n", type);
+            }
+            #undef BRANCH
+            ret = bcf_update_format(buf->out_hdr, out, tag, buf->tmp2, 3*(1+star_allele)*nsmpl, type);
+        }
+        if ( ret!=0 ) error("An error occurred while updating FORMAT/%s\n",tag);
+    }
+}
+static inline int _is_acgtn(char *seq)
+{
+    while ( *seq )
+    {
+        char c = toupper(*seq);
+        if ( c!='A' && c!='C' && c!='G' && c!='T' && c!='N' ) return 0;
+        seq++;
+    }
+    return 1;
+}
+/*
+    The atomization works as follows:
+    - Atomize each alternate allele separately by leaving out sequence identical to the reference. No
+      alignment is performed, just greedy trimming of the end, then from left. This operation returns
+      a list of atoms (atom_t) which carry fragments of REF,ALT and their positions as 0-based offsets
+      to the original REF allele
+    - Sort atoms by POS, REF and ALT. Each unique atom (POS+REF+ALT) forms a new VCF record, each
+      with a single ALT.
+    - For each new VCF record determine how to translate the original allele index (iori) to this new
+      record:
+        - 1: the original allele matches the atom
+        - 0: the original allele does not overlap this atom or the overlapping part matches the REF
+             allele
+        - 2 (or equivalently "."): there is a mismatch between the original allele and the atom
+      The mapping is encoded in a table with columns corresponding to the original ALTs and rows
+      to the new POS+ALTs (atoms). The table is initialized to 0, then we set 1's for matching
+      atoms and 2's for overlapping mismatching atoms.
+
+    Note that different ALT alleles can result in the same atom (the same output line) and this code
+    does not know how to reconcile possibly conflicting VCF annotations. This could be improved
+    and merge logic provided, similarly to `merge -l`. For example, the allelic depths (AD) should
+    be summed for the same atomized output allele. However, this level of complexity is not addressed
+    in this initial draft. Higher priority for now is to provide the inverse "join" operation.
+*/
+void _abuf_split(abuf_t *buf, bcf1_t *rec)
+{
+    int i,j;
+    for (i=1; i<rec->n_allele; i++)
+    {
+        if ( _is_acgtn(rec->d.allele[i]) ) continue;
+        rbuf_expand0(&buf->rbuf, bcf1_t*, buf->rbuf.n+1, buf->vcf);
+        int j = rbuf_append(&buf->rbuf);
+        if ( buf->vcf[j] ) bcf_destroy(buf->vcf[j]);
+        buf->vcf[j] = bcf_dup(rec);
+        return;
+    }
+
+    buf->natoms = 0;
+    for (i=1; i<rec->n_allele; i++) _atomize_allele(buf,rec,i);
+    qsort(buf->atoms,buf->natoms,sizeof(*buf->atoms),_cmp_atoms);
+    _split_table_init(buf,rec,buf->natoms);
+    for (i=0; i<buf->natoms; i++)
+    {
+        if ( i && !_atoms_inconsistent(&buf->atoms[i-1],&buf->atoms[i]) ) continue;
+        _split_table_new(buf, &buf->atoms[i]);  // add a new unique output atom
+    }
+    for (i=0; i<buf->natoms; i++)
+    {
+        // Looping over sorted list of all atoms with possible duplicates from different source ALT alleles
+        atom_t *atom = &buf->atoms[i];
+        for (j=0; j<buf->split.nout; j++)
+        {
+            atom_t *out = buf->split.atoms[j];
+            if ( atom == out ) continue;            // table already set to 1
+            if ( atom->beg > out->end ) continue;   // cannot overlap this output atom
+            if ( atom->end < out->beg ) break;      // this atom is ahead of all subsequent output records
+            _split_table_overlap(buf, j, atom);
+        }
+    }
+    assert( !buf->rbuf.n ); // all records should be flushed first in the SPLIT mode
+
+    // Create the output records, transferring all annotations:
+    // CHROM-QUAL
+    _split_table_set_chrom_qual(buf);
+
+    // INFO
+    for (i=0; i<rec->n_info; i++)
+        _split_table_set_info(buf, &rec->d.info[i]);
+
+    // Set INFO tag with the original result
+    if ( buf->split.info_tag )
+        _split_table_set_history(buf);
+
+    // FORMAT
+    for (i=0; i<rec->n_fmt; i++)
+        _split_table_set_format(buf, &rec->d.fmt[i]);
+}
+
+void abuf_push(abuf_t *buf, bcf1_t *rec)
+{
+    bcf_unpack(rec, BCF_UN_ALL);
+    if ( buf->mode==SPLIT ) _abuf_split(buf,rec);
+}
+
+bcf1_t *abuf_flush(abuf_t *buf, int flush_all)
+{
+    int i;
+
+    if ( buf->rbuf.n==0 ) return NULL;
+    if ( flush_all ) goto ret;
+
+ret:
+    i = rbuf_shift(&buf->rbuf);
+    return buf->vcf[i];
+}
+

--- a/abuf.h
+++ b/abuf.h
@@ -1,0 +1,78 @@
+/* The MIT License
+
+   Copyright (c) 2021 Genome Research Ltd.
+
+   Author: Petr Danecek <pd3@sanger.ac.uk>
+   
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+   
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+   
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+ */
+
+/*
+    Atomize/deatomize complex variants
+*/
+
+#ifndef __ABUF_H__
+#define __ABUF_H__
+
+#include <htslib/vcf.h>
+
+typedef struct _abuf_t abuf_t;
+
+// Modes of operation
+typedef enum
+{
+    NONE,
+
+    // mode of operation, to be passed to abuf_init
+    SPLIT,
+    JOIN,
+
+    BCF_HDR,        // should the records be annotated, a writable bcf header is required
+    INFO_TAG,       // set BCF_HDR first
+    STAR_ALLELE     // 1: use STAR allele (the default), 0: set overlaps to missing
+}
+abuf_opt_t;
+
+#define abuf_set_opt(buf,type,key,value) { type tmp = value; abuf_set(buf, key, (void*)&tmp); }
+void abuf_set(abuf_t *buf, abuf_opt_t key, void *value);
+
+/*
+ *  abuf_init() - init buffer
+ *  @win:   number of sites (>0) or bp (<0)
+ */
+abuf_t *abuf_init(const bcf_hdr_t *hdr, abuf_opt_t mode);
+void abuf_destroy(abuf_t *buf);
+
+/*
+ *  abuf_push() - Push a new site for analysis
+ */
+void abuf_push(abuf_t *buf, bcf1_t *rec);
+
+/*
+ *  abuf_flush() - Return next buffered record
+ *  @flush_all: Set to 1 if no more overlapping records are coming (e.g. end of chromosome or end of file),
+ *              the buffer can be emptied.
+ *  return:     The next atomized/deatomized VCF record or NULL if no record is ready. The returned
+ *              structure will be cleaned by abuf.
+ */
+bcf1_t *abuf_flush(abuf_t *buf, int flush_all);
+
+#endif
+

--- a/doc/bcftools.1
+++ b/doc/bcftools.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: bcftools
 .\"    Author: [see the "AUTHORS" section]
-.\" Generator: DocBook XSL Stylesheets v1.76.1 <http://docbook.sf.net/>
-.\"      Date: 2020-11-25 16:08 GMT
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 2021-02-23 10:44 CET
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "BCFTOOLS" "1" "2020\-11\-25 16:08 GMT" "\ \&" "\ \&"
+.TH "BCFTOOLS" "1" "2021\-02\-23 10:44 CET" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -41,7 +41,7 @@ Most commands accept VCF, bgzipped VCF and BCF with filetype detected automatica
 BCFtools is designed to work on a stream\&. It regards an input file "\-" as the standard input (stdin) and outputs to the standard output (stdout)\&. Several commands can thus be combined with Unix pipes\&.
 .SS "VERSION"
 .sp
-This manual page was last updated \fB2020\-11\-25 16:08 GMT\fR and refers to bcftools git version \fB1\&.11\-24\-g9718479+\fR\&.
+This manual page was last updated \fB2021\-02\-23 10:44 CET\fR and refers to bcftools git version \fB1\&.2\-1248\-g3910e40+\fR\&.
 .SS "BCF1"
 .sp
 The BCF1 format output by versions of samtools <= 0\&.1\&.19 is \fBnot\fR compatible with this version of bcftools\&. To read BCF1 files one can use the view command from old versions of bcftools packaged with samtools versions <= 0\&.1\&.19 to convert to VCF, which can then be read by this version of bcftools\&.
@@ -70,7 +70,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBannotate\fR
 \&.\&. edit VCF files, add or remove annotations
 .RE
@@ -83,7 +82,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBcall\fR
 \&.\&. SNP/indel calling (former "view")
 .RE
@@ -96,7 +94,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBcnv\fR
 \&.\&. Copy Number Variation caller
 .RE
@@ -109,7 +106,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBconcat\fR
 \&.\&. concatenate VCF/BCF files from the same set of samples
 .RE
@@ -122,7 +118,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBconsensus\fR
 \&.\&. create consensus sequence by applying VCF variants
 .RE
@@ -135,7 +130,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBconvert\fR
 \&.\&. convert VCF/BCF to other formats and back
 .RE
@@ -148,7 +142,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBcsq\fR
 \&.\&. haplotype aware consequence caller
 .RE
@@ -161,7 +154,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBfilter\fR
 \&.\&. filter VCF/BCF files using fixed thresholds
 .RE
@@ -174,7 +166,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBgtcheck\fR
 \&.\&. check sample concordance, detect sample swaps and contamination
 .RE
@@ -187,7 +178,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBindex\fR
 \&.\&. index VCF/BCF
 .RE
@@ -200,7 +190,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBisec\fR
 \&.\&. intersections of VCF/BCF files
 .RE
@@ -213,7 +202,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBmerge\fR
 \&.\&. merge VCF/BCF files files from non\-overlapping sample sets
 .RE
@@ -226,7 +214,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBmpileup\fR
 \&.\&. multi\-way pileup producing genotype likelihoods
 .RE
@@ -239,7 +226,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBnorm\fR
 \&.\&. normalize indels
 .RE
@@ -252,7 +238,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBplugin\fR
 \&.\&. run user\-defined plugin
 .RE
@@ -265,7 +250,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBpolysomy\fR
 \&.\&. detect contaminations and whole\-chromosome aberrations
 .RE
@@ -278,7 +262,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBquery\fR
 \&.\&. transform VCF/BCF into user\-defined formats
 .RE
@@ -291,7 +274,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBreheader\fR
 \&.\&. modify VCF/BCF header, change sample names
 .RE
@@ -304,7 +286,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBroh\fR
 \&.\&. identify runs of homo/auto\-zygosity
 .RE
@@ -317,7 +298,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBsort\fR
 \&.\&. sort VCF/BCF files
 .RE
@@ -330,7 +310,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBstats\fR
 \&.\&. produce VCF/BCF stats (former vcfcheck)
 .RE
@@ -343,7 +322,6 @@ For a full list of available commands, run \fBbcftools\fR without arguments\&. F
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBview\fR
 \&.\&. subset, filter and convert VCF and BCF files
 .RE
@@ -359,7 +337,6 @@ Some helper scripts are bundled with the bcftools code\&.
 .sp -1
 .IP \(bu 2.3
 .\}
-
 \fBplot\-vcfstats\fR
 \&.\&. plots the output of
 \fBstats\fR
@@ -1383,7 +1360,7 @@ is true\&. For valid expressions see
 reference sequence in fasta format
 .RE
 .PP
-\fB\-H, \-\-haplotype\fR \fI1\fR|\fI2\fR|\fIR\fR|\fIA\fR|\fILR\fR|\fILA\fR|\fISR\fR|\fISA\fR|\fI1pIu\fR|\fI2pIu\fR
+\fB\-H, \-\-haplotype\fR \fI1\fR|\fI2\fR|\fIR\fR|\fIA\fR|\fII\fR|\fILR\fR|\fILA\fR|\fISR\fR|\fISA\fR|\fI1pIu\fR|\fI2pIu\fR
 .RS 4
 choose which allele from the FORMAT/GT field to use (the codes are case\-insensitive):
 .PP
@@ -1405,6 +1382,11 @@ the REF allele (in heterozygous genotypes)
 \fIA\fR
 .RS 4
 the ALT allele (in heterozygous genotypes)
+.RE
+.PP
+\fII\fR
+.RS 4
+IUPAC code for all genotypes
 .RE
 .PP
 \fILR, LA\fR
@@ -1446,13 +1428,37 @@ is true\&. For valid expressions see
 output variants in the form of IUPAC ambiguity codes
 .RE
 .PP
+\fB\-\-mark\-del\fR \fICHAR\fR
+.RS 4
+instead of removing sequence, insert CHAR for deletions
+.RE
+.PP
+\fB\-\-mark\-ins\fR \fIuc\fR|\fIlc\fR
+.RS 4
+highlight inserted sequence in uppercase (uc) or lowercase (lc), leaving the rest of the sequence as is
+.RE
+.PP
+\fB\-\-mark\-snv\fR \fIuc\fR|\fIlc\fR
+.RS 4
+highlight substitutions in uppercase (uc) or lowercase (lc), leaving the rest of the sequence as is
+.RE
+.PP
 \fB\-m, \-\-mask\fR \fIFILE\fR
 .RS 4
-BED file or TAB file with regions to be replaced with N\&. See discussion of
+BED file or TAB file with regions to be replaced with N (the default) or as specified by the next
+\fB\-\-mask\-with\fR
+option\&. See discussion of
 \fB\-\-regions\-file\fR
 in
 \fBCommon Options\fR
 for file format details\&.
+.RE
+.PP
+\fB\-\-mask\-with\fR \fICHAR\fR|\fIlc\fR|\fIuc\fR
+.RS 4
+replace sequence from
+\fB\-\-mask\fR
+with CHAR, skipping overlapping variants, or change to lowercase (lc) or uppercase (uc)
 .RE
 .PP
 \fB\-M, \-\-missing\fR \fICHAR\fR
@@ -2793,7 +2799,7 @@ Disable probabilistic realignment for the computation of base alignment quality 
 .PP
 \fB\-C, \-\-adjust\-MQ\fR \fIINT\fR
 .RS 4
-Coefficient for downgrading mapping quality for reads containing excessive mismatches\&. Given a read with a phred\-scaled probability q of being generated from the mapped position, the new mapping quality is about sqrt((INT\-q)/INT)*INT\&. A zero value disables this functionality; if enabled, the recommended value for BWA is 50\&. [0]
+Coefficient for downgrading mapping quality for reads containing excessive mismatches\&. Given a read with a phred\-scaled probability q of being generated from the mapped position, the new mapping quality is about sqrt((INT\-q)/INT)*INT\&. A zero value (the default) disables this functionality\&.
 .RE
 .PP
 \fB\-d, \-\-max\-depth\fR \fIINT\fR
@@ -3107,6 +3113,35 @@ Call SNPs and short INDELs, then mark low quality sites and sites with the read 
 .SS "bcftools norm [\fIOPTIONS\fR] \fIfile\&.vcf\&.gz\fR"
 .sp
 Left\-align and normalize indels, check if REF alleles match the reference, split multiallelic sites into multiple rows; recover multiallelics from multiple rows\&. Left\-alignment and normalization will only be applied if the \fB\-\-fasta\-ref\fR option is supplied\&.
+.PP
+\fB\-a, \-\-atomize\fR \fI\&.\fR|\fI*\fR
+.RS 4
+Decompose complex variants (e\&.g\&. split MNVs into consecutive SNVs)\&. Alleles missing because of an overlapping variant can be set either to missing (\&.) or to the star alele (*), as recommended by the VCF specification\&. IMPORTANT: Note that asterisk is expaneded by shell and must be put in quotes or escaped by a backslash:
+.RE
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+    # Before atomization:
+    100  CC  C,GG   1/2
+
+    # After:
+    #   bcftools norm \-a \&.
+    100  C       G      \&./1
+    100  CC      C      1/\&.
+    101  C       G      \&./1
+
+    # After:
+    #   bcftools norm \-a \*(Aq*\*(Aq
+    #   bcftools norm \-a \e*
+    100  C       G,*    2/1
+    100  CC      C,*    1/2
+    101  C       G,*    2/1
+.fi
+.if n \{\
+.RE
+.\}
 .PP
 \fB\-c, \-\-check\-ref\fR \fIe\fR|\fIw\fR|\fIx\fR|\fIs\fR
 .RS 4
@@ -3744,7 +3779,7 @@ for more\&.
 convert between similar tags, such as GL and GP
 .RE
 .PP
-\fBtrio\-dnm\fR
+\fBtrio\-dnm2\fR
 .RS 4
 screen variants for possible de\-novo mutations in trios
 .RE

--- a/doc/bcftools.html
+++ b/doc/bcftools.html
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>bcftools</title><link rel="stylesheet" type="text/css" href="docbook-xsl.css" /><meta name="generator" content="DocBook XSL Stylesheets V1.76.1" /></head><body><div xml:lang="en" class="refentry" title="bcftools" lang="en"><a id="idp25199360"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>bcftools — utilities for variant calling and manipulating VCFs and BCFs.</p></div><div class="refsynopsisdiv" title="Synopsis"><a id="_synopsis"></a><h2>Synopsis</h2><p><span class="strong"><strong>bcftools</strong></span> [--version|--version-only] [--help] [<span class="emphasis"><em>COMMAND</em></span>] [<span class="emphasis"><em>OPTIONS</em></span>]</p></div><div class="refsect1" title="DESCRIPTION"><a id="_description"></a><h2>DESCRIPTION</h2><p>BCFtools  is  a set of utilities that manipulate variant calls in the Variant
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><title>bcftools</title><link rel="stylesheet" type="text/css" href="docbook-xsl.css" /><meta name="generator" content="DocBook XSL Stylesheets Vsnapshot" /></head><body><div xml:lang="en" class="refentry" lang="en"><a id="id1337"></a><div class="titlepage"></div><div class="refnamediv"><h2>Name</h2><p>bcftools — utilities for variant calling and manipulating VCFs and BCFs.</p></div><div class="refsynopsisdiv"><a id="_synopsis"></a><h2>Synopsis</h2><p><span class="strong"><strong>bcftools</strong></span> [--version|--version-only] [--help] [<span class="emphasis"><em>COMMAND</em></span>] [<span class="emphasis"><em>OPTIONS</em></span>]</p></div><div class="refsect1"><a id="_description"></a><h2>DESCRIPTION</h2><p>BCFtools  is  a set of utilities that manipulate variant calls in the Variant
 Call Format (VCF) and its binary counterpart BCF. All commands work
 transparently with both VCFs and BCFs, both uncompressed and BGZF-compressed.</p><p>Most commands accept VCF, bgzipped VCF and BCF with filetype detected
 automatically even when streaming from a pipe. Indexed VCF and BCF
@@ -10,17 +9,17 @@ read simultaneously, they must be indexed and therefore also compressed.
 (Note that files with non-standard index names can be accessed as e.g.
 "<code class="literal">bcftools view -r X:2928329 file.vcf.gz##idx##non-standard-index-name</code>".)</p><p>BCFtools is designed to work on a stream. It regards an input file "-" as the
 standard input (stdin) and outputs to the standard output (stdout). Several
-commands can thus be  combined  with  Unix pipes.</p><div class="refsect2" title="VERSION"><a id="_version"></a><h3>VERSION</h3><p>This manual page was last updated <span class="strong"><strong>2020-11-25 16:08 GMT</strong></span> and refers to bcftools git version <span class="strong"><strong>1.11-24-g9718479+</strong></span>.</p></div><div class="refsect2" title="BCF1"><a id="_bcf1"></a><h3>BCF1</h3><p>The BCF1 format output by versions of samtools &lt;= 0.1.19 is <span class="strong"><strong>not</strong></span>
+commands can thus be  combined  with  Unix pipes.</p><div class="refsect2"><a id="_version"></a><h3>VERSION</h3><p>This manual page was last updated <span class="strong"><strong>2021-02-23 10:44 CET</strong></span> and refers to bcftools git version <span class="strong"><strong>1.2-1248-g3910e40+</strong></span>.</p></div><div class="refsect2"><a id="_bcf1"></a><h3>BCF1</h3><p>The BCF1 format output by versions of samtools &lt;= 0.1.19 is <span class="strong"><strong>not</strong></span>
 compatible with this version of bcftools. To read BCF1 files one can use
 the view command from old versions of bcftools packaged with samtools
 versions &lt;= 0.1.19 to convert to VCF, which can then be read by
-this version of bcftools.</p><pre class="screen">    samtools-0.1.19/bcftools/bcftools view file.bcf1 | bcftools view</pre></div><div class="refsect2" title="VARIANT CALLING"><a id="_variant_calling"></a><h3>VARIANT CALLING</h3><p>See <span class="emphasis"><em>bcftools call</em></span> for variant calling from the output of the
+this version of bcftools.</p><pre class="screen">    samtools-0.1.19/bcftools/bcftools view file.bcf1 | bcftools view</pre></div><div class="refsect2"><a id="_variant_calling"></a><h3>VARIANT CALLING</h3><p>See <span class="emphasis"><em>bcftools call</em></span> for variant calling from the output of the
 <span class="emphasis"><em>samtools mpileup</em></span> command. In versions of samtools &lt;= 0.1.19 calling was
 done with <span class="emphasis"><em>bcftools view</em></span>. Users are now required to choose between the old
 samtools calling model (<span class="emphasis"><em>-c/--consensus-caller</em></span>) and the new multiallelic
 calling model (<span class="emphasis"><em>-m/--multiallelic-caller</em></span>). The multiallelic calling model
-is recommended for most tasks.</p></div></div><div class="refsect1" title="LIST OF COMMANDS"><a id="_list_of_commands"></a><h2>LIST OF COMMANDS</h2><p>For a full list of available commands, run <span class="strong"><strong>bcftools</strong></span> without arguments. For a full
-list of available options, run <span class="strong"><strong>bcftools</strong></span> <span class="emphasis"><em>COMMAND</em></span> without arguments.</p><div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
+is recommended for most tasks.</p></div></div><div class="refsect1"><a id="_list_of_commands"></a><h2>LIST OF COMMANDS</h2><p>For a full list of available commands, run <span class="strong"><strong>bcftools</strong></span> without arguments. For a full
+list of available options, run <span class="strong"><strong>bcftools</strong></span> <span class="emphasis"><em>COMMAND</em></span> without arguments.</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
 <span class="strong"><strong><a class="link" href="#annotate" title="bcftools annotate [OPTIONS] FILE">annotate</a></strong></span>   .. edit VCF files, add or remove annotations
 </li><li class="listitem">
 <span class="strong"><strong><a class="link" href="#call" title="bcftools call [OPTIONS] FILE">call</a></strong></span>        ..  SNP/indel calling (former "view")
@@ -64,10 +63,10 @@ list of available options, run <span class="strong"><strong>bcftools</strong></s
 <span class="strong"><strong><a class="link" href="#stats" title="bcftools stats [OPTIONS] A.vcf.gz [B.vcf.gz]">stats</a></strong></span>      ..  produce VCF/BCF stats (former vcfcheck)
 </li><li class="listitem">
 <span class="strong"><strong><a class="link" href="#view" title="bcftools view [OPTIONS] file.vcf.gz [REGION […]]">view</a></strong></span>        ..  subset, filter and convert VCF and BCF files
-</li></ul></div></div><div class="refsect1" title="LIST OF SCRIPTS"><a id="_list_of_scripts"></a><h2>LIST OF SCRIPTS</h2><p>Some helper scripts are bundled with the bcftools code.</p><div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
+</li></ul></div></div><div class="refsect1"><a id="_list_of_scripts"></a><h2>LIST OF SCRIPTS</h2><p>Some helper scripts are bundled with the bcftools code.</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
 <span class="strong"><strong><a class="link" href="#plot-vcfstats" title="plot-vcfstats [OPTIONS] file.vchk […]">plot-vcfstats</a></strong></span>  .. plots the output of <span class="strong"><strong><a class="link" href="#stats" title="bcftools stats [OPTIONS] A.vcf.gz [B.vcf.gz]">stats</a></strong></span>
-</li></ul></div></div><div class="refsect1" title="COMMANDS AND OPTIONS"><a id="_commands_and_options"></a><h2>COMMANDS AND OPTIONS</h2><div class="refsect2" title="Common Options"><a id="common_options"></a><h3>Common Options</h3><p>The following options are common to many bcftools commands. See usage for
-specific commands to see if they apply.</p><div class="variablelist"><dl><dt><span class="term">
+</li></ul></div></div><div class="refsect1"><a id="_commands_and_options"></a><h2>COMMANDS AND OPTIONS</h2><div class="refsect2"><a id="common_options"></a><h3>Common Options</h3><p>The following options are common to many bcftools commands. See usage for
+specific commands to see if they apply.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     Files can be both VCF or BCF, uncompressed or BGZF-compressed. The file "-"
@@ -83,7 +82,7 @@ specific commands to see if they apply.</p><div class="variablelist"><dl><dt><sp
     matching positions (<span class="strong"><strong>bcftools isec -c</strong></span> <span class="emphasis"><em>all</em></span>), or only sites with  matching variant
     type (<span class="strong"><strong>bcftools isec -c</strong></span> <span class="emphasis"><em>snps</em></span>  <span class="strong"><strong>-c</strong></span> <span class="emphasis"><em>indels</em></span>), or only sites with all alleles
     identical (<span class="strong"><strong>bcftools isec -c</strong></span> <span class="emphasis"><em>none</em></span>).
-</p><div class="variablelist"><dl><dt><span class="term">
+</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="emphasis"><em>none</em></span>
 </span></dt><dd>
             only records with identical REF and ALT alleles are compatible
@@ -181,7 +180,7 @@ specific commands to see if they apply.</p><div class="variablelist"><dl><dt><sp
     option is used; see <span class="strong"><strong><a class="link" href="#view" title="bcftools view [OPTIONS] file.vcf.gz [REGION […]]">bcftools view</a></strong></span> documentation). To use updated
     tags for the subset in another command one can pipe from <span class="strong"><strong>view</strong></span> into
     that command. For example:
-</dd></dl></div><pre class="screen">    bcftools view -Ou -s sample1,sample2 file.vcf | bcftools query -f %INFO/AC\t%INFO/AN\n</pre><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div><pre class="screen">    bcftools view -Ou -s sample1,sample2 file.vcf | bcftools query -f %INFO/AC\t%INFO/AN\n</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-S, --samples-file</strong></span> <span class="emphasis"><em><span class="^">FILE</span></em></span><a id="samples_file"></a>
 </span></dt><dd>
     File of sample names to include or exclude if prefixed with "^".
@@ -198,7 +197,7 @@ specific commands to see if they apply.</p><div class="variablelist"><dl><dt><sp
     sample3    F</pre><p>If the second column is not present, the sex "F" is assumed.
 With <span class="strong"><strong><a class="link" href="#call" title="bcftools call [OPTIONS] FILE">bcftools call</a> -C</strong></span> <span class="emphasis"><em>trio</em></span>, PED file is expected.
 The program ignores the first column and the last indicates sex (1=male, 2=female), for example:</p><pre class="screen">    ignored_column  daughterA fatherA  motherA  2
-    ignored_column  sonB      fatherB  motherB  1</pre><div class="variablelist"><dl><dt><span class="term">
+    ignored_column  sonB      fatherB  motherB  1</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-t, --targets</strong></span> [^]<span class="emphasis"><em>chr</em></span>|<span class="emphasis"><em>chr:pos</em></span>|<span class="emphasis"><em>chr:from-to</em></span>|<span class="emphasis"><em>chr:from-</em></span>[,…]
 </span></dt><dd>
     Similar as <span class="strong"><strong>-r, --regions</strong></span>, but the next position is accessed by streaming the
@@ -222,12 +221,12 @@ The program ignores the first column and the last indicates sex (1=male, 2=femal
     be comma-separated list of alleles, starting with the reference allele.
     Note that the file must be compressed and index.
     Such a file can be easily created from a VCF using:
-</dd></dl></div><pre class="screen">    bcftools query -f'%CHROM\t%POS\t%REF,%ALT\n' file.vcf | bgzip -c &gt; als.tsv.gz &amp;&amp; tabix -s1 -b2 -e2 als.tsv.gz</pre><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div><pre class="screen">    bcftools query -f'%CHROM\t%POS\t%REF,%ALT\n' file.vcf | bgzip -c &gt; als.tsv.gz &amp;&amp; tabix -s1 -b2 -e2 als.tsv.gz</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     Use multithreading with <span class="emphasis"><em>INT</em></span> worker threads. The option is currently used only for the compression of the
     output stream, only when <span class="emphasis"><em>--output-type</em></span> is <span class="emphasis"><em>b</em></span> or <span class="emphasis"><em>z</em></span>. Default: 0.
-</dd></dl></div></div><div class="refsect2" title="bcftools annotate [OPTIONS] FILE"><a id="annotate"></a><h3>bcftools annotate <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Add or remove annotations.</p><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect2"><a id="annotate"></a><h3>bcftools annotate <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Add or remove annotations.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-a, --annotations</strong></span> <span class="emphasis"><em>file</em></span>
 </span></dt><dd>
     Bgzip-compressed and tabix-indexed file with annotations. The file
@@ -251,7 +250,7 @@ The program ignores the first column and the last indicates sex (1=male, 2=femal
 </dd></dl></div><pre class="screen">    # Sample annotation file with columns CHROM, POS, STRING_TAG, NUMERIC_TAG
     1  752566  SomeString      5
     1  798959  SomeOtherString 6
-    # etc.</pre><div class="variablelist"><dl><dt><span class="term">
+    # etc.</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--collapse</strong></span> <span class="emphasis"><em>snps</em></span>|<span class="emphasis"><em>indels</em></span>|<span class="emphasis"><em>both</em></span>|<span class="emphasis"><em>all</em></span>|<span class="emphasis"><em>some</em></span>|<span class="emphasis"><em>none</em></span>
 </span></dt><dd>
     Controls how to match records from the annotation file to the target VCF.
@@ -309,14 +308,14 @@ The program ignores the first column and the last indicates sex (1=male, 2=femal
 </span></dt><dd>
     Lines to append to the VCF header, see also <span class="strong"><strong>-c, --columns</strong></span> and <span class="strong"><strong>-a, --annotations</strong></span>. For example:
 </dd></dl></div><pre class="screen">    ##INFO=&lt;ID=NUMERIC_TAG,Number=1,Type=Integer,Description="Example header line"&gt;
-    ##INFO=&lt;ID=STRING_TAG,Number=1,Type=String,Description="Yet another header line"&gt;</pre><div class="variablelist"><dl><dt><span class="term">
+    ##INFO=&lt;ID=STRING_TAG,Number=1,Type=String,Description="Yet another header line"&gt;</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-I, --set-id</strong></span> [+]<span class="emphasis"><em>FORMAT</em></span>
 </span></dt><dd>
     assign ID on the fly. The format is the same as in the <span class="strong"><strong><a class="link" href="#query" title="bcftools query [OPTIONS] file.vcf.gz [file.vcf.gz […]]">query</a></strong></span>
     command (see below).  By default all existing IDs are replaced. If the
     format string is preceded by "+", only missing IDs will be set. For example,
     one can use
-</dd></dl></div><pre class="screen">    bcftools annotate --set-id +'%CHROM\_%POS\_%REF\_%FIRST_ALT' file.vcf</pre><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div><pre class="screen">    bcftools annotate --set-id +'%CHROM\_%POS\_%REF\_%FIRST_ALT' file.vcf</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-i, --include</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     include only sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -432,10 +431,10 @@ The program ignores the first column and the last indicates sex (1=male, 2=femal
     # Annotate from a bed file (0-based coordinates, half-closed, half-open intervals)
     bcftools annotate -a annots.bed.gz -h annots.hdr -c CHROM,FROM,TO,TAG input.vcf
 
-    # For more examples see http://samtools.github.io/bcftools/howtos/annotate.html</pre></div><div class="refsect2" title="bcftools call [OPTIONS] FILE"><a id="call"></a><h3>bcftools call <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>This command replaces the former <span class="strong"><strong>bcftools view</strong></span> caller. Some of the original
+    # For more examples see http://samtools.github.io/bcftools/howtos/annotate.html</pre></div><div class="refsect2"><a id="call"></a><h3>bcftools call <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>This command replaces the former <span class="strong"><strong>bcftools view</strong></span> caller. Some of the original
 functionality has been temporarily lost in the process of transition under
 <a class="ulink" href="http://github.com/samtools/htslib" target="_top">htslib</a>, but will be added back on popular
-demand. The original calling model can be invoked with the <span class="strong"><strong>-c</strong></span> option.</p><div class="refsect3" title="File format options:"><a id="_file_format_options"></a><h4>File format options:</h4><div class="variablelist"><dl><dt><span class="term">
+demand. The original calling model can be invoked with the <span class="strong"><strong>-c</strong></span> option.</p><div class="refsect3"><a id="_file_format_options"></a><h4>File format options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--no-version</strong></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -468,7 +467,7 @@ demand. The original calling model can be invoked with the <span class="strong">
     MT 1 16569 M 1
     MT 1 16569 F 1
     *  * *     M 2
-    *  * *     F 2</pre><div class="variablelist"><dl><dt><span class="term">
+    *  * *     F 2</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-r, --regions</strong></span> <span class="emphasis"><em>chr</em></span>|<span class="emphasis"><em>chr:pos</em></span>|<span class="emphasis"><em>chr:from-to</em></span>|<span class="emphasis"><em>chr:from-</em></span>[,…]
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -496,7 +495,7 @@ demand. The original calling model can be invoked with the <span class="strong">
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="Input/output options:"><a id="_input_output_options"></a><h4>Input/output options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_input_output_options"></a><h4>Input/output options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-A, --keep-alts</strong></span>
 </span></dt><dd>
     output all alternate alleles present in the alignments even if they do not
@@ -526,7 +525,7 @@ demand. The original calling model can be invoked with the <span class="strong">
     ##INFO=&lt;ID=REF_AC,Number=A,Type=Integer,Description="Allele count in reference genotypes for each ALT allele"&gt;
 
     # Now before calling, stream the raw mpileup output through `bcftools annotate` to add the frequencies
-    bcftools mpileup [...] -Ou | bcftools annotate -a AFs.tab.gz -h AFs.hdr -c CHROM,POS,REF,ALT,REF_AN,REF_AC -Ou | bcftools call -mv -F REF_AN,REF_AC [...]</pre><div class="variablelist"><dl><dt><span class="term">
+    bcftools mpileup [...] -Ou | bcftools annotate -a AFs.tab.gz -h AFs.hdr -c CHROM,POS,REF,ALT,REF_AN,REF_AC -Ou | bcftools call -mv -F REF_AN,REF_AC [...]</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-G, --group-samples</strong></span> <span class="emphasis"><em><span class="TAG:">FILE</span></em></span>|<span class="emphasis"><em>-</em></span>
 </span></dt><dd>
     by default, all samples are assumed to come from a single population. This option allows to group samples
@@ -557,13 +556,13 @@ demand. The original calling model can be invoked with the <span class="strong">
 <span class="strong"><strong>-v, --variants-only</strong></span>
 </span></dt><dd>
     output variant sites only
-</dd></dl></div></div><div class="refsect3" title="Consensus/variant calling options:"><a id="_consensus_variant_calling_options"></a><h4>Consensus/variant calling options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_consensus_variant_calling_options"></a><h4>Consensus/variant calling options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --consensus-caller</strong></span>
 </span></dt><dd>
     the original <span class="strong"><strong>samtools</strong></span>/<span class="strong"><strong>bcftools</strong></span> calling method (conflicts with <span class="strong"><strong>-m</strong></span>)
 </dd><dt><span class="term">
 <span class="strong"><strong>-C, --constrain</strong></span> <span class="emphasis"><em>alleles</em></span>|<span class="emphasis"><em>trio</em></span>
-</span></dt><dd><div class="variablelist"><dl><dt><span class="term">
+</span></dt><dd><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="emphasis"><em>alleles</em></span>
 </span></dt><dd>
             call genotypes given alleles. See also <span class="strong"><strong>-T, --targets-file</strong></span>.
@@ -611,10 +610,10 @@ demand. The original calling model can be invoked with the <span class="strong">
 <span class="strong"><strong>-Y, --chromosome-Y</strong></span>
 </span></dt><dd>
     haploid output for males and skips females (requires PED file with <span class="strong"><strong>-s</strong></span>)
-</dd></dl></div></div></div><div class="refsect2" title="bcftools cnv [OPTIONS] FILE"><a id="cnv"></a><h3>bcftools cnv <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Copy number variation caller, requires a VCF annotated with the Illumina’s
+</dd></dl></div></div></div><div class="refsect2"><a id="cnv"></a><h3>bcftools cnv <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Copy number variation caller, requires a VCF annotated with the Illumina’s
 B-allele frequency (BAF) and Log R Ratio intensity (LRR) values. The HMM
 considers the following copy number states: CN 2 (normal), 1 (single-copy
-loss), 0 (complete loss), 3 (single-copy gain).</p><div class="refsect3" title="General Options:"><a id="_general_options"></a><h4>General Options:</h4><div class="variablelist"><dl><dt><span class="term">
+loss), 0 (complete loss), 3 (single-copy gain).</p><div class="refsect3"><a id="_general_options"></a><h4>General Options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --control-sample</strong></span> <span class="emphasis"><em>string</em></span>
 </span></dt><dd>
     optional control sample name. If given, pairwise calling is performed
@@ -653,7 +652,7 @@ loss), 0 (complete loss), 3 (single-copy gain).</p><div class="refsect3" title="
 <span class="strong"><strong>-T, --targets-file</strong></span> <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="HMM Options:"><a id="_hmm_options"></a><h4>HMM Options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_hmm_options"></a><h4>HMM Options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-a, --aberrant</strong></span> <span class="emphasis"><em>float</em></span>[,<span class="emphasis"><em>float</em></span>]
 </span></dt><dd>
     fraction of aberrant cells in query and control. The hallmark of
@@ -702,13 +701,13 @@ loss), 0 (complete loss), 3 (single-copy gain).</p><div class="refsect3" title="
 </span></dt><dd>
     the HMM probability of transition to another copy number state. Increasing this
     values leads to smaller and more frequent calls.
-</dd></dl></div></div></div><div class="refsect2" title="bcftools concat [OPTIONS] FILE1 FILE2 […]"><a id="concat"></a><h3>bcftools concat <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE1</em></span> <span class="emphasis"><em>FILE2</em></span> […]</h3><p>Concatenate or combine VCF/BCF files. All source files must have the same sample
+</dd></dl></div></div></div><div class="refsect2"><a id="concat"></a><h3>bcftools concat <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE1</em></span> <span class="emphasis"><em>FILE2</em></span> […]</h3><p>Concatenate or combine VCF/BCF files. All source files must have the same sample
 columns appearing in the same order. Can be used, for example, to
 concatenate chromosome VCFs into one VCF, or combine a SNP VCF and an indel
 VCF into one. The input files must be sorted by chr and position. The files
 must be given in the correct order to produce sorted VCF on output unless
 the <span class="strong"><strong>-a, --allow-overlaps</strong></span> option is specified. With the --naive option, the files
-are concatenated without being recompressed, which is very fast..</p><div class="variablelist"><dl><dt><span class="term">
+are concatenated without being recompressed, which is very fast..</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-a, --allow-overlaps</strong></span>
 </span></dt><dd>
     First coordinate of the next file can precede last record of the current file.
@@ -775,13 +774,13 @@ are concatenated without being recompressed, which is very fast..</p><div class=
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect2" title="bcftools consensus [OPTIONS] FILE"><a id="consensus"></a><h3>bcftools consensus <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Create consensus sequence by applying VCF variants to a reference fasta file.
+</dd></dl></div></div><div class="refsect2"><a id="consensus"></a><h3>bcftools consensus <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Create consensus sequence by applying VCF variants to a reference fasta file.
 By default, the program will apply all ALT variants to the reference fasta to
 obtain the consensus sequence. Using the <span class="strong"><strong>--sample</strong></span> (and, optionally,
 <span class="strong"><strong>--haplotype</strong></span>) option will apply genotype (haplotype) calls from FORMAT/GT.
 Note that the program does not act as a primitive variant caller and ignores allelic
 depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
-<span class="strong"><strong>setGT</strong></span> plugin.</p><div class="variablelist"><dl><dt><span class="term">
+<span class="strong"><strong>setGT</strong></span> plugin.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --chain</strong></span> <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     write a chain file for liftover
@@ -795,10 +794,10 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 </span></dt><dd>
     reference sequence in fasta format
 </dd><dt><span class="term">
-<span class="strong"><strong>-H, --haplotype</strong></span> <span class="emphasis"><em>1</em></span>|<span class="emphasis"><em>2</em></span>|<span class="emphasis"><em>R</em></span>|<span class="emphasis"><em>A</em></span>|<span class="emphasis"><em>LR</em></span>|<span class="emphasis"><em>LA</em></span>|<span class="emphasis"><em>SR</em></span>|<span class="emphasis"><em>SA</em></span>|<span class="emphasis"><em>1pIu</em></span>|<span class="emphasis"><em>2pIu</em></span>
+<span class="strong"><strong>-H, --haplotype</strong></span> <span class="emphasis"><em>1</em></span>|<span class="emphasis"><em>2</em></span>|<span class="emphasis"><em>R</em></span>|<span class="emphasis"><em>A</em></span>|<span class="emphasis"><em>I</em></span>|<span class="emphasis"><em>LR</em></span>|<span class="emphasis"><em>LA</em></span>|<span class="emphasis"><em>SR</em></span>|<span class="emphasis"><em>SA</em></span>|<span class="emphasis"><em>1pIu</em></span>|<span class="emphasis"><em>2pIu</em></span>
 </span></dt><dd><p class="simpara">
     choose which allele from the FORMAT/GT field to use (the codes are case-insensitive):
-</p><div class="variablelist"><dl><dt><span class="term">
+</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="emphasis"><em>1</em></span>
 </span></dt><dd>
             the first allele, regardless of phasing
@@ -814,6 +813,10 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 <span class="emphasis"><em>A</em></span>
 </span></dt><dd>
             the ALT allele (in heterozygous genotypes)
+</dd><dt><span class="term">
+<span class="emphasis"><em>I</em></span>
+</span></dt><dd>
+            IUPAC code for all genotypes
 </dd><dt><span class="term">
 <span class="emphasis"><em>LR, LA</em></span>
 </span></dt><dd>
@@ -836,11 +839,28 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 </span></dt><dd>
     output variants in the form of IUPAC ambiguity codes
 </dd><dt><span class="term">
+<span class="strong"><strong>--mark-del</strong></span> <span class="emphasis"><em>CHAR</em></span>
+</span></dt><dd>
+    instead of removing sequence, insert CHAR for deletions
+</dd><dt><span class="term">
+<span class="strong"><strong>--mark-ins</strong></span> <span class="emphasis"><em>uc</em></span>|<span class="emphasis"><em>lc</em></span>
+</span></dt><dd>
+    highlight inserted sequence in uppercase (uc) or lowercase (lc), leaving the rest of the sequence as is
+</dd><dt><span class="term">
+<span class="strong"><strong>--mark-snv</strong></span> <span class="emphasis"><em>uc</em></span>|<span class="emphasis"><em>lc</em></span>
+</span></dt><dd>
+    highlight substitutions in uppercase (uc) or lowercase (lc), leaving the rest of the sequence as is
+</dd><dt><span class="term">
 <span class="strong"><strong>-m, --mask</strong></span> <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
-    BED file or TAB file with regions to be replaced with N. See discussion
+    BED file or TAB file with regions to be replaced with N (the default) or as specified by
+    the next <span class="strong"><strong>--mask-with</strong></span> option. See discussion
     of <span class="strong"><strong>--regions-file</strong></span> in <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span> for file
     format details.
+</dd><dt><span class="term">
+<span class="strong"><strong>--mask-with</strong></span> <span class="emphasis"><em>CHAR</em></span>|<span class="emphasis"><em>lc</em></span>|<span class="emphasis"><em>uc</em></span>
+</span></dt><dd>
+    replace sequence from <span class="strong"><strong>--mask</strong></span> with CHAR, skipping overlapping variants, or change to lowercase (lc) or uppercase (uc)
 </dd><dt><span class="term">
 <span class="strong"><strong>-M, --missing</strong></span> <span class="emphasis"><em>CHAR</em></span>
 </span></dt><dd>
@@ -858,7 +878,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 
     # Create consensus for one region. The fasta header lines are then expected
     # in the form "&gt;chr:from-to".
-    samtools faidx ref.fa 8:11870-11890 | bcftools consensus in.vcf.gz -o out.fa</pre></div><div class="refsect2" title="bcftools convert [OPTIONS] FILE"><a id="convert"></a><h3>bcftools convert <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><div class="refsect3" title="VCF input options:"><a id="_vcf_input_options"></a><h4>VCF input options:</h4><div class="variablelist"><dl><dt><span class="term">
+    samtools faidx ref.fa 8:11870-11890 | bcftools consensus in.vcf.gz -o out.fa</pre></div><div class="refsect2"><a id="convert"></a><h3>bcftools convert <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><div class="refsect3"><a id="_vcf_input_options"></a><h4>VCF input options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-e, --exclude</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     exclude sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -892,7 +912,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 <span class="strong"><strong>-T, --targets-file</strong></span> <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="VCF output options:"><a id="_vcf_output_options"></a><h4>VCF output options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_vcf_output_options"></a><h4>VCF output options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--no-version</strong></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -908,7 +928,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="GEN/SAMPLE conversion:"><a id="_gen_sample_conversion"></a><h4>GEN/SAMPLE conversion:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_gen_sample_conversion"></a><h4>GEN/SAMPLE conversion:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-G, --gensample2vcf</strong></span> <span class="emphasis"><em>prefix</em></span> or <span class="emphasis"><em>gen-file</em></span>,<span class="emphasis"><em>sample-file</em></span>
 </span></dt><dd>
     convert IMPUTE2 output to VCF. The second column must be of the form
@@ -933,7 +953,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
   ID_1 ID_2 missing
   0 0 0
   sample1 sample1 0
-  sample2 sample2 0</pre><div class="variablelist"><dl><dt><span class="term">
+  sample2 sample2 0</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--tag</strong></span> <span class="emphasis"><em>STRING</em></span>
 </span></dt><dd>
     tag to take values for .gen file: GT,PL,GL,GP
@@ -946,11 +966,11 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 </span></dt><dd>
     output sex column in the sample file. The FILE format is
 </dd></dl></div><pre class="screen">    MaleSample    M
-    FemaleSample  F</pre><div class="variablelist"><dl><dt><span class="term">
+    FemaleSample  F</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--vcf-ids</strong></span>
 </span></dt><dd>
     output VCF IDs in the second column instead of CHROM:POS_REF_ALT
-</dd></dl></div></div><div class="refsect3" title="gVCF conversion:"><a id="_gvcf_conversion"></a><h4>gVCF conversion:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_gvcf_conversion"></a><h4>gVCF conversion:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--gvcf2vcf</strong></span>
 </span></dt><dd>
     convert gVCF to VCF, expanding REF blocks into sites. Note that
@@ -962,7 +982,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 <span class="strong"><strong>-f, --fasta-ref</strong></span> <span class="emphasis"><em>file</em></span>
 </span></dt><dd>
     reference sequence in fasta format. Must be indexed with samtools faidx
-</dd></dl></div></div><div class="refsect3" title="HAP/SAMPLE conversion:"><a id="_hap_sample_conversion"></a><h4>HAP/SAMPLE conversion:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_hap_sample_conversion"></a><h4>HAP/SAMPLE conversion:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--hapsample2vcf</strong></span> <span class="emphasis"><em>prefix</em></span> or <span class="emphasis"><em>hap-file</em></span>,<span class="emphasis"><em>sample-file</em></span>
 </span></dt><dd>
     convert from hap/sample format to VCF. The columns of .hap file are
@@ -974,7 +994,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
   ----
   1:111485207_G_A rsID1 111485207 G A 0 1 0 0
   1:111494194_C_T rsID2 111494194 C T 0 1 0 0
-  1:111495231_A_&lt;DEL&gt;_111495784 rsID3 111495231 A &lt;DEL&gt; 0 0 1 0</pre><div class="variablelist"><dl><dt><span class="term">
+  1:111495231_A_&lt;DEL&gt;_111495784 rsID3 111495231 A &lt;DEL&gt; 0 0 1 0</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--hapsample</strong></span> <span class="emphasis"><em>prefix</em></span> or <span class="emphasis"><em>hap-file</em></span>,<span class="emphasis"><em>sample-file</em></span>
 </span></dt><dd>
     convert from VCF to hap/sample format used by IMPUTE2 and SHAPEIT.
@@ -993,11 +1013,11 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 </span></dt><dd>
     output sex column in the sample file. The FILE format is
 </dd></dl></div><pre class="screen">    MaleSample    M
-    FemaleSample  F</pre><div class="variablelist"><dl><dt><span class="term">
+    FemaleSample  F</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--vcf-ids</strong></span>
 </span></dt><dd>
     output VCF IDs instead of "CHROM:POS_REF_ALT" IDs
-</dd></dl></div></div><div class="refsect3" title="HAP/LEGEND/SAMPLE conversion:"><a id="_hap_legend_sample_conversion"></a><h4>HAP/LEGEND/SAMPLE conversion:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_hap_legend_sample_conversion"></a><h4>HAP/LEGEND/SAMPLE conversion:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-H, --haplegendsample2vcf</strong></span> <span class="emphasis"><em>prefix</em></span> or <span class="emphasis"><em>hap-file</em></span>,<span class="emphasis"><em>legend-file</em></span>,<span class="emphasis"><em>sample-file</em></span>
 </span></dt><dd>
     convert from hap/legend/sample format used by IMPUTE2 to VCF, see
@@ -1025,7 +1045,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
   -------
   sample population group sex
   sample1 sample1 sample1 2
-  sample2 sample2 sample2 2</pre><div class="variablelist"><dl><dt><span class="term">
+  sample2 sample2 sample2 2</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--haploid2diploid</strong></span>
 </span></dt><dd>
     with <span class="strong"><strong>-h</strong></span> option converts haploid genotypes to homozygous diploid
@@ -1037,11 +1057,11 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 </span></dt><dd>
     output sex column in the sample file. The FILE format is
 </dd></dl></div><pre class="screen">    MaleSample    M
-    FemaleSample  F</pre><div class="variablelist"><dl><dt><span class="term">
+    FemaleSample  F</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--vcf-ids</strong></span>
 </span></dt><dd>
     output VCF IDs instead of "CHROM:POS_REF_ALT" IDs
-</dd></dl></div></div><div class="refsect3" title="TSV conversion:"><a id="_tsv_conversion"></a><h4>TSV conversion:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_tsv_conversion"></a><h4>TSV conversion:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--tsv2vcf</strong></span> <span class="emphasis"><em>file</em></span>
 </span></dt><dd>
     convert from TSV (tab-separated values) format (such as generated by
@@ -1070,7 +1090,7 @@ depth information, such as INFO/AD or FORMAT/AD. For that, consider using the
 </span></dt><dd>
     file of sample names. See <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
 </dd></dl></div><p><span class="strong"><strong>Example:</strong></span></p><pre class="screen"># Convert 23andme results into VCF
-bcftools convert -c ID,CHROM,POS,AA -s SampleName -f 23andme-ref.fa --tsv2vcf 23andme.txt -Oz -o out.vcf.gz</pre></div></div><div class="refsect2" title="bcftools csq [OPTIONS] FILE"><a id="csq"></a><h3>bcftools csq <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Haplotype aware consequence predictor which correctly handles combined
+bcftools convert -c ID,CHROM,POS,AA -s SampleName -f 23andme-ref.fa --tsv2vcf 23andme.txt -Oz -o out.vcf.gz</pre></div></div><div class="refsect2"><a id="csq"></a><h3>bcftools csq <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Haplotype aware consequence predictor which correctly handles combined
 variants such as MNPs split over multiple VCF records, SNPs separated by
 an intron (but adjacent in the spliced transcript) or nearby frame-shifting
 indels which in combination in fact are not frame-shifting.</p><p>The output VCF is annotated with INFO/BCSQ and FORMAT/BCSQ tag (configurable
@@ -1088,7 +1108,7 @@ unphased data. Alternatively, haplotype aware calling can be turned off
 with the <span class="strong"><strong>--local-csq</strong></span> option.</p><p>If conflicting (overlapping) variants within one haplotype are detected,
 a warning will be emitted and predictions will be based on only the first
 variant in the analysis.</p><p>Symbolic alleles are not supported. They will remain unannotated in the
-output VCF and are ignored for the prediction analysis.</p><div class="variablelist"><dl><dt><span class="term">
+output VCF and are ignored for the prediction analysis.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --custom-tag</strong></span> <span class="emphasis"><em>STRING</em></span>
 </span></dt><dd>
     use this custom tag to store consequences rather than the default BCSQ tag
@@ -1144,7 +1164,7 @@ output VCF and are ignored for the prediction analysis.</p><div class="variablel
     1   ignored_field  three_prime_UTR 21  2054  .   -   .   Parent=transcript:TranscriptId
     1   ignored_field  exon            21  2148  .   -   .   Parent=transcript:TranscriptId
     1   ignored_field  CDS             21  2148  .   -   1   Parent=transcript:TranscriptId
-    1   ignored_field  five_prime_UTR  210 2148  .   -   .   Parent=transcript:TranscriptId</pre><div class="variablelist"><dl><dt><span class="term">
+    1   ignored_field  five_prime_UTR  210 2148  .   -   .   Parent=transcript:TranscriptId</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-i, --include</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     include only sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -1178,7 +1198,7 @@ output VCF and are ignored for the prediction analysis.</p><div class="variablel
 <span class="strong"><strong>-p, --phase</strong></span> <span class="emphasis"><em>a</em></span>|<span class="emphasis"><em>m</em></span>|<span class="emphasis"><em>r</em></span>|<span class="emphasis"><em>R</em></span>|<span class="emphasis"><em>s</em></span>
 </span></dt><dd><p class="simpara">
     how to handle unphased heterozygous genotypes:
-</p><div class="variablelist"><dl><dt><span class="term">
+</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="emphasis"><em>a</em></span>
 </span></dt><dd>
             take GTs as is, create haplotypes regardless of phase (0/1 → 0|1)
@@ -1257,7 +1277,7 @@ output VCF and are ignored for the prediction analysis.</p><div class="variablel
     BCSQ=stop_gained|C2orf83|ENST00000264387|-|141W&gt;141*|228476140C&gt;T
 
     # The consequence type of a variant downstream from a stop are prefixed with *
-    BCSQ=*missense|PER3|ENST00000361923|+|1028M&gt;1028T|7890117T&gt;C</pre></div><div class="refsect2" title="bcftools filter [OPTIONS] FILE"><a id="filter"></a><h3>bcftools filter <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Apply fixed-threshold filters.</p><div class="variablelist"><dl><dt><span class="term">
+    BCSQ=*missense|PER3|ENST00000361923|+|1028M&gt;1028T|7890117T&gt;C</pre></div><div class="refsect2"><a id="filter"></a><h3>bcftools filter <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span></h3><p>Apply fixed-threshold filters.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-e, --exclude</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     exclude sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -1275,7 +1295,7 @@ output VCF and are ignored for the prediction analysis.</p><div class="variablel
 Here the positions 1 and 6 are filtered, 0 and 7 are not:
          0123-456789
     ref  .G.G-..G..
-    ins  .A.GT..A..</pre><div class="variablelist"><dl><dt><span class="term">
+    ins  .A.GT..A..</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-G, --IndelGap</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     filter clusters of indels separated by <span class="emphasis"><em>INT</em></span> or fewer base pairs allowing
@@ -1288,7 +1308,7 @@ Here the positions 1 and 6 are filtered, 0 and 7 are not:
 And similarly here, the second is filtered:
          01 23 456 78
     ref  .A-.A-..A-..
-    ins  .AT.AT..AT..</pre><div class="variablelist"><dl><dt><span class="term">
+    ins  .AT.AT..AT..</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-i, --include</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     include only sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -1343,10 +1363,10 @@ And similarly here, the second is filtered:
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect2" title="bcftools gtcheck [OPTIONS] [-g genotypes.vcf.gz] query.vcf.gz"><a id="gtcheck"></a><h3>bcftools gtcheck [<span class="emphasis"><em>OPTIONS</em></span>] [<span class="strong"><strong>-g</strong></span> <span class="emphasis"><em>genotypes.vcf.gz</em></span>] <span class="emphasis"><em>query.vcf.gz</em></span></h3><p>Checks sample identity. The program can operate in two modes. If the <span class="strong"><strong>-g</strong></span>
+</dd></dl></div></div><div class="refsect2"><a id="gtcheck"></a><h3>bcftools gtcheck [<span class="emphasis"><em>OPTIONS</em></span>] [<span class="strong"><strong>-g</strong></span> <span class="emphasis"><em>genotypes.vcf.gz</em></span>] <span class="emphasis"><em>query.vcf.gz</em></span></h3><p>Checks sample identity. The program can operate in two modes. If the <span class="strong"><strong>-g</strong></span>
 option is given, the identity of samples from <span class="emphasis"><em>query.vcf.gz</em></span>
 is checked against the samples in the <span class="strong"><strong>-g</strong></span> file.
-Without the <span class="strong"><strong>-g</strong></span> option, multi-sample cross-check of samples in <span class="emphasis"><em>query.vcf.gz</em></span> is performed.</p><div class="variablelist"><dl><dt><span class="term">
+Without the <span class="strong"><strong>-g</strong></span> option, multi-sample cross-check of samples in <span class="emphasis"><em>query.vcf.gz</em></span> is performed.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--distinctive-sites</strong></span> <span class="emphasis"><em>NUM[,MEM[,DIR]]</em></span>
 </span></dt><dd>
     Find sites that can distinguish between at least NUM sample pairs. If the number is smaller or equal to 1,
@@ -1409,7 +1429,7 @@ Without the <span class="strong"><strong>-g</strong></span> option, multi-sample
     List of query samples or <span class="strong"><strong>-g</strong></span> samples. If neither <span class="strong"><strong>-s</strong></span> nor <span class="strong"><strong>-S</strong></span> are given, all possible sample
     pair combinations are compared</p><p><span class="strong"><strong>-S, --samples-file</strong></span> [<span class="emphasis"><em>qry</em></span>|<span class="emphasis"><em>gt</em></span>]:'FILE'
     File with the query or <span class="strong"><strong>-g</strong></span> samples to compare.  If neither <span class="strong"><strong>-s</strong></span> nor <span class="strong"><strong>-S</strong></span> are given, all possible sample
-    pair combinations are compared</p><div class="variablelist"><dl><dt><span class="term">
+    pair combinations are compared</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-t, --targets</strong></span> <span class="emphasis"><em>file</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -1430,13 +1450,13 @@ Without the <span class="strong"><strong>-g</strong></span> option, multi-sample
    bcftools gtcheck -s gt:a1,a2,a3 -s qry:b1,b2 -g A.bcf B.bcf
 
    # Compare only two pairs a1,b1 and a1,b2
-   bcftools gtcheck -p a1,b1,a1,b2 -g A.bcf B.bcf</pre></div><div class="refsect2" title="bcftools index [OPTIONS] in.bcf|in.vcf.gz"><a id="index"></a><h3>bcftools index [<span class="emphasis"><em>OPTIONS</em></span>]  <span class="emphasis"><em>in.bcf</em></span>|<span class="emphasis"><em>in.vcf.gz</em></span></h3><p>Creates index for bgzip compressed VCF/BCF files for random access. CSI
+   bcftools gtcheck -p a1,b1,a1,b2 -g A.bcf B.bcf</pre></div><div class="refsect2"><a id="index"></a><h3>bcftools index [<span class="emphasis"><em>OPTIONS</em></span>]  <span class="emphasis"><em>in.bcf</em></span>|<span class="emphasis"><em>in.vcf.gz</em></span></h3><p>Creates index for bgzip compressed VCF/BCF files for random access. CSI
 (coordinate-sorted index) is created by default. The CSI format
 supports indexing of chromosomes up to length 2^31. TBI (tabix index)
 index files, which support chromosome lengths up to 2^29, can be
 created by using the <span class="emphasis"><em>-t/--tbi</em></span> option or using the <span class="emphasis"><em>tabix</em></span> program
 packaged with htslib. When loading an index file, bcftools will try
-the CSI first and then the TBI.</p><div class="refsect3" title="Indexing options:"><a id="_indexing_options"></a><h4>Indexing options:</h4><div class="variablelist"><dl><dt><span class="term">
+the CSI first and then the TBI.</p><div class="refsect3"><a id="_indexing_options"></a><h4>Indexing options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --csi</strong></span>
 </span></dt><dd>
     generate CSI-format index for VCF/BCF files [default]
@@ -1461,7 +1481,7 @@ the CSI first and then the TBI.</p><div class="refsect3" title="Indexing options
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="Stats options:"><a id="_stats_options"></a><h4>Stats options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_stats_options"></a><h4>Stats options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-n, --nrecords</strong></span>
 </span></dt><dd>
     print the number of records based on the CSI or TBI index files
@@ -1472,10 +1492,10 @@ the CSI first and then the TBI.</p><div class="refsect3" title="Indexing options
     Output format is three tab-delimited columns listing the contig
     name, contig length (<span class="emphasis"><em>.</em></span> if unknown) and number of records for
     the contig. Contigs with zero records are not printed.
-</dd></dl></div></div></div><div class="refsect2" title="bcftools isec [OPTIONS] A.vcf.gz B.vcf.gz […]"><a id="isec"></a><h3>bcftools isec [<span class="emphasis"><em>OPTIONS</em></span>]  <span class="emphasis"><em>A.vcf.gz</em></span> <span class="emphasis"><em>B.vcf.gz</em></span> […]</h3><p>Creates intersections, unions and complements of VCF files. Depending
+</dd></dl></div></div></div><div class="refsect2"><a id="isec"></a><h3>bcftools isec [<span class="emphasis"><em>OPTIONS</em></span>]  <span class="emphasis"><em>A.vcf.gz</em></span> <span class="emphasis"><em>B.vcf.gz</em></span> […]</h3><p>Creates intersections, unions and complements of VCF files. Depending
 on the options, the program can output records from one (or more) files
 which have (or do not have) corresponding records with the same position
-in the other files.</p><div class="variablelist"><dl><dt><span class="term">
+in the other files.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --collapse</strong></span> <span class="emphasis"><em>snps</em></span>|<span class="emphasis"><em>indels</em></span>|<span class="emphasis"><em>both</em></span>|<span class="emphasis"><em>all</em></span>|<span class="emphasis"><em>some</em></span>|<span class="emphasis"><em>none</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -1540,9 +1560,9 @@ in the other files.</p><div class="variablelist"><dl><dt><span class="term">
 </span></dt><dd>
     list of input files to output given as 1-based indices. With <span class="strong"><strong>-p</strong></span> and no
     <span class="strong"><strong>-w</strong></span>, all files are written.
-</dd></dl></div><div class="refsect3" title="Examples:"><a id="_examples"></a><h4>Examples:</h4><p>Create intersection and complements of two sets saving the output in dir/*</p><pre class="screen">    bcftools isec -p dir A.vcf.gz B.vcf.gz</pre><p>Filter sites in A (require INFO/MAF&gt;=0.01) and B (require INFO/dbSNP) but not in C,
+</dd></dl></div><div class="refsect3"><a id="_examples"></a><h4>Examples:</h4><p>Create intersection and complements of two sets saving the output in dir/*</p><pre class="screen">    bcftools isec -p dir A.vcf.gz B.vcf.gz</pre><p>Filter sites in A (require INFO/MAF&gt;=0.01) and B (require INFO/dbSNP) but not in C,
 and create an intersection, including only sites which appear in at least two of
-the files after filters have been applied</p><pre class="screen">    bcftools isec -e'MAF&lt;0.01' -i'dbSNP=1' -e- A.vcf.gz B.vcf.gz C.vcf.gz -n +2 -p dir</pre><p>Extract and write records from A shared by both A and B using exact allele match</p><pre class="screen">    bcftools isec -p dir -n=2 -w1 A.vcf.gz B.vcf.gz</pre><p>Extract records private to A or B comparing by position only</p><pre class="screen">    bcftools isec -p dir -n-1 -c all A.vcf.gz B.vcf.gz</pre><p>Print a list of records which are present in A and B but not in C and D</p><pre class="screen">    bcftools isec -n~1100 -c all A.vcf.gz B.vcf.gz C.vcf.gz D.vcf.gz</pre></div></div><div class="refsect2" title="bcftools merge [OPTIONS] A.vcf.gz B.vcf.gz […]"><a id="merge"></a><h3>bcftools merge [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>A.vcf.gz</em></span> <span class="emphasis"><em>B.vcf.gz</em></span> […]</h3><p>Merge multiple VCF/BCF files from non-overlapping sample sets to create one
+the files after filters have been applied</p><pre class="screen">    bcftools isec -e'MAF&lt;0.01' -i'dbSNP=1' -e- A.vcf.gz B.vcf.gz C.vcf.gz -n +2 -p dir</pre><p>Extract and write records from A shared by both A and B using exact allele match</p><pre class="screen">    bcftools isec -p dir -n=2 -w1 A.vcf.gz B.vcf.gz</pre><p>Extract records private to A or B comparing by position only</p><pre class="screen">    bcftools isec -p dir -n-1 -c all A.vcf.gz B.vcf.gz</pre><p>Print a list of records which are present in A and B but not in C and D</p><pre class="screen">    bcftools isec -n~1100 -c all A.vcf.gz B.vcf.gz C.vcf.gz D.vcf.gz</pre></div></div><div class="refsect2"><a id="merge"></a><h3>bcftools merge [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>A.vcf.gz</em></span> <span class="emphasis"><em>B.vcf.gz</em></span> […]</h3><p>Merge multiple VCF/BCF files from non-overlapping sample sets to create one
 multi-sample file.  For example, when merging file <span class="emphasis"><em>A.vcf.gz</em></span> containing
 samples <span class="emphasis"><em>S1</em></span>, <span class="emphasis"><em>S2</em></span> and <span class="emphasis"><em>S3</em></span> and file <span class="emphasis"><em>B.vcf.gz</em></span> containing samples <span class="emphasis"><em>S3</em></span> and
 <span class="emphasis"><em>S4</em></span>, the output file will contain four samples named <span class="emphasis"><em>S1</em></span>, <span class="emphasis"><em>S2</em></span>, <span class="emphasis"><em>S3</em></span>, <span class="emphasis"><em>2:S3</em></span>
@@ -1550,7 +1570,7 @@ and <span class="emphasis"><em>S4</em></span>.</p><p>Note that it is responsibil
 unique across all files. If they are not, the program will exit with an error
 unless the option <span class="strong"><strong>--force-samples</strong></span> is given.  The sample names can be
 also given explicitly using the <span class="strong"><strong>--print-header</strong></span> and <span class="strong"><strong>--use-header</strong></span> options.</p><p>Note that only records from different files can be merged, never from the same file.
-For "vertical" merge take a look at <span class="strong"><strong><a class="link" href="#concat" title="bcftools concat [OPTIONS] FILE1 FILE2 […]">bcftools concat</a></strong></span> or <span class="strong"><strong><a class="link" href="#norm" title="bcftools norm [OPTIONS] file.vcf.gz">bcftools norm</a> -m</strong></span> instead.</p><div class="variablelist"><dl><dt><span class="term">
+For "vertical" merge take a look at <span class="strong"><strong><a class="link" href="#concat" title="bcftools concat [OPTIONS] FILE1 FILE2 […]">bcftools concat</a></strong></span> or <span class="strong"><strong><a class="link" href="#norm" title="bcftools norm [OPTIONS] file.vcf.gz">bcftools norm</a> -m</strong></span> instead.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--force-samples</strong></span>
 </span></dt><dd>
     if the merged files contain duplicate samples names, proceed anyway.
@@ -1620,7 +1640,7 @@ For "vertical" merge take a look at <span class="strong"><strong><a class="link"
 -m indels ..  allow multiallelic indel records
 -m both   ..  both SNP and indel records can be multiallelic
 -m all    ..  SNP records can be merged with indel records
--m id     ..  merge by ID</pre><div class="variablelist"><dl><dt><span class="term">
+-m id     ..  merge by ID</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--no-index</strong></span>
 </span></dt><dd>
     the option allows to merge files without indexing them first. In order for this
@@ -1650,7 +1670,7 @@ For "vertical" merge take a look at <span class="strong"><strong><a class="link"
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect2" title="bcftools mpileup [OPTIONS] -f ref.fa in.bam [in2.bam […]]"><a id="mpileup"></a><h3>bcftools mpileup [<span class="emphasis"><em>OPTIONS</em></span>] <span class="strong"><strong>-f</strong></span> <span class="emphasis"><em>ref.fa</em></span> <span class="emphasis"><em>in.bam</em></span> [<span class="emphasis"><em>in2.bam</em></span> […]]</h3><p>Generate VCF or BCF containing genotype likelihoods for one or multiple
+</dd></dl></div></div><div class="refsect2"><a id="mpileup"></a><h3>bcftools mpileup [<span class="emphasis"><em>OPTIONS</em></span>] <span class="strong"><strong>-f</strong></span> <span class="emphasis"><em>ref.fa</em></span> <span class="emphasis"><em>in.bam</em></span> [<span class="emphasis"><em>in2.bam</em></span> […]]</h3><p>Generate VCF or BCF containing genotype likelihoods for one or multiple
 alignment (BAM or CRAM) files. This is based on the original
 <span class="strong"><strong>samtools mpileup</strong></span> command (with the <span class="strong"><strong>-v</strong></span> or <span class="strong"><strong>-g</strong></span> options) producing
 genotype likelihoods in VCF or BCF format, but not the textual pileup
@@ -1669,7 +1689,7 @@ could be specified using <span class="strong"><strong>-r 20 -t chr20.bed</strong
 index is used to find chromosome 20 and then it is filtered for the
 regions listed in the BED file. Also note that the <span class="strong"><strong>-r</strong></span> option can be much
 slower than <span class="strong"><strong>-t</strong></span> with many regions and can require more memory when
-multiple regions and many alignment files are processed.</p><div class="refsect3" title="Input options"><a id="_input_options"></a><h4>Input options</h4><div class="variablelist"><dl><dt><span class="term">
+multiple regions and many alignment files are processed.</p><div class="refsect3"><a id="_input_options"></a><h4>Input options</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-6, --illumina1.3+</strong></span>
 </span></dt><dd>
     Assume the quality is in the Illumina 1.3+ encoding.
@@ -1694,8 +1714,7 @@ multiple regions and many alignment files are processed.</p><div class="refsect3
     Coefficient  for  downgrading mapping quality for reads containing
     excessive mismatches. Given a read with a phred-scaled probability q of
     being generated from the mapped position, the new mapping quality is
-    about sqrt((INT-q)/INT)*INT. A zero value disables this functionality; if
-    enabled, the recommended value for BWA is 50. [0]
+    about sqrt((INT-q)/INT)*INT. A zero value (the default) disables this functionality.
 </dd><dt><span class="term">
 <span class="strong"><strong>-d, --max-depth</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
@@ -1742,7 +1761,7 @@ multiple regions and many alignment files are processed.</p><div class="refsect3
     RG_ID_5  FILE_1.bam  SAMPLE_A
     RG_ID_6  FILE_2.bam  SAMPLE_A
     *        FILE_3.bam  SAMPLE_C
-    ?        FILE_3.bam  SAMPLE_D</pre><div class="variablelist"><dl><dt><span class="term">
+    ?        FILE_3.bam  SAMPLE_D</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-q, -min-MQ</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     Minimum mapping quality for an alignment to be used [0]
@@ -1798,7 +1817,7 @@ multiple regions and many alignment files are processed.</p><div class="refsect3
 <span class="strong"><strong>-x, --ignore-overlaps</strong></span>
 </span></dt><dd>
     Disable read-pair overlap detection.
-</dd></dl></div></div><div class="refsect3" title="Output options"><a id="_output_options"></a><h4>Output options</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_output_options"></a><h4>Output options</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-a, --annotate</strong></span> <span class="emphasis"><em>LIST</em></span>
 </span></dt><dd>
     Comma-separated list of FORMAT and INFO tags to output. (case-insensitive,
@@ -1820,7 +1839,7 @@ FORMAT/DV   .. Deprecated in favor of FORMAT/AD; Number of high-quality non-refe
 FORMAT/DP4  .. Deprecated in favor of FORMAT/ADF and FORMAT/ADR; Number of high-quality ref-forward, ref-reverse,
                alt-forward and alt-reverse bases (Number=4,Type=Integer)
 FORMAT/DPR  .. Deprecated in favor of FORMAT/AD; Number of high-quality bases for each observed allele (Number=R,Type=Integer)
-INFO/DPR    .. Deprecated in favor of INFO/AD; Number of high-quality bases for each observed allele (Number=R,Type=Integer)</pre><div class="variablelist"><dl><dt><span class="term">
+INFO/DPR    .. Deprecated in favor of INFO/AD; Number of high-quality bases for each observed allele (Number=R,Type=Integer)</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-g, --gvcf</strong></span> <span class="emphasis"><em>INT</em></span>[,…]
 </span></dt><dd>
     output gVCF blocks of homozygous REF calls, with depth (DP) ranges
@@ -1851,7 +1870,7 @@ INFO/DPR    .. Deprecated in favor of INFO/AD; Number of high-quality bases for 
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="Options for SNP/INDEL genotype likelihood computation"><a id="_options_for_snp_indel_genotype_likelihood_computation"></a><h4>Options for SNP/INDEL genotype likelihood computation</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_options_for_snp_indel_genotype_likelihood_computation"></a><h4>Options for SNP/INDEL genotype likelihood computation</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-e, --ext-prob</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     Phred-scaled gap extension sequencing error probability. Reducing <span class="emphasis"><em>INT</em></span>
@@ -1896,7 +1915,7 @@ INFO/DPR    .. Deprecated in favor of INFO/AD; Number of high-quality bases for 
     indel candidates are obtained. It is recommended to collect indel
     candidates from sequencing technologies that have low indel error rate
     such as ILLUMINA [all]
-</dd></dl></div></div><div class="refsect3" title="Examples:"><a id="_examples_2"></a><h4>Examples:</h4><p>Call SNPs and short INDELs, then mark low quality sites and sites with the read
+</dd></dl></div></div><div class="refsect3"><a id="_examples_2"></a><h4>Examples:</h4><p>Call SNPs and short INDELs, then mark low quality sites and sites with the read
 depth exceeding a limit. (The read depth should be adjusted to about twice the
 average read depth as higher read depths usually indicate problematic regions
 which are often enriched for artefacts.) One may consider to add <span class="strong"><strong>-C50</strong></span> to
@@ -1904,10 +1923,32 @@ mpileup if mapping quality is overestimated  for reads containing  excessive
 mismatches.  Applying this option usually helps for BWA-backtrack alignments,
 but may not other aligners.</p><pre class="screen">    bcftools mpileup -Ou -f ref.fa aln.bam | \
     bcftools call -Ou -mv | \
-    bcftools filter -s LowQual -e '%QUAL&lt;20 || DP&gt;100' &gt; var.flt.vcf</pre></div></div><div class="refsect2" title="bcftools norm [OPTIONS] file.vcf.gz"><a id="norm"></a><h3>bcftools norm [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>Left-align and normalize indels, check if REF alleles match the reference,
+    bcftools filter -s LowQual -e '%QUAL&lt;20 || DP&gt;100' &gt; var.flt.vcf</pre></div></div><div class="refsect2"><a id="norm"></a><h3>bcftools norm [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>Left-align and normalize indels, check if REF alleles match the reference,
 split multiallelic sites into multiple rows; recover multiallelics from
 multiple rows. Left-alignment and normalization will only be applied if
-the <span class="strong"><strong><a class="link" href="#fasta_ref">--fasta-ref</a></strong></span> option is supplied.</p><div class="variablelist"><dl><dt><span class="term">
+the <span class="strong"><strong><a class="link" href="#fasta_ref">--fasta-ref</a></strong></span> option is supplied.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
+<span class="strong"><strong>-a, --atomize</strong></span> <span class="emphasis"><em>.</em></span>|<span class="emphasis"><em>*</em></span>
+</span></dt><dd>
+    Decompose complex variants (e.g. split MNVs into consecutive SNVs).
+    Alleles missing because of an overlapping variant can be set either
+    to missing (.) or to the star alele (*), as recommended by
+    the VCF specification. IMPORTANT: Note that asterisk is expaneded
+    by shell and must be put in quotes or escaped by a backslash:
+</dd></dl></div><pre class="screen">    # Before atomization:
+    100  CC  C,GG   1/2
+
+    # After:
+    #   bcftools norm -a .
+    100  C       G      ./1
+    100  CC      C      1/.
+    101  C       G      ./1
+
+    # After:
+    #   bcftools norm -a '*'
+    #   bcftools norm -a \*
+    100  C       G,*    2/1
+    100  CC      C,*    1/2
+    101  C       G,*    2/1</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --check-ref</strong></span> <span class="emphasis"><em>e</em></span>|<span class="emphasis"><em>w</em></span>|<span class="emphasis"><em>x</em></span>|<span class="emphasis"><em>s</em></span>
 </span></dt><dd>
     what to do when incorrect or missing REF allele is encountered:
@@ -2002,13 +2043,13 @@ the <span class="strong"><strong><a class="link" href="#fasta_ref">--fasta-ref</
 </span></dt><dd>
     maximum distance between two records to consider when locally
     sorting variants which changed position during the realignment
-</dd></dl></div></div><div class="refsect2" title="bcftools [plugin NAME|+NAME] [OPTIONS] FILE — [PLUGIN OPTIONS]"><a id="plugin"></a><h3>bcftools [plugin <span class="emphasis"><em>NAME</em></span>|+<span class="emphasis"><em>NAME</em></span>] <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span> — <span class="emphasis"><em>[PLUGIN OPTIONS]</em></span></h3><p>A common framework for various utilities. The plugins can be used
+</dd></dl></div></div><div class="refsect2"><a id="plugin"></a><h3>bcftools [plugin <span class="emphasis"><em>NAME</em></span>|+<span class="emphasis"><em>NAME</em></span>] <span class="emphasis"><em>[OPTIONS]</em></span> <span class="emphasis"><em>FILE</em></span> — <span class="emphasis"><em>[PLUGIN OPTIONS]</em></span></h3><p>A common framework for various utilities. The plugins can be used
 the same way as normal commands only their name is prefixed with "+".
 Most plugins accept two types of parameters: general options shared by all
 plugins followed by a separator, and a list of plugin-specific options.  There
 are some exceptions to this rule, some plugins do not accept the common
 options and implement their own parameters. Therefore please pay attention to
-the usage examples that each plugin comes with.</p><div class="refsect3" title="VCF input options:"><a id="_vcf_input_options_2"></a><h4>VCF input options:</h4><div class="variablelist"><dl><dt><span class="term">
+the usage examples that each plugin comes with.</p><div class="refsect3"><a id="_vcf_input_options_2"></a><h4>VCF input options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-e, --exclude</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     exclude sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -2034,7 +2075,7 @@ the usage examples that each plugin comes with.</p><div class="refsect3" title="
 <span class="strong"><strong>-T, --targets-file</strong></span> <span class="emphasis"><em>file</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="VCF output options:"><a id="_vcf_output_options_2"></a><h4>VCF output options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_vcf_output_options_2"></a><h4>VCF output options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--no-version</strong></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -2050,7 +2091,7 @@ the usage examples that each plugin comes with.</p><div class="refsect3" title="
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="Plugin options:"><a id="_plugin_options"></a><h4>Plugin options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_plugin_options"></a><h4>Plugin options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-h, --help</strong></span>
 </span></dt><dd>
     list plugin’s options
@@ -2071,7 +2112,7 @@ the usage examples that each plugin comes with.</p><div class="refsect3" title="
 <span class="strong"><strong>-V, --version</strong></span>
 </span></dt><dd>
     print version string and exit
-</dd></dl></div></div><div class="refsect3" title="List of plugins coming with the distribution:"><a id="_list_of_plugins_coming_with_the_distribution"></a><h4>List of plugins coming with the distribution:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_list_of_plugins_coming_with_the_distribution"></a><h4>List of plugins coming with the distribution:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>ad-bias</strong></span>
 </span></dt><dd>
     find positions with wildly varying ALT allele frequency (Fisher test on FMT/AD)
@@ -2104,7 +2145,7 @@ the usage examples that each plugin comes with.</p><div class="refsect3" title="
 </span></dt><dd><p class="simpara">
     runs a basic association test, per-site or in a region, and checks for novel alleles and
     genotypes in two groups of samples. Adds the following INFO annotations:
-</p><div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
+</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
 PASSOC  .. Fisher’s exact test probability of genotypic association (REF vs non-REF allele)
 </li><li class="listitem">
 FASSOC  .. proportion of non-REF allele in controls and cases
@@ -2131,7 +2172,7 @@ NOVELGT .. lists samples with a novel genotype not observed in the control group
 <span class="strong"><strong>fill-tags</strong></span>
 </span></dt><dd><p class="simpara">
     set various INFO tags. The list of tags supported in this version:
-</p><div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
+</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
 INFO/AC         Number:A  Type:Integer  ..  Allele count in genotypes
 </li><li class="listitem">
 INFO/AC_Hom     Number:A  Type:Integer  ..  Allele counts in homozygous genotypes
@@ -2250,7 +2291,7 @@ TAG=func(TAG)   Number:1  Type:Integer  ..  Experimental support for user-define
 </span></dt><dd>
     convert between similar tags, such as GL and GP
 </dd><dt><span class="term">
-<span class="strong"><strong>trio-dnm</strong></span>
+<span class="strong"><strong>trio-dnm2</strong></span>
 </span></dt><dd>
     screen variants for possible de-novo mutations in trios
 </dd><dt><span class="term">
@@ -2266,7 +2307,7 @@ TAG=func(TAG)   Number:1  Type:Integer  ..  Experimental support for user-define
 <span class="strong"><strong>variantkey-hex</strong></span>
 </span></dt><dd>
     generate unsorted VariantKey-RSid index files in hexadecimal format
-</dd></dl></div></div><div class="refsect3" title="Examples:"><a id="_examples_3"></a><h4>Examples:</h4><pre class="screen"># List options common to all plugins
+</dd></dl></div></div><div class="refsect3"><a id="_examples_3"></a><h4>Examples:</h4><pre class="screen"># List options common to all plugins
 bcftools plugin
 
 # List available plugins
@@ -2291,11 +2332,11 @@ bcftools +dosage -h
 bcftools +missing2ref in.vcf
 
 # Replace missing genotypes with 0|0
-bcftools +missing2ref in.vcf -- -p</pre></div><div class="refsect3" title="Plugins troubleshooting:"><a id="_plugins_troubleshooting"></a><h4>Plugins troubleshooting:</h4><p>Things to check if your plugin does not show up in the <span class="strong"><strong>bcftools plugin -l</strong></span> output:</p><div class="itemizedlist"><ul class="itemizedlist" type="disc"><li class="listitem">
+bcftools +missing2ref in.vcf -- -p</pre></div><div class="refsect3"><a id="_plugins_troubleshooting"></a><h4>Plugins troubleshooting:</h4><p>Things to check if your plugin does not show up in the <span class="strong"><strong>bcftools plugin -l</strong></span> output:</p><div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
 Run with the <span class="strong"><strong>-v</strong></span> option for verbose output: <span class="strong"><strong>bcftools plugin -lv</strong></span>
 </li><li class="listitem">
 Does the environment variable BCFTOOLS_PLUGINS include the correct path?
-</li></ul></div></div><div class="refsect3" title="Plugins API:"><a id="_plugins_api"></a><h4>Plugins API:</h4><pre class="screen">// Short description used by 'bcftools plugin -l'
+</li></ul></div></div><div class="refsect3"><a id="_plugins_api"></a><h4>Plugins API:</h4><pre class="screen">// Short description used by 'bcftools plugin -l'
 const char *about(void);
 
 // Longer description used by 'bcftools +name -h'
@@ -2310,10 +2351,10 @@ int init(int argc, char **argv, bcf_hdr_t *in_hdr, bcf_hdr_t *out_hdr);
 bcf1_t *process(bcf1_t *rec);
 
 // Called after all lines have been processed to clean up
-void destroy(void);</pre></div></div><div class="refsect2" title="bcftools polysomy [OPTIONS] file.vcf.gz"><a id="polysomy"></a><h3>bcftools polysomy [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>Detect number of chromosomal copies in VCFs annotates with the Illumina’s
+void destroy(void);</pre></div></div><div class="refsect2"><a id="polysomy"></a><h3>bcftools polysomy [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>Detect number of chromosomal copies in VCFs annotates with the Illumina’s
 B-allele frequency (BAF) values. Note that this command is not compiled
 in by default, see the section <span class="strong"><strong>Optional Compilation with GSL</strong></span> in the INSTALL
-file for help.</p><div class="refsect3" title="General options:"><a id="_general_options_2"></a><h4>General options:</h4><div class="variablelist"><dl><dt><span class="term">
+file for help.</p><div class="refsect3"><a id="_general_options_2"></a><h4>General options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-o, --output-dir</strong></span> <span class="emphasis"><em>path</em></span>
 </span></dt><dd>
     output directory
@@ -2342,7 +2383,7 @@ file for help.</p><div class="refsect3" title="General options:"><a id="_general
 </span></dt><dd>
     verbose debugging output which gives hints about the thresholds and decisions made
     by the program. Note that the exact output can change between versions.
-</dd></dl></div></div><div class="refsect3" title="Algorithm options:"><a id="_algorithm_options"></a><h4>Algorithm options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_algorithm_options"></a><h4>Algorithm options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-b, --peak-size</strong></span> <span class="emphasis"><em>float</em></span>
 </span></dt><dd>
     the minimum peak size considered as a good match can be from the interval [0,1]
@@ -2374,7 +2415,7 @@ file for help.</p><div class="refsect3" title="General options:"><a id="_general
 </span></dt><dd>
     a heuristics to filter failed fits where the expected peak symmetry is violated.
     The <span class="emphasis"><em>float</em></span> is from the interval [0,1] and larger is stricter
-</dd></dl></div></div></div><div class="refsect2" title="bcftools query [OPTIONS] file.vcf.gz [file.vcf.gz […]]"><a id="query"></a><h3>bcftools query [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span> [<span class="emphasis"><em>file.vcf.gz</em></span> […]]</h3><p>Extracts fields from VCF or BCF files and outputs them in user-defined format.</p><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div></div><div class="refsect2"><a id="query"></a><h3>bcftools query [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span> [<span class="emphasis"><em>file.vcf.gz</em></span> […]]</h3><p>Extracts fields from VCF or BCF files and outputs them in user-defined format.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-e, --exclude</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>
     exclude sites for which <span class="emphasis"><em>EXPRESSION</em></span> is true. For valid expressions see
@@ -2433,7 +2474,7 @@ file for help.</p><div class="refsect3" title="General options:"><a id="_general
 <span class="strong"><strong>-v, --vcf-list</strong></span> <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     process multiple VCFs listed in the file
-</dd></dl></div><div class="refsect3" title="Format:"><a id="_format"></a><h4>Format:</h4><pre class="literallayout">%CHROM          The CHROM column (similarly also other columns: POS, ID, REF, ALT, QUAL, FILTER)
+</dd></dl></div><div class="refsect3"><a id="_format"></a><h4>Format:</h4><pre class="literallayout">%CHROM          The CHROM column (similarly also other columns: POS, ID, REF, ALT, QUAL, FILTER)
 %END            End position of the REF allele
 %END0           End position of the REF allele in 0-based coordinates
 %FIRST_ALT      Alias for %ALT{0}
@@ -2454,7 +2495,7 @@ file for help.</p><div class="refsect3" title="General options:"><a id="_general
 %TYPE           Variant type (REF, SNP, MNP, INDEL, BND, OTHER)
 []              Format fields must be enclosed in brackets to loop over all samples
 \n              new line
-\t              tab character</pre><pre class="literallayout">Everything else is printed verbatim.</pre></div><div class="refsect3" title="Examples:"><a id="_examples_4"></a><h4>Examples:</h4><pre class="literallayout"># Print chromosome, position, ref allele and the first alternate allele
+\t              tab character</pre><pre class="literallayout">Everything else is printed verbatim.</pre></div><div class="refsect3"><a id="_examples_4"></a><h4>Examples:</h4><pre class="literallayout"># Print chromosome, position, ref allele and the first alternate allele
 bcftools query -f '%CHROM  %POS  %REF  %ALT{0}\n' file.vcf.gz</pre><pre class="literallayout"># Similar to above, but use tabs instead of spaces, add sample name and genotype
 bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%SAMPLE=%GT]\n' file.vcf.gz</pre><pre class="literallayout"># Print FORMAT/GT fields followed by FORMAT/GT fields
 bcftools query -f 'GQ:[ %GQ] \t GT:[ %GT]\n' file.vcf</pre><pre class="literallayout"># Make a BED file: chr, pos (0-based), end pos (1-based), id
@@ -2464,7 +2505,7 @@ bcftools view -i'GT="alt"' file.bcf -Ou | bcftools query -f'[%CHROM:%POS %SAMPLE
 bcftools query -i'GT="het"' -f'[%CHROM:%POS %SAMPLE %GT %pbinom(AD)\n]' file.vcf</pre><pre class="literallayout"># Print the second value of AC field if bigger than 10. Note the (unfortunate) difference in
 # index subscript notation: formatting expressions (-f) uses "{}" while filtering expressions
 # (-i) use "[]". This is for historic reasons and backward-compatibility.
-bcftools query -f '%AC{1}\n' -i 'AC[1]&gt;10' file.vcf.gz</pre></div></div><div class="refsect2" title="bcftools reheader [OPTIONS] file.vcf.gz"><a id="reheader"></a><h3>bcftools reheader [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>Modify header of VCF/BCF files, change sample names.</p><div class="variablelist"><dl><dt><span class="term">
+bcftools query -f '%AC{1}\n' -i 'AC[1]&gt;10' file.vcf.gz</pre></div></div><div class="refsect2"><a id="reheader"></a><h3>bcftools reheader [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>Modify header of VCF/BCF files, change sample names.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-f, --fai</strong></span> <span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     add to the header contig names and their lengths from the provided fasta index file (.fai).
@@ -2491,8 +2532,8 @@ bcftools query -f '%AC{1}\n' -i 'AC[1]&gt;10' file.vcf.gz</pre></div></div><div 
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect2" title="bcftools roh [OPTIONS] file.vcf.gz"><a id="roh"></a><h3>bcftools roh [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>A program for detecting runs of homo/autozygosity. Only bi-allelic sites
-are considered.</p><div class="refsect3" title="The HMM model:"><a id="_the_hmm_model"></a><h4>The HMM model:</h4><pre class="screen">Notation:
+</dd></dl></div></div><div class="refsect2"><a id="roh"></a><h3>bcftools roh [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span></h3><p>A program for detecting runs of homo/autozygosity. Only bi-allelic sites
+are considered.</p><div class="refsect3"><a id="_the_hmm_model"></a><h4>The HMM model:</h4><pre class="screen">Notation:
   D  = Data, AZ = autozygosity, HW = Hardy-Weinberg (non-autozygosity),
   f  = non-ref allele frequency
 
@@ -2509,7 +2550,7 @@ Transition probabilities:
   HWi = P_i(HW)
 
   P_{i+1}(AZ) = oAZ * max[(1 - tAZ * ci) * AZ{i-1} , tAZ * ci * (1-AZ{i-1})]
-  P_{i+1}(HW) = oHW * max[(1 - tHW * ci) * (1-AZ{i-1}) , tHW * ci * AZ{i-1}]</pre></div><div class="refsect3" title="General Options:"><a id="_general_options_3"></a><h4>General Options:</h4><div class="variablelist"><dl><dt><span class="term">
+  P_{i+1}(HW) = oHW * max[(1 - tHW * ci) * (1-AZ{i-1}) , tHW * ci * AZ{i-1}]</pre></div><div class="refsect3"><a id="_general_options_3"></a><h4>General Options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--AF-dflt</strong></span> <span class="emphasis"><em>FLOAT</em></span>
 </span></dt><dd>
     in case allele frequency is not known, use the <span class="emphasis"><em>FLOAT</em></span>. By default, sites where
@@ -2528,7 +2569,7 @@ Transition probabilities:
     <span class="strong"><strong>bgzip</strong></span> and indexed with tabix -s1 -b2 -e2.  Sites which are not present in
     the <span class="emphasis"><em>FILE</em></span> or have different reference or alternate allele will be skipped.
     Note that such a file can be easily created from a VCF using:
-</dd></dl></div><pre class="screen">    bcftools query -f'%CHROM\t%POS\t%REF,%ALT\t%INFO/TAG\n' file.vcf | bgzip -c &gt; freqs.tab.gz</pre><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div><pre class="screen">    bcftools query -f'%CHROM\t%POS\t%REF,%ALT\t%INFO/TAG\n' file.vcf | bgzip -c &gt; freqs.tab.gz</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-b, --buffer-size</strong></span> <span class="emphasis"><em>INT</em></span>[,<span class="emphasis"><em>INT</em></span>]
 </span></dt><dd>
     when the entire many-sample file cannot fit into memory, a sliding
@@ -2617,7 +2658,7 @@ Transition probabilities:
 <span class="strong"><strong>-T, --targets-file</strong></span> <span class="emphasis"><em>file</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="HMM Options:"><a id="_hmm_options_2"></a><h4>HMM Options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_hmm_options_2"></a><h4>HMM Options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-a, --hw-to-az</strong></span> <span class="emphasis"><em>FLOAT</em></span>
 </span></dt><dd>
     P(AZ|HW) transition probability from AZ (autozygous) to HW (Hardy-Weinberg) state
@@ -2630,7 +2671,7 @@ Transition probabilities:
 </span></dt><dd>
     estimate HMM parameters using Baum-Welch algorithm, using the convergence threshold
     <span class="emphasis"><em>FLOAT</em></span>, e.g. 1e-10 (experimental)
-</dd></dl></div></div></div><div class="refsect2" title="bcftools sort [OPTIONS] file.bcf"><a id="sort"></a><h3>bcftools sort [<span class="emphasis"><em>OPTIONS</em></span>] file.bcf</h3><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div></div><div class="refsect2"><a id="sort"></a><h3>bcftools sort [<span class="emphasis"><em>OPTIONS</em></span>] file.bcf</h3><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-m, --max-mem</strong></span> <span class="emphasis"><em>FLOAT</em></span>[<span class="emphasis"><em>kMG</em></span>]
 </span></dt><dd>
     Maximum memory to use. Approximate, affects the number of temporary files written
@@ -2648,7 +2689,7 @@ Transition probabilities:
 <span class="strong"><strong>-T, --temp-dir</strong></span> <span class="emphasis"><em>DIR</em></span>
 </span></dt><dd>
     Use this directory to store temporary files
-</dd></dl></div></div><div class="refsect2" title="bcftools stats [OPTIONS] A.vcf.gz [B.vcf.gz]"><a id="stats"></a><h3>bcftools stats [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>A.vcf.gz</em></span> [<span class="emphasis"><em>B.vcf.gz</em></span>]</h3><p>Parses VCF or BCF and produces text file stats which is suitable for machine
+</dd></dl></div></div><div class="refsect2"><a id="stats"></a><h3>bcftools stats [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>A.vcf.gz</em></span> [<span class="emphasis"><em>B.vcf.gz</em></span>]</h3><p>Parses VCF or BCF and produces text file stats which is suitable for machine
 processing and can be plotted using <span class="strong"><strong><a class="link" href="#plot-vcfstats" title="plot-vcfstats [OPTIONS] file.vchk […]">plot-vcfstats</a></strong></span>.  When two files are given,
 the program generates separate stats for intersection and the complements. By
 default only sites are compared, <span class="strong"><strong>-s</strong></span>/<span class="strong"><strong>-S</strong></span> must given to include also sample
@@ -2658,7 +2699,7 @@ frequency, depth distribution, stats by quality and per-sample counts, singleton
 etc. are printed.
 When two VCF files are given, then stats such as concordance (Genotype concordance by
 non-reference allele frequency, Genotype concordance by sample, Non-Reference Discordance)
-and correlation are also printed. Per-site discordance (PSD) is also printed in <span class="strong"><strong>--verbose</strong></span> mode.</p><div class="variablelist"><dl><dt><span class="term">
+and correlation are also printed. Per-site discordance (PSD) is also printed in <span class="strong"><strong>--verbose</strong></span> mode.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>--af-bins</strong></span> <span class="emphasis"><em>LIST</em></span>|<span class="emphasis"><em>FILE</em></span>
 </span></dt><dd>
     comma separated list of allele frequency bins (e.g. 0.1,0.5,1)
@@ -2695,7 +2736,7 @@ and correlation are also printed. Per-site discordance (PSD) is also printed in 
     tab-delimited file with exons for indel frameshifts statistics. The columns
     of the file are CHR, FROM, TO, with 1-based, inclusive, positions. The file
     is BGZF-compressed and indexed with tabix
-</dd></dl></div><pre class="screen">    tabix -s1 -b2 -e3 file.gz</pre><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div><pre class="screen">    tabix -s1 -b2 -e3 file.gz</pre><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-f, --apply-filters</strong></span> <span class="emphasis"><em>LIST</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -2745,8 +2786,8 @@ and correlation are also printed. Per-site discordance (PSD) is also printed in 
 <span class="strong"><strong>-v, --verbose</strong></span>
 </span></dt><dd>
     produce verbose per-site and per-sample output
-</dd></dl></div></div><div class="refsect2" title="bcftools view [OPTIONS] file.vcf.gz [REGION […]]"><a id="view"></a><h3>bcftools view [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span> [<span class="emphasis"><em>REGION</em></span> […]]</h3><p>View, subset and filter VCF or BCF files by position and filtering expression.
-Convert between VCF and BCF. Former <span class="strong"><strong>bcftools subset</strong></span>.</p><div class="refsect3" title="Output options"><a id="_output_options_2"></a><h4>Output options</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect2"><a id="view"></a><h3>bcftools view [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vcf.gz</em></span> [<span class="emphasis"><em>REGION</em></span> […]]</h3><p>View, subset and filter VCF or BCF files by position and filtering expression.
+Convert between VCF and BCF. Former <span class="strong"><strong>bcftools subset</strong></span>.</p><div class="refsect3"><a id="_output_options_2"></a><h4>Output options</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-G, --drop-genotypes</strong></span>
 </span></dt><dd>
     drop individual genotype information (after subsetting if <span class="strong"><strong>-s</strong></span> option is set)
@@ -2772,7 +2813,7 @@ Convert between VCF and BCF. Former <span class="strong"><strong>bcftools subset
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
 </dd></dl></div><p><span class="strong"><strong>-o, --output</strong></span> <span class="emphasis"><em>FILE</em></span>:
-    output file name. If not present, the default is to print to standard output (stdout).</p><div class="variablelist"><dl><dt><span class="term">
+    output file name. If not present, the default is to print to standard output (stdout).</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-r, --regions</strong></span> <span class="emphasis"><em>chr</em></span>|<span class="emphasis"><em>chr:pos</em></span>|<span class="emphasis"><em>chr:from-to</em></span>|<span class="emphasis"><em>chr:from-</em></span>[,…]
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
@@ -2792,7 +2833,7 @@ Convert between VCF and BCF. Former <span class="strong"><strong>bcftools subset
 <span class="strong"><strong>--threads</strong></span> <span class="emphasis"><em>INT</em></span>
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>
-</dd></dl></div></div><div class="refsect3" title="Subset options:"><a id="_subset_options"></a><h4>Subset options:</h4><div class="variablelist"><dl><dt><span class="term">
+</dd></dl></div></div><div class="refsect3"><a id="_subset_options"></a><h4>Subset options:</h4><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-a, --trim-alt-alleles</strong></span>
 </span></dt><dd>
     remove alleles not seen in the genotype fields from the ALT column. Note that if no alternate allele
@@ -2817,7 +2858,7 @@ Convert between VCF and BCF. Former <span class="strong"><strong>bcftools subset
 </span></dt><dd>
     see <span class="strong"><strong><a class="link" href="#common_options" title="Common Options">Common Options</a></strong></span>. Note that it is possible to create
     multiple subsets simultaneously using the <span class="strong"><strong>split</strong></span> plugin.
-</dd></dl></div></div><div class="refsect3" title="Filter options:"><a id="_filter_options"></a><h4>Filter options:</h4><p>Note that filter options below dealing with counting the number of alleles
+</dd></dl></div></div><div class="refsect3"><a id="_filter_options"></a><h4>Filter options:</h4><p>Note that filter options below dealing with counting the number of alleles
 will, for speed, first check for the values of AC and AN in the INFO column to
 avoid parsing all the genotype (FORMAT/GT) fields in the VCF. This means
 that a filter like <span class="emphasis"><em>--min-af 0.1</em></span> will be calculated from INFO/AC and INFO/AN
@@ -2828,7 +2869,7 @@ is performed before sample removal, but the <span class="strong"><strong>-P</str
 and some are inherently ambiguous, for example allele counts can be taken from the INFO
 column when present but calculated on the fly when absent. Therefore it is strongly recommended to spell out the
 required order explicitly by separating such commands into two steps. (Make sure to use the <span class="strong"><strong>-O u</strong></span> option
-when piping!)</p><div class="variablelist"><dl><dt><span class="term">
+when piping!)</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-c, --min-ac</strong></span> <span class="emphasis"><em>INT</em></span>[<span class="emphasis"><em>:nref</em></span>|<span class="emphasis"><em>:alt1</em></span>|<span class="emphasis"><em>:minor</em></span>|<span class="emphasis"><em>:major</em></span>|:'nonmajor']
 </span></dt><dd>
     minimum allele count (INFO/AC) of sites to be printed.
@@ -2939,10 +2980,10 @@ when piping!)</p><div class="variablelist"><dl><dt><span class="term">
 <span class="strong"><strong>-X, --exclude-private</strong></span>
 </span></dt><dd>
     exclude sites where only the subset samples carry an non-reference allele
-</dd></dl></div></div></div><div class="refsect2" title="bcftools help [COMMAND] | bcftools --help [COMMAND]"><a id="help"></a><h3>bcftools help [<span class="emphasis"><em>COMMAND</em></span>] | bcftools --help [<span class="emphasis"><em>COMMAND</em></span>]</h3><p>Display  a  brief usage message listing the bcftools commands available.
+</dd></dl></div></div></div><div class="refsect2"><a id="help"></a><h3>bcftools help [<span class="emphasis"><em>COMMAND</em></span>] | bcftools --help [<span class="emphasis"><em>COMMAND</em></span>]</h3><p>Display  a  brief usage message listing the bcftools commands available.
 If the name of a command is also given, e.g., bcftools help view, the detailed
-usage message for that particular command is displayed.</p></div><div class="refsect2" title="bcftools [--version|-v]"><a id="version"></a><h3>bcftools [<span class="emphasis"><em>--version</em></span>|<span class="emphasis"><em>-v</em></span>]</h3><p>Display the version numbers and copyright information for bcftools and the
-important libraries used by bcftools.</p></div><div class="refsect2" title="bcftools [--version-only]"><a id="version-only"></a><h3>bcftools [<span class="emphasis"><em>--version-only</em></span>]</h3><p>Display the full bcftools version number in a machine-readable format.</p></div></div><div class="refsect1" title="EXPRESSIONS"><a id="expressions"></a><h2>EXPRESSIONS</h2><p>These filtering expressions are accepted by most of the commands.</p><div class="itemizedlist" title="Valid expressions may contain:"><p class="title"><strong>Valid expressions may contain:</strong></p><ul class="itemizedlist" type="disc"><li class="listitem"><p class="simpara">
+usage message for that particular command is displayed.</p></div><div class="refsect2"><a id="version"></a><h3>bcftools [<span class="emphasis"><em>--version</em></span>|<span class="emphasis"><em>-v</em></span>]</h3><p>Display the version numbers and copyright information for bcftools and the
+important libraries used by bcftools.</p></div><div class="refsect2"><a id="version-only"></a><h3>bcftools [<span class="emphasis"><em>--version-only</em></span>]</h3><p>Display the full bcftools version number in a machine-readable format.</p></div></div><div class="refsect1"><a id="expressions"></a><h2>EXPRESSIONS</h2><p>These filtering expressions are accepted by most of the commands.</p><div class="itemizedlist"><p class="title"><strong>Valid expressions may contain:</strong></p><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem"><p class="simpara">
 numerical constants, string constants, file names (this is currently
   supported only to filter by the ID column)
 </p><pre class="literallayout">1, 1.0, 1e-4
@@ -3052,7 +3093,7 @@ custom perl filtering. Note that this command is not compiled in by default, see
 the section <span class="strong"><strong>Optional Compilation with Perl</strong></span> in the INSTALL file for help
 and misc/demo-flt.pl for a working example. The demo defined the perl subroutine
 "severity" which can be invoked from the command line as follows:
-</p><pre class="literallayout">perl:path/to/script.pl; perl.severity(INFO/CSQ) &gt; 3</pre></li></ul></div><div class="itemizedlist" title="Notes:"><p class="title"><strong>Notes:</strong></p><ul class="itemizedlist" type="disc"><li class="listitem">
+</p><pre class="literallayout">perl:path/to/script.pl; perl.severity(INFO/CSQ) &gt; 3</pre></li></ul></div><div class="itemizedlist"><p class="title"><strong>Notes:</strong></p><ul class="itemizedlist" style="list-style-type: disc; "><li class="listitem">
 String comparisons and regular expressions are case-insensitive
 </li><li class="listitem"><p class="simpara">
 Comma in strings is interpreted as a separator and when multiple values are compared, the OR logic is used.
@@ -3076,9 +3117,9 @@ used on the result. For example, when querying "TAG=1,2,3,4", it will be evaluat
 -e 'TAG[0]!=1'  .. true</pre></li></ul></div><p><span class="strong"><strong>Examples:</strong></span></p><pre class="literallayout">MIN(DV)&gt;5       .. selects the whole site, evaluates min across all values and samples</pre><pre class="literallayout">SMPL_MIN(DV)&gt;5  .. selects matching samples, evaluates within samples</pre><pre class="literallayout">MIN(DV/DP)&gt;0.3</pre><pre class="literallayout">MIN(DP)&gt;10 &amp; MIN(DV)&gt;3</pre><pre class="literallayout">FMT/DP&gt;10  &amp; FMT/GQ&gt;10 .. both conditions must be satisfied within one sample</pre><pre class="literallayout">FMT/DP&gt;10 &amp;&amp; FMT/GQ&gt;10 .. the conditions can be satisfied in different samples</pre><pre class="literallayout">QUAL&gt;10 |  FMT/GQ&gt;10   .. true for sites with QUAL&gt;10 or a sample with GQ&gt;10, but selects only samples with GQ&gt;10</pre><pre class="literallayout">QUAL&gt;10 || FMT/GQ&gt;10   .. true for sites with QUAL&gt;10 or a sample with GQ&gt;10, plus selects all samples at such sites</pre><pre class="literallayout">TYPE="snp" &amp;&amp; QUAL&gt;=10 &amp;&amp; (DP4[2]+DP4[3] &gt; 2)</pre><pre class="literallayout">COUNT(GT="hom")=0      .. no homozygous genotypes at the site</pre><pre class="literallayout">AVG(GQ)&gt;50             .. average (arithmetic mean) of genotype qualities bigger than 50</pre><pre class="literallayout">ID=@file       .. selects lines with ID present in the file</pre><pre class="literallayout">ID!=@~/file    .. skip lines with ID present in the ~/file</pre><pre class="literallayout">MAF[0]&lt;0.05    .. select rare variants at 5% cutoff</pre><pre class="literallayout">POS&gt;=100   .. restrict your range query, e.g. 20:100-200 to strictly sites with POS in that range.</pre><p><span class="strong"><strong>Shell expansion:</strong></span></p><p>Note that expressions must often be quoted because some characters
 have special meaning in the shell.
 An example of expression enclosed in single quotes which cause
-that the whole expression is passed to the program as intended:</p><pre class="literallayout">bcftools view -i '%ID!="." &amp; MAF[0]&lt;0.01'</pre><p>Please refer to the documentation of your shell for details.</p></div><div class="refsect1" title="SCRIPTS AND OPTIONS"><a id="_scripts_and_options"></a><h2>SCRIPTS AND OPTIONS</h2><div class="refsect2" title="plot-vcfstats [OPTIONS] file.vchk […]"><a id="plot-vcfstats"></a><h3>plot-vcfstats [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vchk</em></span> […]</h3><p>Script for processing output of <span class="strong"><strong><a class="link" href="#stats" title="bcftools stats [OPTIONS] A.vcf.gz [B.vcf.gz]">bcftools stats</a></strong></span>. It can merge
+that the whole expression is passed to the program as intended:</p><pre class="literallayout">bcftools view -i '%ID!="." &amp; MAF[0]&lt;0.01'</pre><p>Please refer to the documentation of your shell for details.</p></div><div class="refsect1"><a id="_scripts_and_options"></a><h2>SCRIPTS AND OPTIONS</h2><div class="refsect2"><a id="plot-vcfstats"></a><h3>plot-vcfstats [<span class="emphasis"><em>OPTIONS</em></span>] <span class="emphasis"><em>file.vchk</em></span> […]</h3><p>Script for processing output of <span class="strong"><strong><a class="link" href="#stats" title="bcftools stats [OPTIONS] A.vcf.gz [B.vcf.gz]">bcftools stats</a></strong></span>. It can merge
 results from multiple outputs (useful when running the stats for each
-chromosome separately), plots graphs and creates a PDF presentation.</p><div class="variablelist"><dl><dt><span class="term">
+chromosome separately), plots graphs and creates a PDF presentation.</p><div class="variablelist"><dl class="variablelist"><dt><span class="term">
 <span class="strong"><strong>-m, --merge</strong></span>
 </span></dt><dd>
     Merge vcfstats files to STDOUT, skip plotting.
@@ -3116,15 +3157,15 @@ chromosome separately), plots graphs and creates a PDF presentation.</p><div cla
 bcftools stats -s - &gt; file.vchk</pre><pre class="literallayout"># Plot the stats
 plot-vcfstats -p outdir file.vchk</pre><pre class="literallayout"># The final looks can be customized by editing the generated
 # 'outdir/plot.py' script and re-running manually
-cd outdir &amp;&amp; python plot.py &amp;&amp; pdflatex summary.tex</pre></div></div><div class="refsect1" title="PERFORMANCE"><a id="_performance"></a><h2>PERFORMANCE</h2><p>HTSlib was designed with BCF format in mind. When parsing VCF files, all records
+cd outdir &amp;&amp; python plot.py &amp;&amp; pdflatex summary.tex</pre></div></div><div class="refsect1"><a id="_performance"></a><h2>PERFORMANCE</h2><p>HTSlib was designed with BCF format in mind. When parsing VCF files, all records
 are internally converted into BCF representation. Simple operations, like removing
 a single column from a VCF file, can be therefore done much faster with standard
 UNIX commands, such as <span class="strong"><strong>awk</strong></span> or <span class="strong"><strong>cut</strong></span>.
 Therefore it is recommended to use BCF as input/output format whenever possible to avoid
-large overhead of the VCF → BCF → VCF conversion.</p></div><div class="refsect1" title="BUGS"><a id="_bugs"></a><h2>BUGS</h2><p>Please report any bugs you encounter on the github website: <a class="ulink" href="http://github.com/samtools/bcftools" target="_top">http://github.com/samtools/bcftools</a></p></div><div class="refsect1" title="AUTHORS"><a id="_authors"></a><h2>AUTHORS</h2><p>Heng Li from the Sanger Institute wrote the original C version of htslib,
+large overhead of the VCF → BCF → VCF conversion.</p></div><div class="refsect1"><a id="_bugs"></a><h2>BUGS</h2><p>Please report any bugs you encounter on the github website: <a class="ulink" href="http://github.com/samtools/bcftools" target="_top">http://github.com/samtools/bcftools</a></p></div><div class="refsect1"><a id="_authors"></a><h2>AUTHORS</h2><p>Heng Li from the Sanger Institute wrote the original C version of htslib,
 samtools and bcftools. Bob Handsaker from the Broad Institute implemented the
 BGZF library. Petr Danecek, Shane McCarthy and John Marshall are  maintaining
 and further developing bcftools.  Many other people contributed to the program
 and to the file format specifications, both directly and indirectly by
-providing patches, testing and reporting bugs. We thank them all.</p></div><div class="refsect1" title="RESOURCES"><a id="_resources"></a><h2>RESOURCES</h2><p>BCFtools GitHub website: <a class="ulink" href="http://github.com/samtools/bcftools" target="_top">http://github.com/samtools/bcftools</a></p><p>Samtools GitHub website: <a class="ulink" href="http://github.com/samtools/samtools" target="_top">http://github.com/samtools/samtools</a></p><p>HTSlib GitHub website: <a class="ulink" href="http://github.com/samtools/htslib" target="_top">http://github.com/samtools/htslib</a></p><p>File format specifications: <a class="ulink" href="http://samtools.github.io/hts-specs" target="_top">http://samtools.github.io/hts-specs</a></p><p>BCFtools documentation: <a class="ulink" href="http://samtools.github.io/bcftools" target="_top">http://samtools.github.io/bcftools</a></p><p>BCFtools wiki page: <a class="ulink" href="https://github.com/samtools/bcftools/wiki" target="_top">https://github.com/samtools/bcftools/wiki</a></p></div><div class="refsect1" title="COPYING"><a id="_copying"></a><h2>COPYING</h2><p>The MIT/Expat License or GPL License, see the LICENSE document for details.
+providing patches, testing and reporting bugs. We thank them all.</p></div><div class="refsect1"><a id="_resources"></a><h2>RESOURCES</h2><p>BCFtools GitHub website: <a class="ulink" href="http://github.com/samtools/bcftools" target="_top">http://github.com/samtools/bcftools</a></p><p>Samtools GitHub website: <a class="ulink" href="http://github.com/samtools/samtools" target="_top">http://github.com/samtools/samtools</a></p><p>HTSlib GitHub website: <a class="ulink" href="http://github.com/samtools/htslib" target="_top">http://github.com/samtools/htslib</a></p><p>File format specifications: <a class="ulink" href="http://samtools.github.io/hts-specs" target="_top">http://samtools.github.io/hts-specs</a></p><p>BCFtools documentation: <a class="ulink" href="http://samtools.github.io/bcftools" target="_top">http://samtools.github.io/bcftools</a></p><p>BCFtools wiki page: <a class="ulink" href="https://github.com/samtools/bcftools/wiki" target="_top">https://github.com/samtools/bcftools/wiki</a></p></div><div class="refsect1"><a id="_copying"></a><h2>COPYING</h2><p>The MIT/Expat License or GPL License, see the LICENSE document for details.
 Copyright (c) Genome Research Ltd.</p></div></div></body></html>

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1983,6 +1983,34 @@ split multiallelic sites into multiple rows; recover multiallelics from
 multiple rows. Left-alignment and normalization will only be applied if
 the *<<fasta_ref,--fasta-ref>>* option is supplied.
 
+*-a, --atomize*::
+    Decompose complex variants, e.g. split MNVs into consecutive SNVs.
+    See also *--atom-overlaps* and *--old-rec-tag*.
+
+*--atom-overlaps* '.'|'*'::
+    Alleles missing because of an overlapping variant can be set either 
+    to missing (.) or to the star alele (*), as recommended by
+    the VCF specification. IMPORTANT: Note that asterisk is expaneded
+    by shell and must be put in quotes or escaped by a backslash:
+----
+    # Before atomization:
+    100  CC  C,GG   1/2
+
+    # After:
+    #   bcftools norm -a .
+    100	 C	 G      ./1
+    100	 CC	 C      1/.
+    101	 C	 G      ./1
+
+    # After:
+    #   bcftools norm -a '*'
+    #   bcftools norm -a \*
+    100	 C	 G,*    2/1
+    100	 CC	 C,*    1/2
+    101	 C	 G,*    2/1
+
+----
+
 *-c, --check-ref* 'e'|'w'|'x'|'s'::
     what to do when incorrect or missing REF allele is encountered:
     exit ('e'), warn ('w'), exclude ('x'), or set/fix ('s') bad sites.
@@ -2031,6 +2059,10 @@ the *<<fasta_ref,--fasta-ref>>* option is supplied.
     the '-c s' option can be used to fix or set the REF allele from the
     reference '-f'. The '-N' option will not turn on indel normalisation
     as the '-f' option normally implies
+
+*--old-rec-tag* 'STR'::
+    Add INFO/STR annotation with the original record. The format of the
+    annotation is CHROM|POS|REF|ALT|USED_ALT_IDX. 
 
 *-o, --output* 'FILE'::
     see *<<common_options,Common Options>>*

--- a/test/atomize.split.1.1.out
+++ b/test/atomize.split.1.1.out
@@ -1,0 +1,46 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=135006516>
+##FILTER=<ID=flt,Description="Test FILTER">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=XRF,Number=R,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAF,Number=A,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGF,Number=G,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XRI,Number=R,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAI,Number=A,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGI,Number=G,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XRS,Number=R,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAS,Number=A,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGS,Number=G,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=ISTR,Number=1,Type=String,Description="Test String in INFO">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=FSTR,Number=1,Type=String,Description="Test String in FORMAT">
+##FORMAT=<ID=FFI,Number=1,Type=Integer,Description="Test Integer in FORMAT">
+##FORMAT=<ID=FFF,Number=1,Type=Float,Description="Test Float in FORMAT">
+##FORMAT=<ID=FAF,Number=A,Type=Float,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FAI,Number=A,Type=Integer,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FAS,Number=A,Type=String,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRF,Number=R,Type=Float,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRI,Number=R,Type=Integer,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRS,Number=R,Type=String,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Test Number=G in FORMAT">
+##INFO=<ID=OLD_REC,Number=1,Type=String,Description="Original variant. Format: CHR|POS|REF|ALT|USED_ALT_IDX">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3	S4
+11	101	.	G	C,*	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|4	GT	2	0	0	1
+11	101	.	GCGT	G,*	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|1	GT	1	2	2	2
+11	102	.	C	T,*	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|3	GT	2	0	1	0
+11	104	.	T	A,*	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|2,3	GT	2	1	1	0
+11	201	.	C	G,*	.	.	OLD_REC=11|201|CC|GG,GT|1,2	GT	0	1	1	0
+11	202	.	C	G,*	.	.	OLD_REC=11|201|CC|GG,GT|1	GT	0	1	2	0
+11	202	.	C	T,*	.	.	OLD_REC=11|201|CC|GG,GT|2	GT	0	2	1	0
+12	101	rs101	G	C,*	199	flt	INDEL;AN=4;AC=4,.;DP=19;ISTR=SomeString;XRF=0,4,.;XRI=0,4,.;XAF=4,.;XAI=444,.;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|4	GT	0/2	2/0	0/0	0/1
+12	101	rs101	GCGT	G,*	199	flt	INDEL;AN=4;AC=1,.;DP=19;ISTR=SomeString;XRF=0,10,.;XRI=0,1111,.;XAF=10,.;XAI=1111,.;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|1	GT	0/1	1/2	2/2	2/2
+12	102	rs101	C	T,*	199	flt	INDEL;AN=4;AC=3,.;DP=19;ISTR=SomeString;XRF=0,300000,.;XRI=0,3333,.;XAF=3,.;XAI=33,.;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|3	GT	0/2	2/0	0/1	0/0
+12	104	rs101	T	A,*	199	flt	INDEL;AN=4;AC=2,.;DP=19;ISTR=SomeString;XRF=0,200,.;XRI=0,2222,.;XAF=200000,.;XAI=22,.;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|2,3	GT	0/2	2/1	1/1	1/0
+12	201	.	C	G,*	.	.	OLD_REC=12|201|CC|GG,GT|1,2	GT:FSTR:FFI:FFF:FAF:FAI:FRF:FRI:PL	0/0:xx:0:0:1.1,.:1,.:0,0,.:0,0,.:0,1,2,.,.,.	1:yy:11:1.1:1.1,.:1,.:0,0,.:0,0,.:0,2,.	1/1:zz:22:2.2:1.1,.:1,.:0,0,.:0,0,.:0,1,2,.,.,.	0:.:.:.:.,.:.,.:.,.,.:.,.,.:.
+12	202	.	C	G,*	.	.	OLD_REC=12|201|CC|GG,GT|1	GT:FSTR:FFI:FFF:FAF:FAI:FRF:FRI:PL	0/0:xx:0:0:1.1,.:1,.:0,0,.:0,0,.:0,1,2,.,.,.	1:yy:11:1.1:1.1,.:1,.:0,0,.:0,0,.:0,2,.	2/2:zz:22:2.2:1.1,.:1,.:0,0,.:0,0,.:0,1,2,.,.,.	0:.:.:.:.,.:.,.:.,.,.:.,.,.:.
+12	202	.	C	T,*	.	.	OLD_REC=12|201|CC|GG,GT|2	GT:FSTR:FFI:FFF:FAF:FAI:FRF:FRI:PL	0/0:xx:0:0:2.2,.:2,.:0,1.1,.:0,1,.:0,3,5,.,.,.	2:yy:11:1.1:2.2,.:2,.:0,1.1,.:0,1,.:0,5,.	1/1:zz:22:2.2:2.2,.:2,.:0,1.1,.:0,1,.:0,3,5,.,.,.	0:.:.:.:::.:.:.

--- a/test/atomize.split.1.2.out
+++ b/test/atomize.split.1.2.out
@@ -1,0 +1,46 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=135006516>
+##FILTER=<ID=flt,Description="Test FILTER">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=XRF,Number=R,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAF,Number=A,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGF,Number=G,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XRI,Number=R,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAI,Number=A,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGI,Number=G,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XRS,Number=R,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAS,Number=A,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGS,Number=G,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=ISTR,Number=1,Type=String,Description="Test String in INFO">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=FSTR,Number=1,Type=String,Description="Test String in FORMAT">
+##FORMAT=<ID=FFI,Number=1,Type=Integer,Description="Test Integer in FORMAT">
+##FORMAT=<ID=FFF,Number=1,Type=Float,Description="Test Float in FORMAT">
+##FORMAT=<ID=FAF,Number=A,Type=Float,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FAI,Number=A,Type=Integer,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FAS,Number=A,Type=String,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRF,Number=R,Type=Float,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRI,Number=R,Type=Integer,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRS,Number=R,Type=String,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Test Number=G in FORMAT">
+##INFO=<ID=OLD_REC,Number=1,Type=String,Description="Original variant. Format: CHR|POS|REF|ALT|USED_ALT_IDX">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3	S4
+11	101	.	G	C	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|4	GT	.	0	0	1
+11	101	.	GCGT	G	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|1	GT	1	.	.	.
+11	102	.	C	T	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|3	GT	.	0	1	0
+11	104	.	T	A	.	.	OLD_REC=11|101|GCGT|G,GCGA,GTGA,CCGT|2,3	GT	.	1	1	0
+11	201	.	C	G	.	.	OLD_REC=11|201|CC|GG,GT|1,2	GT	0	1	1	0
+11	202	.	C	G	.	.	OLD_REC=11|201|CC|GG,GT|1	GT	0	1	.	0
+11	202	.	C	T	.	.	OLD_REC=11|201|CC|GG,GT|2	GT	0	.	1	0
+12	101	rs101	G	C	199	flt	INDEL;AN=4;AC=4;DP=19;ISTR=SomeString;XRF=0,4;XRI=0,4;XAF=4;XAI=444;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|4	GT	0/.	./0	0/0	0/1
+12	101	rs101	GCGT	G	199	flt	INDEL;AN=4;AC=1;DP=19;ISTR=SomeString;XRF=0,10;XRI=0,1111;XAF=10;XAI=1111;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|1	GT	0/1	1/.	./.	./.
+12	102	rs101	C	T	199	flt	INDEL;AN=4;AC=3;DP=19;ISTR=SomeString;XRF=0,300000;XRI=0,3333;XAF=3;XAI=33;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|3	GT	0/.	./0	0/1	0/0
+12	104	rs101	T	A	199	flt	INDEL;AN=4;AC=2;DP=19;ISTR=SomeString;XRF=0,200;XRI=0,2222;XAF=200000;XAI=22;OLD_REC=12|101|GCGT|G,GCGA,GTGA,CCGT|2,3	GT	0/.	./1	1/1	1/0
+12	201	.	C	G	.	.	OLD_REC=12|201|CC|GG,GT|1,2	GT:FSTR:FFI:FFF:FAF:FAI:FRF:FRI:PL	0/0:xx:0:0:1.1:1:0,0:0,0:0,1,2	1:yy:11:1.1:1.1:1:0,0:0,0:0,2	1/1:zz:22:2.2:1.1:1:0,0:0,0:0,1,2	0:.:.:.:.:.:.,.:.,.:.
+12	202	.	C	G	.	.	OLD_REC=12|201|CC|GG,GT|1	GT:FSTR:FFI:FFF:FAF:FAI:FRF:FRI:PL	0/0:xx:0:0:1.1:1:0,0:0,0:0,1,2	1:yy:11:1.1:1.1:1:0,0:0,0:0,2	./.:zz:22:2.2:1.1:1:0,0:0,0:0,1,2	0:.:.:.:.:.:.,.:.,.:.
+12	202	.	C	T	.	.	OLD_REC=12|201|CC|GG,GT|2	GT:FSTR:FFI:FFF:FAF:FAI:FRF:FRI:PL	0/0:xx:0:0:2.2:2:0,1.1:0,1:0,3,5	.:yy:11:1.1:2.2:2:0,1.1:0,1:0,5	1/1:zz:22:2.2:2.2:2:0,1.1:0,1:0,3,5	0:.:.:.:::.:.:.

--- a/test/atomize.split.1.vcf
+++ b/test/atomize.split.1.vcf
@@ -1,0 +1,34 @@
+##fileformat=VCFv4.3
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=135006516>
+##FILTER=<ID=flt,Description="Test FILTER">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=XRF,Number=R,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAF,Number=A,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGF,Number=G,Type=Float,Description="Test Number=AGR in INFO">
+##INFO=<ID=XRI,Number=R,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAI,Number=A,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGI,Number=G,Type=Integer,Description="Test Number=AGR in INFO">
+##INFO=<ID=XRS,Number=R,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=XAS,Number=A,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=XGS,Number=G,Type=String,Description="Test Number=AGR in INFO">
+##INFO=<ID=ISTR,Number=1,Type=String,Description="Test String in INFO">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=FSTR,Number=1,Type=String,Description="Test String in FORMAT">
+##FORMAT=<ID=FFI,Number=1,Type=Integer,Description="Test Integer in FORMAT">
+##FORMAT=<ID=FFF,Number=1,Type=Float,Description="Test Float in FORMAT">
+##FORMAT=<ID=FAF,Number=A,Type=Float,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FAI,Number=A,Type=Integer,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FAS,Number=A,Type=String,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRF,Number=R,Type=Float,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRI,Number=R,Type=Integer,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=FRS,Number=R,Type=String,Description="Test Number=AR in FORMAT">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Test Number=G in FORMAT">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1	S2	S3	S4
+11	101	.	GCGT	G,GCGA,GTGA,CCGT	.	.	.	GT	1	2	3	4
+11	201	.	CC	GG,GT	.	.	.	GT	0	1	2	0
+12	101	rs101	GCGT	G,GCGA,GTGA,CCGT	199	flt	INDEL;AN=4;AC=1,2,3,4;DP=19;ISTR=SomeString;XRF=0,1e+01,2e+02,300000,4;XRI=0,1111,2222,3333,4;XRS=000,AAA,BBB,DDD,xx;XAF=1e+01,200000,3,4.0;XAI=1111,22,33,444;XAS=AAA,DDD,xx,zzz;XGF=1e+01,2e+02,3e+03,500000,.,9e+09,7;XGI=1111,2222,3333,5555,.,9999,7;XGS=A,B,C,E,.,F,x	GT	0/1	1/2	2/3	2/4
+12	201	.	CC	GG,GT	.	.	.	GT:FSTR:FFI:FFF:FAF:FAI:FAS:FRF:FRI:FRS:PL	0/0:xx:00:0.0:1.1,2.2:1,2:a,b:0.0,1.1,2.2:0,1,2:a,b,c:0,1,2,3,4,5	1:yy:11:1.1:1.1,2.2:1,2:a,b:0.0,1.1,2.2:0,1,2:a,b,c:0,2,5	2/2:zz:22:2.2:1.1,2.2:1,2:a,b:0.0,1.1,2.2:0,1,2:a,b,c:0,1,2,3,4,5	0

--- a/test/atomize.split.2.1.out
+++ b/test/atomize.split.2.1.out
@@ -1,0 +1,9 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=1,length=135006516>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=OLD_REC,Number=1,Type=String,Description="Original variant. Format: CHR|POS|REF|ALT|USED_ALT_IDX">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+1	100	.	C	G	.	.	OLD_REC=1|100|CC|GG|1	GT	0/1
+1	101	.	C	G	.	.	OLD_REC=1|100|CC|GG|1	GT	0/1
+1	110	.	C	T,<*>	.	.	.	GT	0/1

--- a/test/atomize.split.2.2.out
+++ b/test/atomize.split.2.2.out
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.3
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=1,length=135006516>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+1	100	.	C	G	.	.	.	GT	./1
+1	100	.	CC	C	.	.	.	GT	1/.
+1	101	.	C	G	.	.	.	GT	./1

--- a/test/atomize.split.2.vcf
+++ b/test/atomize.split.2.vcf
@@ -1,0 +1,6 @@
+##fileformat=VCFv4.3
+##contig=<ID=1,length=135006516>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+1	100	.	CC	GG	.	.	.	GT	0/1
+1	110	.	C	T,<*>	.	.	.	GT	0/1

--- a/test/test.pl
+++ b/test/test.pl
@@ -232,6 +232,10 @@ test_vcf_norm($opts,in=>'norm.rmdup.2',out=>'norm.rmdup.2.2.out',args=>'-d snps'
 test_vcf_norm($opts,in=>'norm.2',fai=>'norm.2',out=>'norm.2.out',args=>'');
 test_vcf_norm($opts,in=>'norm.iupac',fai=>'norm.iupac',out=>'norm.iupac.out',args=>'-c s');
 test_vcf_norm($opts,in=>'norm.3',fai=>'norm.3',out=>'norm.3.out',args=>'-c s');
+test_vcf_norm($opts,in=>'atomize.split.1',out=>'atomize.split.1.1.out',args=>'--atomize --old-rec-tag OLD_REC');
+test_vcf_norm($opts,in=>'atomize.split.1',out=>'atomize.split.1.2.out',args=>'--atomize --atom-overlaps . --old-rec-tag OLD_REC');
+test_vcf_norm($opts,in=>'atomize.split.2',out=>'atomize.split.2.1.out',args=>'--atomize --old-rec-tag OLD_REC');
+test_vcf_norm($opts,in=>'atomize.split.2',out=>'atomize.split.2.1.out',args=>'--atomize --atom-overlaps . --old-rec-tag OLD_REC');
 test_vcf_view($opts,in=>'view',out=>'view.1.out',args=>'-aUc1 -C1 -s NA00002 -v snps',reg=>'');
 test_vcf_view($opts,in=>'view',out=>'view.2.out',args=>'-f PASS -Xks NA00003',reg=>'-r20,Y');
 test_vcf_view($opts,in=>'view',out=>'view.3.out',args=>'-xs NA00003',reg=>'');

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -39,6 +39,7 @@ THE SOFTWARE.  */
 #include <htslib/khash_str2int.h>
 #include "bcftools.h"
 #include "rbuf.h"
+#include "abuf.h"
 
 #define CHECK_REF_EXIT 1
 #define CHECK_REF_WARN 2
@@ -85,13 +86,13 @@ typedef struct
     int32_t *int32_arr;
     int ntmp_arr1, ntmp_arr2, nint32_arr;
     kstring_t *tmp_str;
-    kstring_t *tmp_als, tmp_als_str;
+    kstring_t *tmp_als, tmp_kstr;
     int ntmp_als;
     rbuf_t rbuf;
     int buf_win;            // maximum distance between two records to consider
     int aln_win;            // the realignment window size (maximum repeat size)
     bcf_srs_t *files;       // using the synced reader only for -r option
-    bcf_hdr_t *hdr;
+    bcf_hdr_t *hdr, *out_hdr;
     cmpals_t cmpals_in, cmpals_out;
     faidx_t *fai;
     struct { int tot, set, swap; } nref;
@@ -99,6 +100,11 @@ typedef struct
     int argc, rmdup, output_type, n_threads, check_ref, strict_filter, do_indels;
     int nchanged, nskipped, nsplit, ntotal, mrows_op, mrows_collapse, parsimonious;
     int record_cmd_line, force, force_warned, keep_sum_ad;
+    abuf_t *abuf;
+    abuf_opt_t atomize;
+    int use_star_allele;
+    char *old_rec_tag;
+    htsFile *out;
 }
 args_t;
 
@@ -159,7 +165,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
         line->d.allele[0][0] = ref[0]; 
         args->nref.set++; 
         free(ref);
-        bcf_update_alleles(args->hdr,line,(const char**)line->d.allele,line->n_allele);
+        bcf_update_alleles(args->out_hdr,line,(const char**)line->d.allele,line->n_allele);
         return;
     }
 
@@ -173,7 +179,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
     if ( has_non_acgtn )
     {
         args->nref.set++;
-        bcf_update_alleles(args->hdr,line,(const char**)line->d.allele,line->n_allele);
+        bcf_update_alleles(args->out_hdr,line,(const char**)line->d.allele,line->n_allele);
         if ( !strncasecmp(line->d.allele[0],ref,reflen) ) { free(ref); return; }
     }
 
@@ -196,7 +202,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
     if ( fix )
     {
         args->nref.set++;
-        bcf_update_alleles(args->hdr,line,(const char**)line->d.allele,line->n_allele);
+        bcf_update_alleles(args->out_hdr,line,(const char**)line->d.allele,line->n_allele);
         if ( !strncasecmp(line->d.allele[0],ref,reflen) ) { free(ref); return; }
     }
 
@@ -218,7 +224,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
             kputc(',',&str);
             kputs(line->d.allele[i],&str);
         }
-        bcf_update_alleles_str(args->hdr,line,str.s);
+        bcf_update_alleles_str(args->out_hdr,line,str.s);
         free(ref);
         free(str.s);
         return;
@@ -234,7 +240,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
         else
             kputs(line->d.allele[j],&str);
     }
-    bcf_update_alleles_str(args->hdr,line,str.s);
+    bcf_update_alleles_str(args->out_hdr,line,str.s);
     args->nref.swap++;
     free(ref);
     free(str.s);
@@ -252,7 +258,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
         else if ( gts[j]==bcf_gt_unphased(i) ) gts[j] = bcf_gt_unphased(0);
         else if ( gts[j]==bcf_gt_phased(i) ) gts[j] = bcf_gt_phased(0);
     }
-    bcf_update_genotypes(args->hdr,line,gts,ngts);
+    bcf_update_genotypes(args->out_hdr,line,gts,ngts);
 
     // update AC
     int nac = bcf_get_info_int32(args->hdr, line, "AC", &args->tmp_arr1, &ntmp);
@@ -261,7 +267,7 @@ static void fix_ref(args_t *args, bcf1_t *line)
     {
         int32_t *ac = (int32_t*)args->tmp_arr1;
         ac[i-1] = ni;
-        bcf_update_info_int32(args->hdr, line, "AC", ac, nac);
+        bcf_update_info_int32(args->out_hdr, line, "AC", ac, nac);
     }
 }
 
@@ -287,7 +293,7 @@ static void fix_dup_alt(args_t *args, bcf1_t *line)
         if ( !args->tmp_arr1[i] ) continue;
         line->d.allele[j++] = line->d.allele[i];
     }
-    bcf_update_alleles(args->hdr, line, (const char**)line->d.allele, nals);
+    bcf_update_alleles(args->out_hdr, line, (const char**)line->d.allele, nals);
 
 
     // update genotypes
@@ -305,7 +311,36 @@ static void fix_dup_alt(args_t *args, bcf1_t *line)
         gts[i] = bcf_gt_is_phased(gts[i]) ? bcf_gt_phased(ial_new) : bcf_gt_unphased(ial_new);
         changed = 1;
     }
-    if ( changed ) bcf_update_genotypes(args->hdr,line,gts,ngts);
+    if ( changed ) bcf_update_genotypes(args->out_hdr,line,gts,ngts);
+}
+
+static void set_old_rec_tag(args_t *args, bcf1_t *dst, bcf1_t *src, int ialt)
+{
+    if ( !args->old_rec_tag ) return;
+
+    // only update if the tag is not present already, there can be multiple normalization steps
+    int i, id = bcf_hdr_id2int(args->out_hdr, BCF_DT_ID, args->old_rec_tag);
+    bcf_unpack(dst, BCF_UN_INFO);
+    for (i=0; i<dst->n_info; i++)
+    {
+        bcf_info_t *inf = &dst->d.info[i];
+        if ( inf && inf->key == id ) return;
+    }
+
+    args->tmp_kstr.l = 0;
+    ksprintf(&args->tmp_kstr,"%s|%"PRIhts_pos"|%s|",bcf_seqname(args->hdr,src),src->pos+1,src->d.allele[0]);
+    for (i=1; i<src->n_allele; i++)
+    {
+        kputs(src->d.allele[i],&args->tmp_kstr);
+        if ( i+1<src->n_allele ) kputc(',',&args->tmp_kstr);
+    }
+    if ( ialt>0 )
+    {
+        args->tmp_kstr.s[args->tmp_kstr.l-1] = '|';
+        kputw(ialt,&args->tmp_kstr);
+    }
+    if ( (bcf_update_info_string(args->out_hdr, dst, args->old_rec_tag, args->tmp_kstr.s))!=0 )
+            error("An error occurred while updating INFO/%s\n",args->old_rec_tag);
 }
 
 #define ERR_DUP_ALLELE       -2
@@ -352,7 +387,7 @@ static int realign(args_t *args, bcf1_t *line)
         if ( line->rlen > 1 )
         {
             line->d.allele[0][1] = 0;
-            bcf_update_alleles(args->hdr,line,(const char**)line->d.allele,line->n_allele);
+            bcf_update_alleles(args->out_hdr,line,(const char**)line->d.allele,line->n_allele);
         }
         return ERR_OK;
     }
@@ -382,7 +417,7 @@ static int realign(args_t *args, bcf1_t *line)
     }
 
     // trim from right
-    int ori_pos = line->pos;
+    int new_pos = line->pos;
     while (1)
     {
         // is the rightmost base identical in all alleles?
@@ -393,7 +428,7 @@ static int realign(args_t *args, bcf1_t *line)
             if ( als[i].l < min_len ) min_len = als[i].l;
         }
         if ( i!=line->n_allele ) break; // there are differences, cannot be trimmed
-        if ( min_len<=1 && line->pos==0 ) break;
+        if ( min_len<=1 && new_pos==0 ) break;
 
         int pad_from_left = 0;
         for (i=0; i<line->n_allele; i++) // trim all alleles
@@ -403,10 +438,10 @@ static int realign(args_t *args, bcf1_t *line)
         }
         if ( pad_from_left )
         {
-            int npad = line->pos >= args->aln_win ? args->aln_win : line->pos;
+            int npad = new_pos >= args->aln_win ? args->aln_win : new_pos;
             free(ref);
-            ref = faidx_fetch_seq(args->fai, (char*)args->hdr->id[BCF_DT_CTG][line->rid].key, line->pos-npad, line->pos-1, &nref);
-            if ( !ref ) error("faidx_fetch_seq failed at %s:%"PRId64"\n", args->hdr->id[BCF_DT_CTG][line->rid].key, (int64_t) line->pos-npad+1);
+            ref = faidx_fetch_seq(args->fai, (char*)args->hdr->id[BCF_DT_CTG][line->rid].key, new_pos-npad, new_pos-1, &nref);
+            if ( !ref ) error("faidx_fetch_seq failed at %s:%"PRId64"\n", args->hdr->id[BCF_DT_CTG][line->rid].key, (int64_t) new_pos-npad+1);
             replace_iupac_codes(ref,nref);
             for (i=0; i<line->n_allele; i++)
             {
@@ -415,7 +450,7 @@ static int realign(args_t *args, bcf1_t *line)
                 memcpy(als[i].s,ref,npad);
                 als[i].l += npad;
             }
-            line->pos -= npad;
+            new_pos -= npad;
         }
     }
     free(ref);
@@ -441,32 +476,36 @@ static int realign(args_t *args, bcf1_t *line)
             memmove(als[i].s,als[i].s+ntrim_left,als[i].l-ntrim_left);
             als[i].l -= ntrim_left;
         }
-        line->pos += ntrim_left;
+        new_pos += ntrim_left;
     }
 
     // Have the alleles changed?
     als[0].s[ als[0].l ] = 0;  // in order for strcmp to work
-    if ( ori_pos==line->pos && !strcasecmp(line->d.allele[0],als[0].s) ) return ERR_OK;
+    if ( new_pos==line->pos && !strcasecmp(line->d.allele[0],als[0].s) ) return ERR_OK;
+
+    set_old_rec_tag(args, line, line, 0);
 
     // Create new block of alleles and update
-    args->tmp_als_str.l = 0;
+    args->tmp_kstr.l = 0;
     for (i=0; i<line->n_allele; i++)
     {
-        if (i>0) kputc(',',&args->tmp_als_str);
-        kputsn(als[i].s,als[i].l,&args->tmp_als_str);
+        if (i>0) kputc(',',&args->tmp_kstr);
+        kputsn(als[i].s,als[i].l,&args->tmp_kstr);
     }
-    args->tmp_als_str.s[ args->tmp_als_str.l ] = 0;
-    bcf_update_alleles_str(args->hdr,line,args->tmp_als_str.s);
+    args->tmp_kstr.s[ args->tmp_kstr.l ] = 0;
+    bcf_update_alleles_str(args->out_hdr,line,args->tmp_kstr.s);
     args->nchanged++;
 
     // Update INFO/END if necessary
     int new_reflen = strlen(line->d.allele[0]);
-    if ( (ori_pos!=line->pos || reflen!=new_reflen) && bcf_get_info_int32(args->hdr, line, "END", &args->int32_arr, &args->nint32_arr)==1 )
+    if ( (new_pos!=line->pos || reflen!=new_reflen) && bcf_get_info_int32(args->hdr, line, "END", &args->int32_arr, &args->nint32_arr)==1 )
     {
         // bcf_update_alleles_str() messed up rlen because line->pos changed. This will be fixed by bcf_update_info_int32()
+        line->pos = new_pos;
         args->int32_arr[0] = line->pos + new_reflen;
-        bcf_update_info_int32(args->hdr, line, "END", args->int32_arr, 1);
+        bcf_update_info_int32(args->out_hdr, line, "END", args->int32_arr, 1);
     }
+    line->pos = new_pos;
 
     return ERR_OK;
 }
@@ -496,13 +535,13 @@ static void split_info_numeric(args_t *args, bcf1_t *src, bcf_info_t *info, int 
                 } \
                 if ( args->force ) \
                 { \
-                    bcf_update_info_##type(args->hdr,dst,tag,NULL,0); \
+                    bcf_update_info_##type(args->out_hdr,dst,tag,NULL,0); \
                     return; \
                 } \
                 error("Error: wrong number of fields in INFO/%s at %s:%"PRId64", expected %d, found %d\n", \
                         tag,bcf_seqname(args->hdr,src),(int64_t) src->pos+1,src->n_allele-1,ret); \
             } \
-            bcf_update_info_##type(args->hdr,dst,tag,vals+ialt,1); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,vals+ialt,1); \
         } \
         else if ( len==BCF_VL_R ) \
         { \
@@ -518,7 +557,7 @@ static void split_info_numeric(args_t *args, bcf1_t *src, bcf_info_t *info, int 
                 } \
                 if ( args->force ) \
                 { \
-                    bcf_update_info_##type(args->hdr,dst,tag,NULL,0); \
+                    bcf_update_info_##type(args->out_hdr,dst,tag,NULL,0); \
                     return; \
                 } \
                 error("Error: wrong number of fields in INFO/%s at %s:%"PRId64", expected %d, found %d\n", \
@@ -535,7 +574,7 @@ static void split_info_numeric(args_t *args, bcf1_t *src, bcf_info_t *info, int 
             { \
                 if ( ialt!=0 ) vals[1] = vals[ialt+1]; \
             } \
-            bcf_update_info_##type(args->hdr,dst,tag,vals,2); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,vals,2); \
         } \
         else if ( len==BCF_VL_G ) \
         { \
@@ -551,7 +590,7 @@ static void split_info_numeric(args_t *args, bcf1_t *src, bcf_info_t *info, int 
                 } \
                 if ( args->force ) \
                 { \
-                    bcf_update_info_##type(args->hdr,dst,tag,NULL,0); \
+                    bcf_update_info_##type(args->out_hdr,dst,tag,NULL,0); \
                     return; \
                 } \
                 error("Error: wrong number of fields in INFO/%s at %s:%"PRId64", expected %d, found %d\n", \
@@ -562,10 +601,10 @@ static void split_info_numeric(args_t *args, bcf1_t *src, bcf_info_t *info, int 
                 vals[1] = vals[bcf_alleles2gt(0,ialt+1)]; \
                 vals[2] = vals[bcf_alleles2gt(ialt+1,ialt+1)]; \
             } \
-            bcf_update_info_##type(args->hdr,dst,tag,vals,3); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,vals,3); \
         } \
         else \
-            bcf_update_info_##type(args->hdr,dst,tag,vals,ret); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,vals,ret); \
     }
     switch (bcf_hdr_id2type(args->hdr,BCF_HL_INFO,info->key))
     {
@@ -618,7 +657,7 @@ static void split_info_string(args_t *args, bcf1_t *src, bcf_info_t *info, int i
         STR_MOVE_NTH(str.s,tmp,str.s+str.l,ialt,len);
         if ( len<0 ) return;   // wrong number of fields: skip
         str.s[len] = 0;
-        bcf_update_info_string(args->hdr,dst,tag,str.s);
+        bcf_update_info_string(args->out_hdr,dst,tag,str.s);
     }
     else if ( len==BCF_VL_R )
     {
@@ -629,7 +668,7 @@ static void split_info_string(args_t *args, bcf1_t *src, bcf_info_t *info, int i
         STR_MOVE_NTH(&str.s[len],tmp,str.s+str.l,ialt,len);
         if ( len<0 ) return;   // wrong number of fields: skip
         str.s[len] = 0;
-        bcf_update_info_string(args->hdr,dst,tag,str.s);
+        bcf_update_info_string(args->out_hdr,dst,tag,str.s);
     }
     else if ( len==BCF_VL_G )
     {
@@ -644,16 +683,16 @@ static void split_info_string(args_t *args, bcf1_t *src, bcf_info_t *info, int i
         STR_MOVE_NTH(&str.s[len],tmp,str.s+str.l,iaa-i0a-1,len);
         if ( len<0 ) return;   // wrong number of fields: skip
         str.s[len] = 0;
-        bcf_update_info_string(args->hdr,dst,tag,str.s);
+        bcf_update_info_string(args->out_hdr,dst,tag,str.s);
     }
     else
-        bcf_update_info_string(args->hdr,dst,tag,str.s);
+        bcf_update_info_string(args->out_hdr,dst,tag,str.s);
 }
 static void split_info_flag(args_t *args, bcf1_t *src, bcf_info_t *info, int ialt, bcf1_t *dst)
 {
     const char *tag = bcf_hdr_int2id(args->hdr,BCF_DT_ID,info->key);
     int ret = bcf_get_info_flag(args->hdr,src,tag,&args->tmp_arr1,&args->ntmp_arr1);
-    bcf_update_info_flag(args->hdr,dst,tag,NULL,ret);
+    bcf_update_info_flag(args->out_hdr,dst,tag,NULL,ret);
 }
 
 static void split_format_genotype(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int ialt, bcf1_t *dst)
@@ -679,7 +718,7 @@ static void split_format_genotype(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int
         }
         gt += ngts;
     }
-    bcf_update_genotypes(args->hdr,dst,args->tmp_arr1,ngts*nsmpl);
+    bcf_update_genotypes(args->out_hdr,dst,args->tmp_arr1,ngts*nsmpl);
 }
 static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int ialt, bcf1_t *dst)
 {
@@ -695,7 +734,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
         int i,j, nsmpl = bcf_hdr_nsamples(args->hdr); \
         if ( nvals==nsmpl ) /* all values are missing */ \
         { \
-            bcf_update_format_##type(args->hdr,dst,tag,vals,nsmpl); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,vals,nsmpl); \
             return; \
         } \
         if ( len==BCF_VL_A ) \
@@ -712,7 +751,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
                 } \
                 if ( args->force ) \
                 { \
-                    bcf_update_format_##type(args->hdr,dst,tag,NULL,0); \
+                    bcf_update_format_##type(args->out_hdr,dst,tag,NULL,0); \
                     return; \
                 } \
                 error("Error: wrong number of fields in FMT/%s at %s:%"PRId64", expected %d, found %d\n", \
@@ -726,7 +765,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
                 dst_vals += 1; \
                 src_vals += nvals; \
             } \
-            bcf_update_format_##type(args->hdr,dst,tag,vals,nsmpl); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,vals,nsmpl); \
         } \
         else if ( len==BCF_VL_R ) \
         { \
@@ -742,7 +781,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
                 } \
                 if ( args->force ) \
                 { \
-                    bcf_update_format_##type(args->hdr,dst,tag,NULL,0); \
+                    bcf_update_format_##type(args->out_hdr,dst,tag,NULL,0); \
                     return; \
                 } \
                 error("Error: wrong number of fields in FMT/%s at %s:%"PRId64", expected %d, found %d\n", \
@@ -772,7 +811,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
                     src_vals += nvals; \
                 } \
             } \
-            bcf_update_format_##type(args->hdr,dst,tag,vals,nsmpl*2); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,vals,nsmpl*2); \
         } \
         else if ( len==BCF_VL_G ) \
         { \
@@ -788,7 +827,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
                 } \
                 if ( args->force ) \
                 { \
-                    bcf_update_format_##type(args->hdr,dst,tag,NULL,0); \
+                    bcf_update_format_##type(args->out_hdr,dst,tag,NULL,0); \
                     return; \
                 } \
                 error("Error at %s:%"PRId64", the tag %s has wrong number of fields\n", bcf_seqname(args->hdr,src),(int64_t) src->pos+1,bcf_hdr_int2id(args->hdr,BCF_DT_ID,fmt->id)); \
@@ -819,10 +858,10 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
                 dst_vals += all_haploid ? 2 : 3; \
                 src_vals += nvals; \
             } \
-            bcf_update_format_##type(args->hdr,dst,tag,vals,all_haploid ? nsmpl*2 : nsmpl*3); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,vals,all_haploid ? nsmpl*2 : nsmpl*3); \
         } \
         else \
-            bcf_update_format_##type(args->hdr,dst,tag,vals,nvals); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,vals,nvals); \
     }
     switch (bcf_hdr_id2type(args->hdr,BCF_HL_FMT,fmt->id))
     {
@@ -869,7 +908,7 @@ static void split_format_string(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int i
             ptr += blen;
         }
         if ( maxlen<blen ) squeeze_format_char(str.s,blen,maxlen,nsmpl);
-        bcf_update_format_char(args->hdr,dst,tag,str.s,nsmpl*maxlen);
+        bcf_update_format_char(args->out_hdr,dst,tag,str.s,nsmpl*maxlen);
     }
     else if ( len==BCF_VL_R )
     {
@@ -887,7 +926,7 @@ static void split_format_string(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int i
             ptr += blen;
         }
         if ( maxlen<blen ) squeeze_format_char(str.s,blen,maxlen,nsmpl);
-        bcf_update_format_char(args->hdr,dst,tag,str.s,nsmpl*maxlen);
+        bcf_update_format_char(args->out_hdr,dst,tag,str.s,nsmpl*maxlen);
     }
     else if ( len==BCF_VL_G )
     {
@@ -915,7 +954,7 @@ static void split_format_string(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int i
                 }
                 if ( args->force )
                 {
-                    bcf_update_format_char(args->hdr,dst,tag,NULL,0);
+                    bcf_update_format_char(args->out_hdr,dst,tag,NULL,0);
                     return;
                 }
                 error("Error: wrong number of fields in FMT/%s at %s:%"PRId64", expected %d or %d, found %d\n",
@@ -946,12 +985,11 @@ static void split_format_string(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int i
             ptr += blen;
         }
         if ( maxlen<blen ) squeeze_format_char(str.s,blen,maxlen,nsmpl);
-        bcf_update_format_char(args->hdr,dst,tag,str.s,nsmpl*maxlen);
+        bcf_update_format_char(args->out_hdr,dst,tag,str.s,nsmpl*maxlen);
     }
     else
-        bcf_update_format_char(args->hdr,dst,tag,str.s,str.l);
+        bcf_update_format_char(args->out_hdr,dst,tag,str.s,str.l);
 }
-
 
 static void split_multiallelic_to_biallelics(args_t *args, bcf1_t *line)
 {
@@ -985,11 +1023,11 @@ static void split_multiallelic_to_biallelics(args_t *args, bcf1_t *line)
 
         // Not quite sure how to handle IDs, they can be assigned to a specific
         // ALT.  For now we leave the ID unchanged for all.
-        bcf_update_id(args->hdr, dst, line->d.id ? line->d.id : ".");
+        bcf_update_id(args->out_hdr, dst, line->d.id ? line->d.id : ".");
 
         tmp.l = rlen;
         kputs(line->d.allele[i+1],&tmp);
-        bcf_update_alleles_str(args->hdr,dst,tmp.s);
+        bcf_update_alleles_str(args->out_hdr,dst,tmp.s);
 
         if ( line->d.n_flt ) bcf_update_filter(args->hdr, dst, line->d.flt, line->d.n_flt);
 
@@ -1002,6 +1040,7 @@ static void split_multiallelic_to_biallelics(args_t *args, bcf1_t *line)
             else if ( type==BCF_HT_FLAG ) split_info_flag(args, line, info, i, dst);
             else split_info_string(args, line, info, i, dst);
         }
+        set_old_rec_tag(args, dst, line, i + 1); // 1-based indexes
 
         dst->n_sample = line->n_sample;
         for (j=0; j<line->n_fmt; j++)
@@ -1065,7 +1104,7 @@ static void merge_info_numeric(args_t *args, bcf1_t **lines, int nlines, bcf_inf
                     vals[ args->maps[i].map[k+1] - 1 ] = vals2[k]; \
                 } \
             } \
-            bcf_update_info_##type(args->hdr,dst,tag,args->tmp_arr1,nvals); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals); \
         } \
         else if ( len==BCF_VL_R ) \
         { \
@@ -1089,7 +1128,7 @@ static void merge_info_numeric(args_t *args, bcf1_t **lines, int nlines, bcf_inf
                     vals[ args->maps[i].map[k] ] = vals2[k]; \
                 } \
             } \
-            bcf_update_info_##type(args->hdr,dst,tag,args->tmp_arr1,nvals); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals); \
         } \
         else if ( len==BCF_VL_G ) \
         { \
@@ -1123,10 +1162,10 @@ static void merge_info_numeric(args_t *args, bcf1_t **lines, int nlines, bcf_inf
                     } \
                 } \
             } \
-            bcf_update_info_##type(args->hdr,dst,tag,args->tmp_arr1,nvals); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals); \
         } \
         else \
-            bcf_update_info_##type(args->hdr,dst,tag,vals,nvals_ori); \
+            bcf_update_info_##type(args->out_hdr,dst,tag,vals,nvals_ori); \
     }
     switch (bcf_hdr_id2type(args->hdr,BCF_HL_INFO,info->key))
     {
@@ -1139,7 +1178,7 @@ static void merge_info_flag(args_t *args, bcf1_t **lines, int nlines, bcf_info_t
 {
     const char *tag = bcf_hdr_int2id(args->hdr,BCF_DT_ID,info->key);
     int ret = bcf_get_info_flag(args->hdr,lines[0],tag,&args->tmp_arr1,&args->ntmp_arr1);
-    bcf_update_info_flag(args->hdr,dst,tag,NULL,ret);
+    bcf_update_info_flag(args->out_hdr,dst,tag,NULL,ret);
 }
 int copy_string_field(char *src, int isrc, int src_len, kstring_t *dst, int idst); // see vcfmerge.c
 static void merge_info_string(args_t *args, bcf1_t **lines, int nlines, bcf_info_t *info, bcf1_t *dst)
@@ -1167,7 +1206,7 @@ static void merge_info_string(args_t *args, bcf1_t **lines, int nlines, bcf_info
         str.s[str.l] = 0;
         args->tmp_arr1  = (uint8_t*) str.s;
         args->ntmp_arr1 = str.m;
-        bcf_update_info_string(args->hdr,dst,tag,str.s);
+        bcf_update_info_string(args->out_hdr,dst,tag,str.s);
     }
     else if ( len==BCF_VL_G )
     {
@@ -1194,12 +1233,12 @@ static void merge_info_string(args_t *args, bcf1_t **lines, int nlines, bcf_info
         str.s[str.l] = 0;
         args->tmp_arr1  = (uint8_t*) str.s;
         args->ntmp_arr1 = str.m;
-        bcf_update_info_string(args->hdr,dst,tag,str.s);
+        bcf_update_info_string(args->out_hdr,dst,tag,str.s);
     }
     else
     {
         bcf_get_info_string(args->hdr,lines[0],tag,&args->tmp_arr1,&args->ntmp_arr1);
-        bcf_update_info_string(args->hdr,dst,tag,args->tmp_arr1);
+        bcf_update_info_string(args->out_hdr,dst,tag,args->tmp_arr1);
     }
 }
 static void merge_format_genotype(args_t *args, bcf1_t **lines, int nlines, bcf_fmt_t *fmt, bcf1_t *dst)
@@ -1242,7 +1281,7 @@ static void merge_format_genotype(args_t *args, bcf1_t **lines, int nlines, bcf_
             gt2 += ngts;
         }
     }
-    bcf_update_genotypes(args->hdr,dst,args->tmp_arr1,ngts*nsmpl);
+    bcf_update_genotypes(args->out_hdr,dst,args->tmp_arr1,ngts*nsmpl);
 }
 static int diploid_to_haploid(int size, int nsmpl, int nals, uint8_t *vals)
 {
@@ -1295,7 +1334,7 @@ static void merge_format_numeric(args_t *args, bcf1_t **lines, int nlines, bcf_f
                     vals2 += nvals2; \
                 } \
             } \
-            bcf_update_format_##type(args->hdr,dst,tag,args->tmp_arr1,nvals*nsmpl); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals*nsmpl); \
         } \
         else if ( len==BCF_VL_R ) \
         { \
@@ -1323,7 +1362,7 @@ static void merge_format_numeric(args_t *args, bcf1_t **lines, int nlines, bcf_f
                     vals2 += nvals2; \
                 } \
             } \
-            bcf_update_format_##type(args->hdr,dst,tag,args->tmp_arr1,nvals*nsmpl); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals*nsmpl); \
         } \
         else if ( len==BCF_VL_G ) \
         { \
@@ -1402,10 +1441,10 @@ static void merge_format_numeric(args_t *args, bcf1_t **lines, int nlines, bcf_f
                     vals2 += nvals;\
                 }\
             }\
-            bcf_update_format_##type(args->hdr,dst,tag,args->tmp_arr1,nvals*nsmpl); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals*nsmpl); \
         } \
         else \
-            bcf_update_format_##type(args->hdr,dst,tag,args->tmp_arr1,nvals_ori*nsmpl); \
+            bcf_update_format_##type(args->out_hdr,dst,tag,args->tmp_arr1,nvals_ori*nsmpl); \
     }
     switch (bcf_hdr_id2type(args->hdr,BCF_HL_FMT,fmt->id))
     {
@@ -1422,7 +1461,7 @@ static void merge_format_string(args_t *args, bcf1_t **lines, int nlines, bcf_fm
     if ( len!=BCF_VL_A && len!=BCF_VL_R && len!=BCF_VL_G )
     {
         int nret = bcf_get_format_char(args->hdr,lines[0],tag,&args->tmp_arr1,&args->ntmp_arr1);
-        bcf_update_format_char(args->hdr,dst,tag,args->tmp_arr1,nret);
+        bcf_update_format_char(args->out_hdr,dst,tag,args->tmp_arr1,nret);
         return;
     }
 
@@ -1534,7 +1573,7 @@ static void merge_format_string(args_t *args, bcf1_t **lines, int nlines, bcf_fm
     }
     args->ntmp_arr2 = str.m;
     args->tmp_arr2  = (uint8_t*)str.s;
-    bcf_update_format_char(args->hdr,dst,tag,str.s,str.l);
+    bcf_update_format_char(args->out_hdr,dst,tag,str.s,str.l);
 }
 
 char **merge_alleles(char **a, int na, int *map, char **b, int *nb, int *mb);   // see vcfmerge.c
@@ -1555,7 +1594,7 @@ static void merge_biallelics_to_multiallelic(args_t *args, bcf1_t *dst, bcf1_t *
             dst->qual = lines[i]->qual;
     }
 
-    bcf_update_id(args->hdr, dst, lines[0]->d.id);
+    bcf_update_id(args->out_hdr, dst, lines[0]->d.id);
 
     // Merge and set the alleles, create a mapping from source allele indexes to dst idxs
     hts_expand0(map_t,nlines,args->mmaps,args->maps);   // a mapping for each line
@@ -1569,20 +1608,20 @@ static void merge_biallelics_to_multiallelic(args_t *args, bcf1_t *dst, bcf1_t *
     }
     for (i=1; i<nlines; i++)
     {
-        if (lines[i]->d.id[0]!='.' || lines[i]->d.id[1]) bcf_add_id(args->hdr, dst, lines[i]->d.id);
+        if (lines[i]->d.id[0]!='.' || lines[i]->d.id[1]) bcf_add_id(args->out_hdr, dst, lines[i]->d.id);
         args->maps[i].nals = lines[i]->n_allele;
         hts_expand(int,args->maps[i].nals,args->maps[i].mals,args->maps[i].map);
         args->als = merge_alleles(lines[i]->d.allele, lines[i]->n_allele, args->maps[i].map, args->als, &args->nals, &args->mals);
         if ( !args->als ) error("Failed to merge alleles at %s:%"PRId64"\n", bcf_seqname(args->hdr,dst),(int64_t) dst->pos+1);
     }
-    bcf_update_alleles(args->hdr, dst, (const char**)args->als, args->nals);
+    bcf_update_alleles(args->out_hdr, dst, (const char**)args->als, args->nals);
     for (i=0; i<args->nals; i++)
     {
         free(args->als[i]);
         args->als[i] = NULL;
     }
 
-    if ( lines[0]->d.n_flt ) bcf_update_filter(args->hdr, dst, lines[0]->d.flt, lines[0]->d.n_flt);
+    if ( lines[0]->d.n_flt ) bcf_update_filter(args->out_hdr, dst, lines[0]->d.flt, lines[0]->d.n_flt);
     for (i=1; i<nlines; i++) {
         int j;
         for (j=0; j<lines[i]->d.n_flt; j++) {
@@ -1590,13 +1629,13 @@ static void merge_biallelics_to_multiallelic(args_t *args, bcf1_t *dst, bcf1_t *
             // otherwise accumulate FILTERs
             if (lines[i]->d.flt[j] == bcf_hdr_id2int(args->hdr, BCF_DT_ID, "PASS")) {
                 if (args->strict_filter) {
-                    bcf_update_filter(args->hdr, dst, lines[i]->d.flt, lines[i]->d.n_flt);
+                    bcf_update_filter(args->out_hdr, dst, lines[i]->d.flt, lines[i]->d.n_flt);
                     break;
                 }
                 else
                     continue;
             }
-            bcf_add_filter(args->hdr, dst, lines[i]->d.flt[j]);
+            bcf_add_filter(args->out_hdr, dst, lines[i]->d.flt[j]);
         }
     }
 
@@ -1766,7 +1805,7 @@ static void flush_buffer(args_t *args, htsFile *file, int n)
             if ( mrows_ready_to_flush(args, args->lines[k]) )
             {
                 while ( (line=mrows_flush(args)) )
-                    if ( bcf_write1(file, args->hdr, line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
+                    if ( bcf_write1(file, args->out_hdr, line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
             }
             int merge = 1;
             if ( args->mrows_collapse!=COLLAPSE_BOTH && args->mrows_collapse!=COLLAPSE_ANY )
@@ -1799,12 +1838,12 @@ static void flush_buffer(args_t *args, htsFile *file, int n)
             prev_type |= line_type;
             if ( args->rmdup & BCF_SR_PAIR_EXACT ) cmpals_add(&args->cmpals_out, args->lines[k]);
         }
-        if ( bcf_write1(file, args->hdr, args->lines[k])!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
+        if ( bcf_write1(file, args->out_hdr, args->lines[k])!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
     }
     if ( args->mrows_op==MROWS_MERGE && !args->rbuf.n )
     {
         while ( (line=mrows_flush(args)) )
-            if ( bcf_write1(file, args->hdr, line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
+            if ( bcf_write1(file, args->out_hdr, line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
     }
 }
 
@@ -1819,6 +1858,10 @@ static void init_data(args_t *args)
     else
         args->keep_sum_ad = -1;
 
+    args->out_hdr = bcf_hdr_dup(args->hdr);
+    if ( args->old_rec_tag )
+        bcf_hdr_printf(args->out_hdr,"##INFO=<ID=%s,Number=1,Type=String,Description=\"Original variant. Format: CHR|POS|REF|ALT|USED_ALT_IDX\">",args->old_rec_tag); 
+
     rbuf_init(&args->rbuf, 100);
     args->lines = (bcf1_t**) calloc(args->rbuf.m, sizeof(bcf1_t*));
     if ( args->ref_fname )
@@ -1831,6 +1874,14 @@ static void init_data(args_t *args)
         args->mrow_out = bcf_init1();
         args->tmp_str = (kstring_t*) calloc(bcf_hdr_nsamples(args->hdr),sizeof(kstring_t));
         args->diploid = (uint8_t*) malloc(bcf_hdr_nsamples(args->hdr));
+    }
+    if ( args->atomize==SPLIT )
+    {
+        args->abuf = abuf_init(args->hdr, SPLIT); 
+        abuf_set_opt(args->abuf, bcf_hdr_t*, BCF_HDR, args->out_hdr);
+        if ( args->old_rec_tag )
+            abuf_set_opt(args->abuf, const char*, INFO_TAG, args->old_rec_tag);
+        abuf_set_opt(args->abuf, int, STAR_ALLELE, args->use_star_allele);
     }
 }
 
@@ -1856,7 +1907,7 @@ static void destroy_data(args_t *args)
     for (i=0; i<args->ntmp_als; i++)
         free(args->tmp_als[i].s);
     free(args->tmp_als);
-    free(args->tmp_als_str.s);
+    free(args->tmp_kstr.s);
     if ( args->tmp_str )
     {
         for (i=0; i<bcf_hdr_nsamples(args->hdr); i++) free(args->tmp_str[i].s);
@@ -1868,15 +1919,16 @@ static void destroy_data(args_t *args)
     free(args->tmp_arr1);
     free(args->tmp_arr2);
     free(args->diploid);
+    if ( args->abuf ) abuf_destroy(args->abuf);
+    bcf_hdr_destroy(args->out_hdr);
     if ( args->mrow_out ) bcf_destroy1(args->mrow_out);
     if ( args->fai ) fai_destroy(args->fai);
     if ( args->mseq ) free(args->seq);
 }
 
 
-static void normalize_line(args_t *args, bcf1_t **line_ptr)
+static void normalize_line(args_t *args, bcf1_t *line)
 {
-    bcf1_t *line = *line_ptr;
     if ( args->fai )
     {
         if ( args->check_ref & CHECK_REF_FIX ) fix_ref(args, line);
@@ -1906,8 +1958,8 @@ static void normalize_line(args_t *args, bcf1_t **line_ptr)
     rbuf_expand0(&args->rbuf,bcf1_t*,args->rbuf.n+1,args->lines);
     int i,j;
     i = j = rbuf_append(&args->rbuf);
-    if ( !args->lines[i] ) args->lines[i] = bcf_init1();
-    SWAP(bcf1_t*, (*line_ptr), args->lines[i]);
+    if ( args->lines[i] ) bcf_destroy(args->lines[i]);
+    args->lines[i] = bcf_dup(line);
     while ( rbuf_prev(&args->rbuf,&i) )
     {
         if ( args->lines[i]->pos > args->lines[j]->pos ) SWAP(bcf1_t*, args->lines[i], args->lines[j]);
@@ -1915,21 +1967,38 @@ static void normalize_line(args_t *args, bcf1_t **line_ptr)
     }
 }
 
+static bcf1_t *next_atomized_line(args_t *args)
+{
+    bcf1_t *rec = NULL;
+    if ( args->atomize==SPLIT )
+    {
+        rec = abuf_flush(args->abuf, 0);
+        if ( rec ) return rec;
+    }
+
+    if ( !bcf_sr_next_line(args->files) ) return NULL;
+
+    if ( args->atomize==SPLIT )
+    {
+        abuf_push(args->abuf,bcf_sr_get_line(args->files,0));
+        return abuf_flush(args->abuf, 0);
+    }
+    return bcf_sr_get_line(args->files,0);
+}
 static void normalize_vcf(args_t *args)
 {
-    htsFile *out = hts_open(args->output_fname, hts_bcf_wmode2(args->output_type,args->output_fname));
-    if ( out == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
+    args->out = hts_open(args->output_fname, hts_bcf_wmode2(args->output_type,args->output_fname));
+    if ( args->out == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
     if ( args->n_threads )
-        hts_set_opt(out, HTS_OPT_THREAD_POOL, args->files->p);
-    if (args->record_cmd_line) bcf_hdr_append_version(args->hdr, args->argc, args->argv, "bcftools_norm");
-    if ( bcf_hdr_write(out, args->hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
+        hts_set_opt(args->out, HTS_OPT_THREAD_POOL, args->files->p);
+    if (args->record_cmd_line) bcf_hdr_append_version(args->out_hdr, args->argc, args->argv, "bcftools_norm");
+    if ( bcf_hdr_write(args->out, args->out_hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
 
+    bcf1_t *line;
     int prev_rid = -1, prev_pos = -1, prev_type = 0;
-    while ( bcf_sr_next_line(args->files) )
+    while ( (line = next_atomized_line(args)) )
     {
         args->ntotal++;
-
-        bcf1_t *line = args->files->readers[0].buffer[0];
         if ( args->rmdup )
         {
             int line_type = bcf_get_variant_types(line);
@@ -1953,7 +2022,7 @@ static void normalize_vcf(args_t *args)
 
         // still on the same chromosome?
         int i,j,ilast = rbuf_last(&args->rbuf);
-        if ( ilast>=0 && line->rid != args->lines[ilast]->rid ) flush_buffer(args, out, args->rbuf.n); // new chromosome
+        if ( ilast>=0 && line->rid != args->lines[ilast]->rid ) flush_buffer(args, args->out, args->rbuf.n); // new chromosome
 
         int split = 0;
         if ( args->mrows_op==MROWS_SPLIT )
@@ -1968,13 +2037,13 @@ static void normalize_vcf(args_t *args)
                 args->nsplit++;
                 split_multiallelic_to_biallelics(args, line);
                 for (j=0; j<args->ntmp_lines; j++)
-                    normalize_line(args, &args->tmp_lines[j]);
+                    normalize_line(args, args->tmp_lines[j]);
             }
             else
                 split = 0;
         }
         if ( !split )
-            normalize_line(args, &args->files->readers[0].buffer[0]);
+            normalize_line(args, line);
 
         // find out how many sites to flush
         ilast = rbuf_last(&args->rbuf);
@@ -1984,10 +2053,10 @@ static void normalize_vcf(args_t *args)
             if ( args->lines[ilast]->pos - args->lines[i]->pos < args->buf_win ) break;
             j++;
         }
-        if ( j>0 ) flush_buffer(args, out, j);
+        if ( j>0 ) flush_buffer(args, args->out, j);
     }
-    flush_buffer(args, out, args->rbuf.n);
-    if ( hts_close(out)!=0 ) error("[%s] Error: close failed .. %s\n", __func__,args->output_fname);
+    flush_buffer(args, args->out, args->rbuf.n);
+    if ( hts_close(args->out)!=0 ) error("[%s] Error: close failed .. %s\n", __func__,args->output_fname);
 
     fprintf(stderr,"Lines   total/split/realigned/skipped:\t%d/%d/%d/%d\n", args->ntotal,args->nsplit,args->nchanged,args->nskipped);
     if ( args->check_ref & CHECK_REF_FIX )
@@ -2003,24 +2072,27 @@ static void usage(void)
     fprintf(stderr, "Usage:   bcftools norm [options] <in.vcf.gz>\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "    -c, --check-ref <e|w|x|s>         check REF alleles and exit (e), warn (w), exclude (x), or set (s) bad sites [e]\n");
-    fprintf(stderr, "    -D, --remove-duplicates           remove duplicate lines of the same type.\n");
-    fprintf(stderr, "    -d, --rm-dup <type>               remove duplicate snps|indels|both|all|exact\n");
-    fprintf(stderr, "    -f, --fasta-ref <file>            reference sequence\n");
-    fprintf(stderr, "        --force                       try to proceed even if malformed tags are encountered. Experimental, use at your own risk\n");
-    fprintf(stderr, "        --keep-sum <tag,..>           keep vector sum constant when splitting multiallelics (see github issue #360)\n");
-    fprintf(stderr, "    -m, --multiallelics <-|+>[type]   split multiallelics (-) or join biallelics (+), type: snps|indels|both|any [both]\n");
-    fprintf(stderr, "        --no-version                  do not append version and command line to the header\n");
-    fprintf(stderr, "    -N, --do-not-normalize            do not normalize indels (with -m or -c s)\n");
-    fprintf(stderr, "    -o, --output <file>               write output to a file [standard output]\n");
-    fprintf(stderr, "    -O, --output-type <type>          'b' compressed BCF; 'u' uncompressed BCF; 'z' compressed VCF; 'v' uncompressed VCF [v]\n");
-    fprintf(stderr, "    -r, --regions <region>            restrict to comma-separated list of regions\n");
-    fprintf(stderr, "    -R, --regions-file <file>         restrict to regions listed in a file\n");
-    fprintf(stderr, "    -s, --strict-filter               when merging (-m+), merged site is PASS only if all sites being merged PASS\n");
-    fprintf(stderr, "    -t, --targets <region>            similar to -r but streams rather than index-jumps\n");
-    fprintf(stderr, "    -T, --targets-file <file>         similar to -R but streams rather than index-jumps\n");
-    fprintf(stderr, "        --threads <int>               use multithreading with <int> worker threads [0]\n");
-    fprintf(stderr, "    -w, --site-win <int>              buffer for sorting lines which changed position during realignment [1000]\n");
+    fprintf(stderr, "    -a, --atomize                   Decompose complex variants (e.g. MNVs become consecutive SNVs)\n");
+    fprintf(stderr, "        --atom-overlaps '*'|.       Use the star allele (*) for overlapping alleles or set to missing (.) [*]\n");
+    fprintf(stderr, "    -c, --check-ref e|w|x|s         Check REF alleles and exit (e), warn (w), exclude (x), or set (s) bad sites [e]\n");
+    fprintf(stderr, "    -D, --remove-duplicates         Remove duplicate lines of the same type.\n");
+    fprintf(stderr, "    -d, --rm-dup TYPE               Remove duplicate snps|indels|both|all|exact\n");
+    fprintf(stderr, "    -f, --fasta-ref FILE            Reference sequence\n");
+    fprintf(stderr, "        --force                     Try to proceed even if malformed tags are encountered. Experimental, use at your own risk\n");
+    fprintf(stderr, "        --keep-sum TAG,..           Keep vector sum constant when splitting multiallelics (see github issue #360)\n");
+    fprintf(stderr, "    -m, --multiallelics -|+TYPE     Split multiallelics (-) or join biallelics (+), type: snps|indels|both|any [both]\n");
+    fprintf(stderr, "        --no-version                Do not append version and command line to the header\n");
+    fprintf(stderr, "    -N, --do-not-normalize          Do not normalize indels (with -m or -c s)\n");
+    fprintf(stderr, "        --old-rec-tag STR           Annotate modified records with INFO/STR indicating the original variant\n");
+    fprintf(stderr, "    -o, --output FILE               Write output to a file [standard output]\n");
+    fprintf(stderr, "    -O, --output-type TYPE          'b' compressed BCF; 'u' uncompressed BCF; 'z' compressed VCF; 'v' uncompressed VCF [v]\n");
+    fprintf(stderr, "    -r, --regions REGION            Restrict to comma-separated list of regions\n");
+    fprintf(stderr, "    -R, --regions-file FILE         Restrict to regions listed in a file\n");
+    fprintf(stderr, "    -s, --strict-filter             When merging (-m+), merged site is PASS only if all sites being merged PASS\n");
+    fprintf(stderr, "    -t, --targets REGION            Similar to -r but streams rather than index-jumps\n");
+    fprintf(stderr, "    -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n");
+    fprintf(stderr, "        --threads INT               Use multithreading with <int> worker threads [0]\n");
+    fprintf(stderr, "    -w, --site-win INT              Buffer for sorting lines which changed position during realignment [1000]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "   # normalize and left-align indels\n");
@@ -2048,11 +2120,15 @@ int main_vcfnorm(int argc, char *argv[])
     args->do_indels = 1;
     int region_is_file  = 0;
     int targets_is_file = 0;
+    args->use_star_allele = 1;
 
     static struct option loptions[] =
     {
         {"help",no_argument,NULL,'h'},
         {"force",no_argument,NULL,7},
+        {"atomize",no_argument,NULL,'a'},
+        {"atom-overlaps",required_argument,NULL,11},
+        {"old-rec-tag",required_argument,NULL,12},
         {"keep-sum",required_argument,NULL,10},
         {"fasta-ref",required_argument,NULL,'f'},
         {"do-not-normalize",no_argument,NULL,'N'},
@@ -2073,7 +2149,7 @@ int main_vcfnorm(int argc, char *argv[])
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "hr:R:f:w:Dd:o:O:c:m:t:T:sN",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hr:R:f:w:Dd:o:O:c:m:t:T:sNa",loptions,NULL)) >= 0) {
         switch (c) {
             case  10:
                 // possibly generalize this also to INFO/AD and other tags
@@ -2081,6 +2157,13 @@ int main_vcfnorm(int argc, char *argv[])
                     error("Error: only --keep-sum AD is currently supported. See https://github.com/samtools/bcftools/issues/360 for more.\n");
                 args->keep_sum_ad = 1;  // this will be set to the header id or -1 in init_data
                 break;
+            case 'a': args->atomize = SPLIT; break;
+            case 11 :
+                if ( optarg[0]=='*' ) args->use_star_allele = 1;
+                else if ( optarg[0]=='.' ) args->use_star_allele = 0;
+                else error("Invalid argument to --atom-overlaps. Perhaps you wanted: \"--atom-overlaps '*'\"?\n");
+                break;
+            case 12 : args->old_rec_tag = optarg; break;
             case 'N': args->do_indels = 0; break;
             case 'd':
                 if ( !strcmp("snps",optarg) ) args->rmdup = BCF_SR_PAIR_SNPS;
@@ -2152,7 +2235,7 @@ int main_vcfnorm(int argc, char *argv[])
     }
     else fname = argv[optind];
 
-    if ( !args->ref_fname && !args->mrows_op && !args->rmdup ) error("Expected -f, -m, -D or -d option\n");
+    if ( !args->ref_fname && !args->mrows_op && !args->rmdup && args->atomize==NONE ) error("Expected -a, -f, -m, -D or -d option\n");
     if ( !args->check_ref && args->ref_fname ) args->check_ref = CHECK_REF_EXIT;
     if ( args->check_ref && !args->ref_fname ) error("Expected --fasta-ref with --check-ref\n");
 


### PR DESCRIPTION
- The `-a, --atomize` option allows to decompose complex variants,
for example MNVs into consecutive SNVs

- The `--old-rec-tag` options indicates the original variant

Resolves #1052 and #128