### PR TITLE
Fixes +check-ploidy reporting wrong chromosome

### DIFF
--- a/plugins/check-ploidy.c
+++ b/plugins/check-ploidy.c
@@ -108,7 +108,7 @@ bcf1_t *process(bcf1_t *rec)
         for (i=0; i<args->ndat; i++)
         {
             dat_t *dat = &args->dat[i];
-            if ( dat->ploidy!=0 ) printf("%s\t%s\t%d\t%d\t%d\n", dat->sample,bcf_seqname(args->hdr,rec),dat->beg+1,dat->end+1,dat->ploidy); 
+            if ( dat->ploidy!=0 ) printf("%s\t%s\t%d\t%d\t%d\n", dat->sample,bcf_hdr_id2name(args->hdr, args->rid),dat->beg+1,dat->end+1,dat->ploidy);
             dat->ploidy = 0;
         }
     }


### PR DESCRIPTION
The check-ploidy plugin currently reports the wrong chromosome when flushing the results from the previous region. This PR corrects the record from which the chromosome name is gathered.

Minimal `example.vcf`:
```
##fileformat=VCFv4.1
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##contig=<ID=22,assembly=b37>
##contig=<ID=X,assembly=b37>
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1
22	1	1	C	G	.	PASS	.	GT	1/1
X	1	2	C	G	.	PASS	.	GT	1
```

Before fix:
```
$ bcftools +check-ploidy example.vcf 
# [1]Sample     [2]Chromosome   [3]Region Start [4]Region End   [5]Ploidy
S1      X       1       1       2
S1      X       1       1       1
```

After fix:
```
bcftools +check-ploidy example.vcf 
# [1]Sample     [2]Chromosome   [3]Region Start [4]Region End   [5]Ploidy
S1      22      1       1       2
S1      X       1       1       1
```