### PR TITLE
Minor bcftools merge speedups

### DIFF
--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -3070,7 +3070,8 @@ void merge_vcf(args_t *args)
 
     int *rid_tab = calloc(args->maux->n, sizeof(*rid_tab));
     if (!rid_tab)
-        return; // NB: no ability to return error code.
+        error("[%s:%d] Could not allocate %ld bytes\n",
+              __FILE__, __LINE__, args->maux->n*sizeof(*rid_tab));
 
     while ( bcf_sr_next_line(args->files) )
     {

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -1267,7 +1267,12 @@ void merge_info(args_t *args, bcf1_t *out)
             bcf_info_t *inf = &line->d.info[j];
 
             const char *key = hdr->id[BCF_DT_ID][inf->key].key;
-            if ( !args->keep_AC_AN && (!strcmp("AC",key) || !strcmp("AN",key)) ) continue;  // AC and AN are done in merge_format() after genotypes are done
+            // AC and AN are done in merge_format() after genotypes are done
+            if (!args->keep_AC_AN &&
+                (key[0] == 'A'
+                  && (key[1] == 'C' || key[1] == 'N')
+                  && key[2] == 0))
+                continue;
 
             int id = bcf_hdr_id2int(out_hdr, BCF_DT_ID, key);
             if ( id==-1 ) error("Error: The INFO field is not defined in the header: %s\n", key);


### PR DESCRIPTION
It's still pretty slow, mainly due to a lot of parsing and info field hackery, but this PR speeds it up by 10-15% by removing most of the dominant function (strcmp).  These come through direct calls (looking for "AN" and "AC" in a tight loop) and excess use of dictionary lookups.

I think there are more dict caching things we could do to avoid more khash usage, but this is a relatively simple start.
