### PR TITLE
Add new `bcftools head` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ OBJS     = main.o vcfindex.o tabix.o \
            vcfstats.o vcfisec.o vcfmerge.o vcfquery.o vcffilter.o filter.o vcfsom.o \
            vcfnorm.o vcfgtcheck.o vcfview.o vcfannotate.o vcfroh.o vcfconcat.o \
            vcfcall.o mcall.o vcmp.o gvcf.o reheader.o convert.o vcfconvert.o tsv2vcf.o \
-           vcfcnv.o HMM.o consensus.o ploidy.o bin.o hclust.o version.o \
+           vcfcnv.o vcfhead.o HMM.o consensus.o ploidy.o bin.o hclust.o version.o \
            regidx.o smpl_ilist.o csq.o vcfbuf.o \
            mpileup.o bam2bcf.o bam2bcf_indel.o bam_sample.o \
            vcfsort.o cols.o extsort.o dist.o abuf.o \
@@ -249,6 +249,7 @@ vcfnorm.o: vcfnorm.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_faid
 vcfquery.o: vcfquery.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_khash_str2int_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(convert_h)
 vcfroh.o: vcfroh.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(bcftools_h) HMM.h $(smpl_ilist_h) $(filter_h)
 vcfcnv.o: vcfcnv.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kstring_h) $(htslib_kfunc_h) $(htslib_khash_str2int_h) $(bcftools_h) HMM.h rbuf.h
+vcfhead.o: vcfhead.c $(htslib_kstring_h) $(htslib_vcf_h) $(bcftools_h)
 vcfsom.o: vcfsom.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(bcftools_h)
 vcfsort.o: vcfsort.c $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_hts_os_h) kheap.h $(bcftools_h)
 vcfstats.o: vcfstats.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_faidx_h) $(bcftools_h) $(filter_h) bin.h dist.h

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 ## Release a.b
 
+* New `bcftools head` subcommand for conveniently displaying the headers
+  of a VCF or BCF file. Without any options, this is equivalent to
+  `bcftools view --header-only --no-version` but more succinct and memorable.
+
 Changes affecting specific commands:
 
 * bcftools annotate

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -85,6 +85,7 @@ list of available options, run *bcftools* 'COMMAND' without arguments.
 - *<<csq,csq>>*       ..  haplotype aware consequence caller
 - *<<filter,filter>>*    ..  filter VCF/BCF files using fixed thresholds
 - *<<gtcheck,gtcheck>>*   ..  check sample concordance, detect sample swaps and contamination
+- *<<head,head>>*      ..  view VCF/BCF file headers
 - *<<index,index>>*     ..  index VCF/BCF
 - *<<isec,isec>>*      ..  intersections of VCF/BCF files
 - *<<merge,merge>>*     ..  merge VCF/BCF files files from non-overlapping sample sets
@@ -1585,6 +1586,27 @@ Without the *-g* option, multi-sample cross-check of samples in 'query.vcf.gz' i
 //        most dissimilar to the rest.
 
 
+[[head]]
+=== bcftools head ['OPTIONS'] ['FILE']
+By default, prints all headers from the specified input file to standard output
+in VCF format. The input file may be in VCF or BCF format; if no 'FILE' is
+specified, standard input will be read. With appropriate options, only some
+of the headers and/or additionally some of the variant records will be printed.
+
+The *bcftools head* command outputs VCF headers almost exactly as they appear
+in the input file: it may add a `##FILTER=<ID=PASS>` header if not already
+present, but it never adds version or command line information itself.
+
+==== Options:
+*-h, --header* 'INT'::
+    Display only the first 'INT' header lines.
+    By default, all header lines are displayed.
+
+*-n, --records* 'INT'::
+    Also display the first 'INT' variant records.
+    By default, no variant records are displayed.
+
+
 [[index]]
 === bcftools index ['OPTIONS']  'in.bcf'|'in.vcf.gz'
 Creates index for bgzip compressed VCF/BCF files for random access. CSI
@@ -2985,7 +3007,7 @@ Convert between VCF and BCF. Former *bcftools subset*.
     drop individual genotype information (after subsetting if *-s* option is set)
 
 *-h, --header-only*::
-    output the VCF header only
+    output the VCF header only (see also *<<head,bcftools head>>*)
 
 *-H, --no-header*::
     suppress the header in VCF output

--- a/main.c
+++ b/main.c
@@ -43,6 +43,7 @@ int main_vcfsom(int argc, char *argv[]);
 int main_vcfnorm(int argc, char *argv[]);
 int main_vcfgtcheck(int argc, char *argv[]);
 int main_vcfview(int argc, char *argv[]);
+int main_vcfhead(int argc, char *argv[]);
 int main_vcfcall(int argc, char *argv[]);
 int main_vcfannotate(int argc, char *argv[]);
 int main_vcfroh(int argc, char *argv[]);
