### PR TITLE
Stop make check from running tests twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ csq.o: csq.c $(htslib_hts_h) $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(hts
 #
 # If using MSYS, avoid poor shell expansion via:
 #    MSYS2_ARG_CONV_EXCL="*" make check
-check test-no-plugins: $(PROGRAMS) $(TEST_PROGRAMS) $(BGZIP) $(TABIX)
+check-no-plugins test-no-plugins: $(PROGRAMS) $(TEST_PROGRAMS) $(BGZIP) $(TABIX)
 	./test/test-rbuf
 	./test/test-regidx
 	REF_PATH=: ./test/test.pl --exec bgzip=$(BGZIP) --exec tabix=$(TABIX) --htsdir=$(HTSDIR) $${TEST_OPTS:-}


### PR DESCRIPTION
`check` runs `test-plugins` via a rule on [Makefile line 203](https://github.com/daviesrob/bcftools/blob/5940e5c61dac80d45bdb554af4b6b939a11a5873/Makefile#L203), so we don't want it to run `test-no-plugins` as well.