### PR TITLE
Switched back to openssl for Alpine.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -232,8 +232,10 @@ Alpine Linux
 Note: To install gsl-dev, it may be necessary to enable the "community"
 repository in /etc/apk/repositories.
 
+Note: some older Alpine versions use libressl-dev rather than openssl-dev.
+
 doas apk update  # Ensure the package list is up to date
-doas apk add autoconf automake make gcc musl-dev perl bash zlib-dev bzip2-dev xz-dev curl-dev libressl-dev gsl-dev perl-dev
+doas apk add autoconf automake make gcc musl-dev perl bash zlib-dev bzip2-dev xz-dev curl-dev openssl-dev gsl-dev perl-dev
 
 OpenSUSE
 --------


### PR DESCRIPTION
Alpine 3.17 switched to OpenSSL.

See #samtools/htslib#1591.