### PR TITLE
Fixed typo in doc bcftools.txt

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -267,7 +267,7 @@ The program ignores the first column and the last indicates sex (1=male, 2=femal
     ::
     With the *call -C* 'alleles' command, third column of the targets file must
     be comma-separated list of alleles, starting with the reference allele.
-    Note that the file must be compressed and index.
+    Note that the file must be compressed and indexed.
     Such a file can be easily created from a VCF using:
 ----
     bcftools query -f'%CHROM\t%POS\t%REF,%ALT\n' file.vcf | bgzip -c > als.tsv.gz && tabix -s1 -b2 -e2 als.tsv.gz


### PR DESCRIPTION
Changed "Note that the file must be compressed and index." to
"Note that the file must be compressed and indexed."