### PR TITLE
Correct the mpileup --config 1.12 parameter set.

### DIFF
--- a/mpileup.c
+++ b/mpileup.c
@@ -1162,7 +1162,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
         "\n", mplp->indel_bias);
     fprintf(fp,
         "Configuration profiles activated with -X, --config:\n"
-        "    1.12:        -Q13 -h100 -m1\n"
+        "    1.12:        -Q13 -h100 -m1 -F0.002\n"
         "    illumina:    [ default values ]\n"
         "    ont:         -B -Q5 --max-BQ 30 -I [also try eg |bcftools call -P0.01]\n"
         "    pacbio-ccs:  -D -Q5 --max-BQ 50 -F0.1 -o25 -e1 --delta-BQ 10 -M99999\n"
@@ -1388,7 +1388,7 @@ int main_mpileup(int argc, char *argv[])
                 mplp.flag |= MPLP_NO_INDEL;
             } else if (strcasecmp(optarg, "1.12") == 0) {
                 // 1.12 and earlier
-                mplp.min_frac = 0.05;
+                mplp.min_frac = 0.002;
                 mplp.min_support = 1;
                 mplp.min_baseQ = 13;
                 mplp.tandemQ = 100;


### PR DESCRIPTION
I forgot to add -F0.002 in here.  The new default is -F0.05.

Note this also may be a problem for multi-sample calling.  A figure of
5% is too high once you start having lots of files, so I think perhaps
-p should be the default if multiple files are specified. (It's useful
in a single file scenario because it's a pre-filter and cuts out a lot
of the realignment assessment.)  If we do this we'd need the negation,
mayube --combine-sample-mF long option.