### PR TITLE
Fix Makefile dependencies; correct VCF data files [minor]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ bcftools: $(OBJS) $(HTSLIB)
 
 plugins: $(PLUGINS)
 
-bcftools_h = bcftools.h $(htslib_hts_defs_h) $(htslib_vcf_h)
+bcftools_h = bcftools.h $(htslib_hts_defs_h) $(htslib_vcf_h) $(htslib_synced_bcf_reader_h)
 call_h = call.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) vcmp.h
 variantkey_h = variantkey.h hex.h
 convert_h = convert.h $(htslib_vcf_h)
@@ -240,7 +240,7 @@ vcfplugin.o: vcfplugin.c config.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) 
 vcfcall.o: vcfcall.c $(htslib_vcf_h) $(htslib_kfunc_h) $(htslib_synced_bcf_reader_h) $(htslib_khash_str2int_h) $(bcftools_h) $(call_h) $(prob1_h) $(ploidy_h) $(gvcf_h) regidx.h $(vcfbuf_h)
 vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_thread_pool_h) $(bcftools_h)
 vcfconvert.o: vcfconvert.c $(htslib_faidx_h) $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kseq_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
-vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h
+vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h regidx.h
 vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kbitset_h) $(htslib_hts_os_h) $(bcftools_h) extsort.h
 vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(bcftools_h)
 vcfisec.o: vcfisec.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(bcftools_h) $(filter_h)

--- a/test/annotate.olap.1.out
+++ b/test/annotate.olap.1.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.r3
+##fileformat=VCFv4.3
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##reference=ref.fa
 ##contig=<ID=1,assembly=b37,length=249250621>

--- a/test/annotate.olap.2.out
+++ b/test/annotate.olap.2.out
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.r3
+##fileformat=VCFv4.3
 ##FILTER=<ID=PASS,Description="All filters passed">
 ##reference=ref.fa
 ##contig=<ID=1,assembly=b37,length=249250621>

--- a/test/annotate.olap.vcf
+++ b/test/annotate.olap.vcf
@@ -1,4 +1,4 @@
-##fileformat=VCFv4.r3
+##fileformat=VCFv4.3
 ##reference=ref.fa
 ##contig=<ID=1,assembly=b37,length=249250621>
 ##ALT=<ID=CNV,Description="Copy Number Variation">


### PR DESCRIPTION
Update dependencies to reflect recent changes (from ce4cd8911c8e666cd76da9ce16ceeebf4c388905 and 5c6de9ba32008523d6f4bb077423bf72165d3bc2).
Fix typo on `##fileformat` line in test data and expected output (from 7e36b52ef2b1d98e4d5142e9631b3ea392440f41).