### PR TITLE
Make check-ploidy report ploidy when genotype contains missingness 

### DIFF
--- a/plugins/check-ploidy.c
+++ b/plugins/check-ploidy.c
@@ -119,13 +119,12 @@ bcf1_t *process(bcf1_t *rec)
         for (i=0; i<rec->n_sample; i++) \
         { \
             type_t *p = (type_t*) (fmt_gt->p + i*fmt_gt->size); \
-            int nal, missing = 0; \
+            int nal = 0; \
             for (nal=0; nal<fmt_gt->n; nal++) \
             { \
                 if ( p[nal]==vector_end ) break; /* smaller ploidy */ \
-                if ( bcf_gt_is_missing(p[nal]) ) { missing=1; break; } /* missing allele */ \
             } \
-            if ( !nal || missing ) continue; /* missing genotype */ \
+            if ( !nal ) continue; /* missing genotype */ \
             dat_t *dat = &args->dat[i]; \
             if ( dat->ploidy==nal ) \
             { \


### PR DESCRIPTION
According to the VCF specification, `./.`, for example, contains information about a diploid genotype. We don't know what the call is for the alleles but we do know that there is 2 of them and therefore we expect the reported ploidy to be 2.

This change makes the `+check-ploidy` plugin report the ploidy at sites that contain missinging, as this metric is well defined. The current behavior of not reporting ploidy for some call assignments (missing - even where it's only partial) is unexpected.


Minimal `example.vcf`:
```
##fileformat=VCFv4.1
##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
##contig=<ID=20,assembly=b37>
##contig=<ID=21,assembly=b37>
##contig=<ID=22,assembly=b37>
##contig=<ID=X,assembly=b37>
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	S1
20	1	1	C	G	.	PASS	.	GT	0/0
21	1	2	C	G	.	PASS	.	GT	./0
22	1	3	C	G	.	PASS	.	GT	./.
X	1	4	C	G	.	PASS	.	GT	.
```

Before change:
```
$ bcftools +check-ploidy example.vcf 
# [1]Sample     [2]Chromosome   [3]Region Start [4]Region End   [5]Ploidy
S1      21      1       1       2
```
_Note: the reported chromosome is wrong due to the issue fixed in #1530 ._

After change:
```
$ bcftools +check-ploidy example.vcf 
# [1]Sample     [2]Chromosome   [3]Region Start [4]Region End   [5]Ploidy
S1      20      1       1       2
S1      21      1       1       2
S1      22      1       1       2
S1      X       1       1       1
```
_Note: this output came from a copy of the plugin that also includes the fix in #1530 ._