@@ -100,6 +101,10 @@ static cmd_t cmds[] =
     { .func  = main_vcfconvert,
       .alias = "convert",
       .help  = "convert VCF/BCF files to different formats and back"
+    },
+    { .func  = main_vcfhead,
+      .alias = "head",
+      .help  = "view VCF/BCF file headers"
     },
     { .func  = main_vcfisec,
       .alias = "isec",

--- a/vcfhead.c
+++ b/vcfhead.c
@@ -1,0 +1,133 @@
+/*  vcfhead.c -- view VCF/BCF file headers.
+
+    Copyright (C) 2021 University of Glasgow.
+
+    Author: John Marshall <jmarshall@hey.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.  */
+
+#include <getopt.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <htslib/kstring.h>
+#include <htslib/vcf.h>
+
+#include "bcftools.h"
+
+int main_vcfhead(int argc, char *argv[])
+{
+    static const char usage[] =
+"\n"
+"About: Displays VCF/BCF headers and optionally the first few variant records\n"
+"Usage: bcftools head [OPTION]... [FILE]\n"
+"\n"
+"Options:\n"
+"  -h, --headers INT   Display INT header lines [all]\n"
+"  -n, --records INT   Display INT variant record lines [none]\n"
+"\n";
+
+    static const struct option loptions[] = {
+        { "headers", required_argument, NULL, 'h' },
+        { "records", required_argument, NULL, 'n' },
+        { NULL, 0, NULL, 0 }
+    };
+
+    int all_headers = 1;
+    uint64_t nheaders = 0;
+    uint64_t nrecords = 0;
+
+    int c, nargs;
+    while ((c = getopt_long(argc, argv, "h:n:", loptions, NULL)) >= 0)
+        switch (c) {
+        case 'h': all_headers = 0; nheaders = strtoull(optarg, NULL, 0); break;
+        case 'n': nrecords = strtoull(optarg, NULL, 0); break;
+        default:
+            fputs(usage, stderr);
+            return EXIT_FAILURE;
+        }
+
+    nargs = argc - optind;
+    if (nargs == 0 && isatty(STDIN_FILENO)) {
+        fputs(usage, stdout);
+        return EXIT_SUCCESS;
+    }
+    else if (nargs > 1) {
+        fputs(usage, stderr);
+        return EXIT_FAILURE;
+    }
+
+    const char *fname = (nargs == 1)? argv[optind] : "-";
+    vcfFile *fp = bcf_open(fname, "r");
+    if (fp == NULL) {
+        if (strcmp(fname, "-") != 0)
+            error_errno("[%s] Can't open \"%s\"", __func__, fname);
+        else
+            error_errno("[%s] Can't open standard input", __func__);
+    }
+
+    bcf_hdr_t *hdr = bcf_hdr_read(fp);
+    if (hdr == NULL) {
+        bcf_close(fp);
+        if (strcmp(fname, "-") != 0)
+            error("[%s] Can't read headers from \"%s\"\n", __func__, fname);
+        else
+            error("[%s] Can't read headers\n", __func__);
+    }
+
+    kstring_t str = KS_INITIALIZE;
+
+    if (all_headers) {
+        bcf_hdr_format(hdr, 0, &str);
+        fputs(ks_str(&str), stdout);
+    }
+    else if (nheaders > 0) {
+        bcf_hdr_format(hdr, 0, &str);
+        char *lim = str.s;
+        uint64_t n;
+        for (n = 0; n < nheaders; n++) {
+            lim = strchr(lim, '\n');
+            if (lim) lim++;
+            else break;
+        }
+        if (lim) *lim = '\0';
+        fputs(ks_str(&str), stdout);
+    }
+
+    if (nrecords > 0) {
+        bcf1_t *rec = bcf_init();
+        uint64_t n;
+        for (n = 0; n < nrecords && bcf_read(fp, hdr, rec) >= 0; n++) {
+            ks_clear(&str);
+            if (vcf_format(hdr, rec, &str) >= 0)
+                fputs(ks_str(&str), stdout);
+            else
+                fprintf(stderr, "[%s] Record #%"PRIu64 " is invalid\n", __func__, n+1);
+        }
+        bcf_destroy(rec);
+    }
+
+    ks_free(&str);
+    bcf_hdr_destroy(hdr);
+    bcf_close(fp);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Companion PR to samtools/samtools#1517, this adds a new `bcftools head` command for viewing a VCF/BCF file's headers, verbatim. The idea is to have consistent `samtools head` / `bcftools head` commands rather than having to remember which of `-h`/`-H` you want with which `view` command.

`bcftools head` prints the input file's headers and optionally also its first few variant records. (This command always displays the headers as they are in the file — modulo a `##FILTER=<ID=PASS,…>` line — never adding version or command line information itself.)

This PR also adds a `view --with-header` option (equivalent to the default), so that both samtools and bcftools view commands have all three of `--header-only`/`--no-header`/`--with-header` for consistency.
(It also splits the `-h, --header-only` / `-H, --no-header` option usage descriptions into separate lines for clarity.)

And it also reformats the list of commands in _doc/bcftools.txt_ so that the `..` and descriptions line up vertically when viewed with `man bcftools`. (Sadly at the cost of no longer lining up in the _doc/bcftools.txt_ source code.)