### PR TITLE
parametrize brief-predictions parameter (-b) of bcftools csq

### DIFF
--- a/doc/bcftools.1
+++ b/doc/bcftools.1
@@ -1920,9 +1920,7 @@ use this custom tag to store consequences rather than the default BCSQ tag
 .PP
 \fB\-b, \-\-brief\-predictions\fR
 .RS 4
-annotate with abbreviated protein\-changing predictions\&. That is, instead of writing the whole modified protein sequence with potentially hundreds of aminoacids, only an abbreviated version such as
-\fI25E\&.\&.329>25G\&.\&.94\fR
-will be written
+annotate with abbreviated protein\-changing predictions\&. That is, instead of writing the whole modified protein sequence with potentially hundreds of aminoacids, only an abbreviated version with an optionally specified number of aminoacids (default=1) such as \fI25E\&.\&.329>25G\&.\&.94\fR will be written
 .RE
 .PP
 \fB\-e, \-\-exclude\fR \fIEXPRESSION\fR

--- a/doc/bcftools.html
+++ b/doc/bcftools.html
@@ -1122,7 +1122,8 @@ output VCF and are ignored for the prediction analysis.</p><div class="variablel
 </span></dt><dd>
     annotate with abbreviated protein-changing predictions. That is, instead of writing
     the whole modified protein sequence with potentially hundreds of aminoacids, only an
-    abbreviated version such as <span class="emphasis"><em>25E..329&gt;25G..94</em></span> will be written
+    abbreviated version with an optionally specified number of aminoacids (default=1)
+    such as <span class="emphasis"><em>25E..329&gt;25G..94</em></span> will be written
 </dd><dt><span class="term">
 <span class="strong"><strong>-e, --exclude</strong></span> <span class="emphasis"><em>EXPRESSION</em></span>
 </span></dt><dd>

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1147,10 +1147,11 @@ output VCF and are ignored for the prediction analysis.
 *-c, --custom-tag* 'STRING'::
     use this custom tag to store consequences rather than the default BCSQ tag
 
-*-b, --brief-predictions*::
+*-b, --brief-predictions* '[INT]'::
     annotate with abbreviated protein-changing predictions. That is, instead of writing
     the whole modified protein sequence with potentially hundreds of aminoacids, only an
-    abbreviated version such as '25E..329>25G..94' will be written
+    abbreviated version with an optionally specified number of aminoacids (default=1)
+    such as '25E..329>25G..94' will be written
 
 *-e, --exclude* 'EXPRESSION'::
     exclude sites for which 'EXPRESSION' is true. For valid expressions see

--- a/test/csq/ENST00000410009/frameshift.3.cmd
+++ b/test/csq/ENST00000410009/frameshift.3.cmd
@@ -1,0 +1,1 @@
+{bin}/bcftools csq -b 5 -f ENST00000410009.fa -g ENST00000410009.gff frameshift.vcf | ../sort-csq | {bin}/bcftools query -f'%POS\t%REF\t%ALT\t%BCSQ\n'

--- a/test/csq/ENST00000410009/frameshift.3.cmd.out
+++ b/test/csq/ENST00000410009/frameshift.3.cmd.out
@@ -1,0 +1,1 @@
+5507	G	GC	frameshift|CD207|ENST00000410009|protein_coding|-|25EPPPK..329>25GASSQ..94|5507G>GC,splice_region|CD207|ENST00000410009|protein_coding


### PR DESCRIPTION
With 64a5e1d a new parameter was introduced to abbreviate protein prediction consequences. This PR extends the parameter with an optional number value to abbreviate the amino acid sequences to a certain length and to keep the compact nomenclature of missense mutations as if the parameter was not specified.

Example:
```
bcftools csq -b 5 -f ENST00000410009.fa -g ENST00000410009.gff frameshift.vcf | ../sort-csq | bcftools query -f'%POS\t%REF\t%ALT\t%BCSQ\n'
Parsing ENST00000410009.gff ...
Indexed 1 transcripts, 6 exons, 6 CDSs, 2 UTRs
Calling...
5507    G       GC      frameshift|CD207|ENST00000410009|protein_coding|-|25EPPPK..329>25GASSQ..94|5507G>GC,splice_region|CD207|ENST00000410009|protein_coding
``` 

Original issue was #957.