### PR TITLE
Switch to https for htslib git clone

### DIFF
--- a/.ci_helpers/clone
+++ b/.ci_helpers/clone
@@ -11,7 +11,7 @@ branch=$3
 
 ref=''
 [ -n "$branch" ] && ref=$(git ls-remote --heads "$repository" "$branch" 2>/dev/null)
-[ -z "$ref" ] && repository='git://github.com/samtools/htslib.git'
+[ -z "$ref" ] && repository='https://github.com/samtools/htslib.git'
 
 set -x
 git clone --recurse-submodules --shallow-submodules --depth=1 ${ref:+--branch="$branch"} "$repository" "$localdir"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ timeout_in: 10m
 # clone with our own commands too.
 clone_template: &HTSLIB_CLONE
   htslib_clone_script: |
-    .ci_helpers/clone "git://github.com/${CIRRUS_REPO_OWNER}/htslib" "${HTSDIR}" "${CIRRUS_BRANCH}"
+    .ci_helpers/clone "https://github.com/${CIRRUS_REPO_OWNER}/htslib" "${HTSDIR}" "${CIRRUS_BRANCH}"
 
 
 #--------------------------------------------------

--- a/INSTALL
+++ b/INSTALL
@@ -3,8 +3,8 @@ For the impatient
 
 The latest source code can be downloaded from github and compiled using:
 
-    git clone --recurse-submodules git://github.com/samtools/htslib.git
-    git clone git://github.com/samtools/bcftools.git
+    git clone --recurse-submodules https://github.com/samtools/htslib.git
+    git clone https://github.com/samtools/bcftools.git
     cd bcftools
      # The following is optional:
      #   autoheader && autoconf && ./configure --enable-libgsl --enable-perl-filters


### PR DESCRIPTION
Due to deprecation of the unencrypted git protocol at GitHub.
See https://github.blog/2021-09-01-improving-git-protocol-security-github