### PR TITLE
Include <strings.h> directly where needed [minor]

### DIFF
--- a/vcfindex.c
+++ b/vcfindex.c
@@ -24,6 +24,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <unistd.h>
 #include <getopt.h>
 #include <htslib/vcf.h>


### PR DESCRIPTION
Other source files that use `strcase*()` functions #include <strings.h> themselves, so do so for this source file too. (<strings.h> is often a byproduct of <string.h> but POSIX doesn't require that.) As noted in the similar PR #1399, this is a bit of a theoretical problem but other theoretical problems have still caused trouble — so might as well make this trivial fix too.