### PR TITLE
Update bcftools documentation 

### DIFF
--- a/doc/bcftools.1
+++ b/doc/bcftools.1
@@ -2684,7 +2684,7 @@ List of input alignment files, one file per line [null]
 .RS 4
 Disable probabilistic realignment for the computation of base alignment
 quality (BAQ). BAQ is the Phred\-scaled probability of a read base being
-misaligned. Applying this option greatly helps to reduce false SNPs caused
+misaligned. BAQ greatly helps to reduce false SNPs caused
 by misalignments.
 .RE
 .sp


### PR DESCRIPTION
corrects --no-BAQ description in mpileup options in the documentation