### PR TITLE
Recommend "icc -fp-model precise" if doing "make check".

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -197,6 +197,16 @@ compiler or SSL implementation.  It is assumed you already have the core set
 of packages for the given distribution - the lists may be incomplete if
 this is not the case.
 
+Intel Compiler
+--------------
+
+At some optimisation levels the Intel compiler may use approximate
+floating point mathematics.  We do not believe this to produce
+substantially erroneous results, but it can cause the test harness to
+fail due to minor fluctuations in the least significiant digits.  If
+you wish to use icc with the test harness, it is recommended you use
+the "-fp-model precise" icc option.
+
 Debian / Ubuntu
 ---------------
 


### PR DESCRIPTION
Without this we get 24 test failures, as the default -fp-model is a bit fast and loose.  (Ideally our tests wouldn't object so much about minor fluctuations in the least significant digits, as that's not really the thing we're trying to validate.)

An example, from the first test failure (icc 2021):

```
                        < 17    2041    .       G       A,<*>   0       .       
DP=7;I16=0,0,4,3,0,0,276,11066,0,0,420,25200,0,0,137,2895;QS=0,1,0;VDB=**0.80233**;S
GB=-0.636426;MQSBZ=0;FS=0;MQ0F=0        PL      223,21,0,223,21,223
                        ---
                        > 17    2041    .       G       A,<*>   0       .       
DP=7;I16=0,0,4,3,0,0,276,11066,0,0,420,25200,0,0,137,2895;QS=0,1,0;VDB=**0.802329**;
SGB=-0.636426;MQSBZ=0;FS=0;MQ0F=0       PL      223,21,0,223,21,223
```
