### PR TITLE
[index] Allow the index statistics to run just with the index file

### DIFF
--- a/doc/bcftools.1
+++ b/doc/bcftools.1
@@ -2438,13 +2438,13 @@ see
 .PP
 \fB\-n, \-\-nrecords\fR
 .RS 4
-print the number of records based on the CSI or TBI index files
+print the number of records based on the CSI or TBI index files. Can run just with the index file.
 .RE
 .PP
 \fB\-s, \-\-stats\fR
 .RS 4
 Print per contig stats based on the CSI or TBI index files\&. Output format is three tab\-delimited columns listing the contig name, contig length (\fI\&.\fR
-if unknown) and number of records for the contig\&. Contigs with zero records are not printed\&.
+if unknown) and number of records for the contig\&. Contigs with zero records are not printed\&. Can run just with the index file.
 .RE
 .RE
 .SS "bcftools isec [\fIOPTIONS\fR] \fIA\&.vcf\&.gz\fR \fIB\&.vcf\&.gz\fR [\&...]"


### PR DESCRIPTION
Some index statistics, such as the total number of records (`--nrecords`) and the number of records per chromosome (`--stats`) can be retrieved directly from the index file associated with a VCF/BCF file, without the need for the actual variant call file. This PR implements this behaviour, by making the VCF/BCF file optional.

There is still the aspect of HTSlib's `hts_open()` throwing an error, when the VCF/BCF is not found, but the error message can be discarded by redirecting `stderr` to `/dev/null`, thus obtaining a clean output.

Fixes #1418 