### PR TITLE
bcftools +fill-tag: include F_MISSING in --tag all

### DIFF
--- a/plugins/fill-tags.c
+++ b/plugins/fill-tags.c
@@ -473,7 +473,10 @@ uint32_t parse_tags(args_t *args, const char *str)
         if ( !strcasecmp(tags[i],"all") )
         {
             flag |= ~(SET_END|SET_TYPE);
-            flag |= parse_func(args,"F_MISSING=F_MISSING","F_MISSING"); // include F_MISSING as part of 'all'
+            // include F_MISSING as part of 'all', which requires explicitly
+            // initialising it as a filter expression not just setting a
+            // bitfield flag.
+            flag |= parse_func(args,"F_MISSING=F_MISSING","F_MISSING");
             args->warned = ~(SET_END|SET_TYPE);
             args->unpack |= BCF_UN_FMT;
         }

--- a/plugins/fill-tags.c
+++ b/plugins/fill-tags.c
@@ -473,6 +473,7 @@ uint32_t parse_tags(args_t *args, const char *str)
         if ( !strcasecmp(tags[i],"all") )
         {
             flag |= ~(SET_END|SET_TYPE);
+            flag |= parse_func(args,"F_MISSING=F_MISSING","F_MISSING"); // include F_MISSING as part of 'all'
             args->warned = ~(SET_END|SET_TYPE);
             args->unpack |= BCF_UN_FMT;
         }


### PR DESCRIPTION
 Hello,

A simple patch that ensures `INFO/F_MISSING` is calculated when doing `bcftools +fill-tags in.vcf.gz -- --tags all`. All other "standard" tags are, and it confused me that a tag explicitly listed in the man page was not included when using `--tags all`.

Best,
K