### PR TITLE
Switch cirrus ubuntu image to ubuntu:latest

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,7 +76,7 @@ gcc_task:
 ubuntu_task:
   name: ubuntu-clang
   container:
-    image: ubuntu:devel
+    image: ubuntu:latest
     cpu: 2
     memory: 1G
 


### PR DESCRIPTION
Done to fix a problem where clang fails to install due to an inconsistency in the apt sources used by the ubuntu kinetic (a.k.a
devel) Docker image.  This means an update to clang via the kinetic-proposed source makes it uninstallable on that image
until the proposed change makes it to the kinetic one.

Switching to ubuntu:latest means we won't be quite as leading-edge but it's less likely to break unexpectedly.

This goes with similar pull requests in HTSlib and SAMtools.