### PR TITLE
drop-genotypes for concat

### DIFF
--- a/doc/bcftools.1
+++ b/doc/bcftools.1
@@ -1359,6 +1359,10 @@ Alias for \fB\-d exact\fP
 .RS 4
 Read file names from \fIFILE\fP, one file name per line.
 .RE
+\fB\-G, \-\-drop\-genotypes\fP
+.RS 4
+drop individual genotype information.
+.RE
 .sp
 \fB\-l, \-\-ligate\fP
 .RS 4

--- a/test/concat.5.3.out
+++ b/test/concat.5.3.out
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=chr1>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	1	.	A	C	.	.	.
+chr1	2	.	C	G	.	.	.
+chr1	3	.	G	T	.	.	.
+chr1	4	.	T	A	.	.	.

--- a/test/test.pl
+++ b/test/test.pl
@@ -714,6 +714,8 @@ run_test(\&test_vcf_concat,$opts,in=>['concat.4.a','concat.4.b'],out=>'concat.5.
 run_test(\&test_vcf_concat,$opts,in=>['concat.5.a','concat.5.b','concat.5.c'],out=>'concat.5.1.out',do_bcf=>0,args=>'-l --ligate-warn');
 run_test(\&test_vcf_concat,$opts,in=>['concat.5.a','concat.5.b','concat.5.c'],out=>'concat.5.1.out',do_bcf=>1,args=>'-l --ligate-warn');
 run_test(\&test_vcf_concat,$opts,in=>['concat.5.a','concat.5.b','concat.5.c'],out=>'concat.5.2.out',do_bcf=>1,args=>'-l --ligate-force');
+run_test(\&test_vcf_concat,$opts,in=>['concat.5.a','concat.5.b','concat.5.c'],out=>'concat.5.3.out',do_bcf=>0,args=>'-G -a -D');
+run_test(\&test_vcf_concat,$opts,in=>['concat.5.a','concat.5.b','concat.5.c'],out=>'concat.5.3.out',do_bcf=>1,args=>'-G -a -D');
 run_test(\&test_vcf_reheader,$opts,in=>'reheader',out=>'reheader.1.out',header=>'reheader.hdr');
 run_test(\&test_vcf_reheader,$opts,in=>'reheader',out=>'reheader.2.out',samples=>'reheader.samples');
 run_test(\&test_vcf_reheader,$opts,in=>'reheader',out=>'reheader.2.out',samples=>'reheader.samples2');

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -61,9 +61,19 @@ typedef struct _args_t
     int argc, nfnames, allow_overlaps, phased_concat, regions_is_file, regions_overlap;
     int compact_PS, phase_set_changed, naive_concat, naive_concat_trust_headers;
     int verbose, explicit_output_type, ligate_force, ligate_warn;
+    int sites_only;
     htsThreadPool *tpool;
 }
 args_t;
