### PR TITLE
Add `bcftools index --stats --all` option to display all contigs

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1731,6 +1731,10 @@ the CSI first and then the TBI.
     see *<<common_options,Common Options>>*
 
 ==== Stats options:
+*-a, --all*::
+    Used in conjunction with *-s, --stats*, print per contig stats
+    for all contigs, even those with zero records.
+
 *-n, --nrecords*::
     print the number of records based on the CSI or TBI index files
 
@@ -1738,7 +1742,7 @@ the CSI first and then the TBI.
     Print per contig stats based on the CSI or TBI index files.
     Output format is three tab-delimited columns listing the contig
     name, contig length ('.' if unknown) and number of records for
-    the contig. Contigs with zero records are not printed.
+    the contig. Contigs with zero records are not printed by default.
 
 [[isec]]
 === bcftools isec ['OPTIONS']  'A.vcf.gz' 'B.vcf.gz' [...]

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1733,7 +1733,8 @@ the CSI first and then the TBI.
 ==== Stats options:
 *-a, --all*::
     Used in conjunction with *-s, --stats*, print per contig stats
-    for all contigs, even those with zero records.
+    for all contigs, even those with zero records and those for which
+    no stats are recorded in the index file (shown as '.').
 
 *-n, --nrecords*::
     print the number of records based on the CSI or TBI index files

--- a/vcfindex.c
+++ b/vcfindex.c
@@ -183,13 +183,15 @@ int vcf_index_stats(char *fname, int stats)
     for (tid=0; tid<nseq; tid++)
     {
         uint64_t records, v;
-        hts_idx_get_stat(tbx ? tbx->idx : idx, tid, &records, &v);
+        int ret = hts_idx_get_stat(tbx ? tbx->idx : idx, tid, &records, &v);
         sum += records;
         if ( (stats&total) || (records == 0 && !(stats&all_contigs)) ) continue;
         const char *ctg_name = tbx ? seq[tid] : hdr ? bcf_hdr_id2name(hdr, tid) : "n/a";
         bcf_hrec_t *hrec = hdr ? bcf_hdr_get_hrec(hdr, BCF_HL_CTG, "ID", ctg_name, NULL) : NULL;
         int hkey = hrec ? bcf_hrec_find_key(hrec, "length") : -1;
-        printf("%s\t%s\t%" PRIu64 "\n", ctg_name, hkey<0?".":hrec->vals[hkey], records);
+        printf("%s\t%s\t", ctg_name, hkey<0?".":hrec->vals[hkey]);
+        if (ret >= 0) printf("%" PRIu64 "\n", records);
+        else printf(".\n");
     }
     if ( !sum )
     {

--- a/vcfindex.c
+++ b/vcfindex.c
@@ -40,7 +40,8 @@ DEALINGS IN THE SOFTWARE.  */
 
 enum {
     per_contig = 1,
-    total = 2
+    all_contigs = 2,
+    total = 4
 };
 
 static void usage(void)
@@ -58,6 +59,7 @@ static void usage(void)
     fprintf(stderr, "        --threads INT        use multithreading with INT worker threads [0]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Stats options:\n");
+    fprintf(stderr, "    -a, --all            with --stats, print stats for all contigs even when zero\n");
     fprintf(stderr, "    -n, --nrecords       print number of records based on existing index file\n");
     fprintf(stderr, "    -s, --stats          print per contig stats based on existing index file\n");
     fprintf(stderr, "\n");
@@ -183,7 +185,7 @@ int vcf_index_stats(char *fname, int stats)
         uint64_t records, v;
         hts_idx_get_stat(tbx ? tbx->idx : idx, tid, &records, &v);
         sum += records;
-        if ( (stats&total) || !records ) continue;
+        if ( (stats&total) || (records == 0 && !(stats&all_contigs)) ) continue;
         const char *ctg_name = tbx ? seq[tid] : hdr ? bcf_hdr_id2name(hdr, tid) : "n/a";
         bcf_hrec_t *hrec = hdr ? bcf_hdr_get_hrec(hdr, BCF_HL_CTG, "ID", ctg_name, NULL) : NULL;
         int hkey = hrec ? bcf_hrec_find_key(hrec, "length") : -1;
@@ -224,6 +226,7 @@ int main_vcfindex(int argc, char *argv[])
 
     static struct option loptions[] =
     {
+        {"all",no_argument,NULL,'a'},
         {"csi",no_argument,NULL,'c'},
         {"tbi",no_argument,NULL,'t'},
         {"force",no_argument,NULL,'f'},
@@ -237,7 +240,7 @@ int main_vcfindex(int argc, char *argv[])
     };
 
     char *tmp;
-    while ((c = getopt_long(argc, argv, "ctfm:sno:", loptions, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "ctfm:snao:", loptions, NULL)) >= 0)
     {
         switch (c)
         {
@@ -250,6 +253,7 @@ int main_vcfindex(int argc, char *argv[])
                 break;
             case 's': stats |= per_contig; break;
             case 'n': stats |= total; break;
+            case 'a': stats |= all_contigs; break;
             case 9:
                 n_threads = strtol(optarg,&tmp,10);
                 if ( *tmp ) error("Could not parse argument: --threads %s\n", optarg);


### PR DESCRIPTION
By default, contigs containing zero records are omitted. Add an option to print these too.

In particular, for old index files generated without metadata pseudo-bins, this is the difference between listing all the contigs and printing nothing. Fixes #1771.