### PR TITLE
make USE_GPL=1 clean all fails because GSL_LIBS already defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ print-version:
 ifdef USE_GPL
     main.o : EXTRA_CPPFLAGS += -DUSE_GPL
     OBJS += polysomy.o peakfit.o
-    GSL_LIBS ?= -lgsl -lcblas
+    GSL_LIBS += -lgsl -lcblas
 endif
 
 print-%:

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,9 @@ print-version:
 ifdef USE_GPL
     main.o : EXTRA_CPPFLAGS += -DUSE_GPL
     OBJS += polysomy.o peakfit.o
-    GSL_LIBS += -lgsl -lcblas
+    #ifndef GSL_LIBS
+        GSL_LIBS += -lgsl -lcblas
+    #endif
 endif
 
 print-%:

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,9 @@ print-version:
 ifdef USE_GPL
     main.o : EXTRA_CPPFLAGS += -DUSE_GPL
     OBJS += polysomy.o peakfit.o
-    #ifndef GSL_LIBS
+    ifndef GSL_LIBS
         GSL_LIBS += -lgsl -lcblas
-    #endif
+    endif
 endif
 
 print-%:


### PR DESCRIPTION
Hi,

Small fix for:

`make USE_GPL=1 clean all`

`GSL_LIBS ?= -lgsl -lcblas` didn't work for me because GSL_LIBS was already defined in the Makefile beforehand.

Best, Tobias