+
+#define DROP_GENOTYPES(args, line) if ( args->sites_only ) {\
+    bcf_subset(args->out_hdr, line, 0, 0);\
+    }
+
+#define DROP_HDR_GENOTYPES(args, hdr)  if (args->sites_only) {\
+	    hdr = bcf_hdr_subset(hdr, 0, 0, 0);\
+	    bcf_hdr_remove(hdr, BCF_HL_FMT, NULL);\
+        }
 
 static void init_data(args_t *args)
 {
@@ -85,6 +95,9 @@ static void init_data(args_t *args)
     {
         htsFile *fp = hts_open(args->fnames[i], "r"); if ( !fp ) error("Failed to open: %s\n", args->fnames[i]);
         bcf_hdr_t *hdr = bcf_hdr_read(fp); if ( !hdr ) error("Failed to parse header: %s\n", args->fnames[i]);
+        
+        DROP_HDR_GENOTYPES(args, hdr)
+        
         args->out_hdr = bcf_hdr_merge(args->out_hdr,hdr);
         if ( bcf_hdr_nsamples(hdr) != bcf_hdr_nsamples(args->out_hdr) )
             error("Different number of samples in %s. Perhaps \"bcftools merge\" is what you are looking for?\n", args->fnames[i]);
@@ -485,6 +498,7 @@ static void concat(args_t *args)
             if ( bcf_sr_has_line(args->files,0) )
             {
                 bcf1_t *line = bcf_sr_get_line(args->files,0);
+                DROP_GENOTYPES(args, line)
                 bcf_sr_seek(args->files, bcf_seqname(args->files->readers[0].header,line), line->pos);
                 seek_pos = line->pos;
                 seek_chr = bcf_hdr_name2id(args->out_hdr, bcf_seqname(args->files->readers[0].header,line));
@@ -530,7 +544,8 @@ static void concat(args_t *args)
                 // Get a line to learn about current position
                 ir = _get_active_index(args->files);
                 bcf1_t *line = bcf_sr_get_line(args->files,ir);
-
+                DROP_GENOTYPES(args,line)
+                
                 // This can happen after bcf_sr_seek: indel may start before the coordinate which we seek to.
                 if ( seek_chr>=0 && seek_pos>line->pos && seek_chr==bcf_hdr_name2id(args->out_hdr, bcf_seqname(args->files->readers[ir].header,line)) ) continue;
                 seek_pos = seek_chr = -1;
@@ -574,6 +589,7 @@ static void concat(args_t *args)
                 }
 
                 bcf1_t *line0 = bcf_sr_get_line(args->files,0);
+                DROP_GENOTYPES(args,line0)
                 bcf1_t *line1 = args->files->nreaders > 1 ? bcf_sr_get_line(args->files,1) : NULL;
                 phased_push(args, line0, line1, is_overlap);
             }
@@ -594,6 +610,7 @@ static void concat(args_t *args)
             {
                 bcf1_t *line = bcf_sr_get_line(args->files,i);
                 if ( !line ) continue;
+                DROP_GENOTYPES(args,line)
                 bcf_translate(args->out_hdr, args->files->readers[i].header, line);
                 if ( bcf_write1(args->out_fh, args->out_hdr, line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
                 if ( args->remove_dups ) break;
@@ -616,6 +633,8 @@ static void concat(args_t *args)
             htsFile *fp = hts_open(args->fnames[i], "r"); if ( !fp ) error("\nFailed to open: %s\n", args->fnames[i]);
             if ( args->n_threads ) hts_set_opt(fp, HTS_OPT_THREAD_POOL, args->tpool);
             bcf_hdr_t *hdr = bcf_hdr_read(fp); if ( !hdr ) error("\nFailed to parse header: %s\n", args->fnames[i]);
+            DROP_HDR_GENOTYPES(args, hdr)
+            
             if ( !fp->is_bin && args->output_type&FT_VCF )
             {
                 line->max_unpack = BCF_UN_STR;
@@ -623,6 +642,25 @@ static void concat(args_t *args)
                 while ( hts_getline(fp, KS_SEP_LINE, &fp->line) >=0 )
                 {
                     char *str = fp->line.s;
+                    
+                    // remove genotypes
+                    if ( args->sites_only )
+                    {
+                        int ntab = 0;
+                        while ( *str )
+                        {
+                            if ( *str == '\t' )
+                            {
+                                if ( ++ntab == 8)
+                                    {
+                                        *str = 0;
+                                        break;
+                                    }
+                            }
+                            str++;
+                        }           
+                        str = fp->line.s;
+                    }
                     while ( *str && *str!='\t' ) str++;
                     tmp.l = 0;
                     kputsn(fp->line.s,str-fp->line.s,&tmp);
@@ -651,6 +689,7 @@ static void concat(args_t *args)
                 line->max_unpack = 0;
                 while ( bcf_read(fp, hdr, line)==0 )
                 {
+                    DROP_GENOTYPES(args,line)
                     bcf_translate(args->out_hdr, hdr, line);
 
                     if ( prev_chr_id!=line->rid )
@@ -773,6 +812,7 @@ static void naive_concat_check_headers(args_t *args)
     {
         htsFile *fp = hts_open(args->fnames[i], "r"); if ( !fp ) error("Failed to open: %s\n", args->fnames[i]);
         bcf_hdr_t *hdr = bcf_hdr_read(fp); if ( !hdr ) error("Failed to parse header: %s\n", args->fnames[i]);
+        DROP_HDR_GENOTYPES(args, hdr)
         htsFormat type = *hts_get_format(fp);
         hts_close(fp);
 
@@ -929,6 +969,7 @@ static void usage(args_t *args)
     fprintf(stderr, "   -d, --rm-dups STRING           Output duplicate records present in multiple files only once: <snps|indels|both|all|exact>\n");
     fprintf(stderr, "   -D, --remove-duplicates        Alias for -d exact\n");
     fprintf(stderr, "   -f, --file-list FILE           Read the list of files from a file.\n");
+    fprintf(stderr, "   -G, --drop-genotypes           Drop individual genotype information.\n");
     fprintf(stderr, "   -l, --ligate                   Ligate phased VCFs by matching phase at overlapping haplotypes\n");
     fprintf(stderr, "       --ligate-force             Ligate even non-overlapping chunks, keep all sites\n");
     fprintf(stderr, "       --ligate-warn              Drop sites in imperfect overlaps\n");
@@ -983,10 +1024,11 @@ int main_vcfconcat(int argc, char *argv[])
         {"min-PQ",required_argument,NULL,'q'},
         {"no-version",no_argument,NULL,8},
         {"write-index",no_argument,NULL,13},
+        {"drop-genotypes",no_argument,NULL,'G'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "h:?o:O:f:alq:Dd:r:R:cnv:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "h:?o:O:f:alq:Dd:Gr:R:cnv:",loptions,NULL)) >= 0)
     {
         switch (c) {
             case 'c': args->compact_PS = 1; break;
@@ -1002,6 +1044,7 @@ int main_vcfconcat(int argc, char *argv[])
             case 'a': args->allow_overlaps = 1; break;
             case 'l': args->phased_concat = 1; break;
             case 'f': args->file_list = optarg; break;
+            case 'G': args->sites_only = 1; break;
             case 'o': args->output_fname = optarg; break;
             case 'O':
                 args->explicit_output_type = 1;


### PR DESCRIPTION
Hi all,

This PR adds a new options `-G/--drops-genotypes` for `concat`. 


Motivation:

 I often want to 

- just create a list of sites from a set of vcf with many samples
- split a list of vcf into a list intervals (for parallelisation) 

I could pipe the output of "concat" into "bcftools view -G" but I imagine it should be faster to drop the genotypes from the very start.

I implemented the removal of the samples with two macros.

It looks like it's working. I added a few tests but I don't have a clear view about all the tests that should be performed, all the combinations I should test.

I updated the documentation.

Thanks !
