### PR TITLE
Vcf format detection

### DIFF
--- a/vcfview.c
+++ b/vcfview.c
@@ -839,8 +839,10 @@ int main_vcfview(int argc, char *argv[])
     }
 
     if (args->write_index) {
-        if (bcf_idx_save(args->out) < 0)
+        if (bcf_idx_save(args->out) < 0) {
+            hts_close(args->out);
             error("Error: cannot write to index %s\n", args->index_fn);
+        }
         free(args->index_fn);
     }
 

--- a/version.c
+++ b/version.c
@@ -84,10 +84,13 @@ void set_wmode(char dst[8], int file_type, const char *fname, int clevel)
 {
     const char *ret = NULL;
     int len = fname ? strlen(fname) : 0;
-    if ( len >= 4 && !strcasecmp(".bcf",fname+len-4) ) ret = hts_bcf_wmode(FT_BCF|FT_GZ);
-    else if ( len >= 4 && !strcasecmp(".vcf",fname+len-4) ) ret = hts_bcf_wmode(FT_VCF);
-    else if ( len >= 7 && !strcasecmp(".vcf.gz",fname+len-7) ) ret = hts_bcf_wmode(FT_VCF|FT_GZ);
-    else if ( len >= 8 && !strcasecmp(".vcf.bgz",fname+len-8) ) ret = hts_bcf_wmode(FT_VCF|FT_GZ);
+    char *delim = strstr(fname, HTS_IDX_DELIM);
+    if (delim)
+        len = delim-fname;
+    if ( len >= 4 && !strncasecmp(".bcf",fname+len-4,4) ) ret = hts_bcf_wmode(FT_BCF|FT_GZ);
+    else if ( len >= 4 && !strncasecmp(".vcf",fname+len-4,4) ) ret = hts_bcf_wmode(FT_VCF);
+    else if ( len >= 7 && !strncasecmp(".vcf.gz",fname+len-7,7) ) ret = hts_bcf_wmode(FT_VCF|FT_GZ);
+    else if ( len >= 8 && !strncasecmp(".vcf.bgz",fname+len-8,8) ) ret = hts_bcf_wmode(FT_VCF|FT_GZ);
     else ret = hts_bcf_wmode(file_type);
     if ( clevel>=0 && clevel<=9 )
     {


### PR DESCRIPTION
- Make a.vcf.gz##idx##a.vcf.gz.csi do the right thing.

- Flush & close the VCF/BCF file if index writing failed, so we're in a known-good state.