### PR TITLE
Add error checking to gvcf_write_block

### DIFF
--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -2564,6 +2564,9 @@ void gvcf_write_block(args_t *args, int start, int end)
     {
         int slen  = 0;
         char *seq = faidx_fetch_seq(args->gvcf_fai,maux->chr,out->pos,out->pos,&slen);
+        if (!seq)
+            exit(1); // faidx_fetch_seq has already reported the error.
+
         if (slen)
         {
             out->d.allele[0][0] = seq[0];


### PR DESCRIPTION
This avoids a segmentation fault when bcftools merge uses an incomplete fasta .fai file.

Fixes #1900

For some definition of "fixes".  It now exists cleanly instead of simply dumping core due to a null-pointer exception.  The cause of the error in 1900 though was incompatible .fa and .fai files, caused by "git pull" on an existing clone.  To consider: make check could remove all the auto-generated .fai files to avoid such breakages.