### PR TITLE
Remove unused <zlib.h> inclusions [minor]

### DIFF
--- a/prob1.c
+++ b/prob1.c
@@ -30,18 +30,11 @@ THE SOFTWARE.  */
 #include <errno.h>
 #include <assert.h>
 #include <limits.h>
-#include <zlib.h>
 #include "prob1.h"
-
-// #include "kstring.h"
-// #include "kseq.h"
-// KSTREAM_INIT(gzFile, gzread, 16384)
 
 #define MC_MAX_EM_ITER 16
 #define MC_EM_EPS 1e-5
 #define MC_DEF_INDEL 0.15
-
-gzFile bcf_p1_fp_lk;
 
 void bcf_p1_indel_prior(bcf_p1aux_t *ma, double x)
 {
@@ -304,8 +297,6 @@ static void mc_cal_y_core(bcf_p1aux_t *ma, int beg)
         }
     }
     if (z[0] != ma->z) memcpy(ma->z, z[0], sizeof(double) * (ma->M + 1));
-    if (bcf_p1_fp_lk)
-        gzwrite(bcf_p1_fp_lk, ma->z, sizeof(double) * (ma->M + 1));
 }
 
 static void mc_cal_y(bcf_p1aux_t *ma)

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -32,7 +32,6 @@ THE SOFTWARE.  */
 #include <math.h>
 #include <htslib/vcf.h>
 #include <time.h>
-#include <zlib.h>
 #include <stdarg.h>
 #include <htslib/kfunc.h>
 #include <htslib/synced_bcf_reader.h>


### PR DESCRIPTION
Remove remaining references to `bcf_p1_fp_lk`, which has been unused since the undocumented `call -K` option was removed in c4172c5eca9e03113b028676b993c7279e5b1477 in 2013.

After that, neither source file actually uses anything from `<zlib.h>` (_vcfcall.c_ already didn't).

Hence somewhat surprisingly bcftools does not directly use zlib itself (it does indirectly via htslib, of course). So the zlib probing etc could in principle be removed from _configure.ac_ and _Makefile_, but that may not be worth doing at this time.