### PR TITLE
Portability improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,8 @@ main.o: main.c $(htslib_hts_h) config.h version.h $(bcftools_h)
 vcfannotate.o: vcfannotate.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(bcftools_h) vcmp.h $(filter_h) $(convert_h) $(smpl_ilist_h) regidx.h $(htslib_khash_h) $(dbuf_h)
 vcfplugin.o: vcfplugin.c config.h $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) $(bcftools_h) vcmp.h $(filter_h)
 vcfcall.o: vcfcall.c $(htslib_vcf_h) $(htslib_kfunc_h) $(htslib_synced_bcf_reader_h) $(htslib_khash_str2int_h) $(bcftools_h) $(call_h) $(prob1_h) $(ploidy_h) $(gvcf_h) regidx.h $(vcfbuf_h)
-vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_thread_pool_h) $(bcftools_h)
-vcfconvert.o: vcfconvert.c $(htslib_faidx_h) $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kseq_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
+vcfconcat.o: vcfconcat.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_thread_pool_h) $(htslib_hts_endian_h) $(bcftools_h)
+vcfconvert.o: vcfconvert.c $(htslib_faidx_h) $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kseq_h) $(htslib_hts_endian_h) $(bcftools_h) $(filter_h) $(convert_h) $(tsv2vcf_h)
 vcffilter.o: vcffilter.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) rbuf.h regidx.h
 vcfgtcheck.o: vcfgtcheck.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kbitset_h) $(htslib_hts_os_h) $(htslib_bgzf_h) $(bcftools_h) extsort.h filter.h
 vcfindex.o: vcfindex.c $(htslib_vcf_h) $(htslib_tbx_h) $(htslib_kstring_h) $(htslib_bgzf_h) $(bcftools_h)
@@ -261,10 +261,10 @@ vcfview.o: vcfview.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfu
 reheader.o: reheader.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_kseq_h) $(htslib_thread_pool_h) $(htslib_faidx_h) $(htslib_khash_str2int_h) $(bcftools_h) $(khash_str2str_h)
 tabix.o: tabix.c $(htslib_bgzf_h) $(htslib_tbx_h)
 ccall.o: ccall.c $(htslib_kfunc_h) $(call_h) kmin.h $(prob1_h)
-convert.o: convert.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kfunc_h) $(htslib_khash_str2int_h) $(bcftools_h) $(variantkey_h) $(convert_h) $(filter_h)
+convert.o: convert.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_kfunc_h) $(htslib_khash_str2int_h) $(htslib_hts_endian_h) $(bcftools_h) $(variantkey_h) $(convert_h) $(filter_h)
 tsv2vcf.o: tsv2vcf.c $(tsv2vcf_h)
 em.o: em.c $(htslib_vcf_h) kmin.h $(call_h)
-filter.o: filter.c $(htslib_khash_str2int_h) $(htslib_hts_defs_h) $(htslib_vcfutils_h) $(htslib_kfunc_h) config.h $(filter_h) $(bcftools_h)
+filter.o: filter.c $(htslib_khash_str2int_h) $(htslib_hts_defs_h) $(htslib_vcfutils_h) $(htslib_kfunc_h) $(htslib_hts_endian_h) config.h $(filter_h) $(bcftools_h)
 	$(CC) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CPPFLAGS) $(PERL_CFLAGS) -c -o $@ $<
 gvcf.o: gvcf.c $(gvcf_h) $(bcftools_h)
 kmin.o: kmin.c kmin.h

--- a/convert.c
+++ b/convert.c
@@ -31,6 +31,7 @@ THE SOFTWARE.  */
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <stdint.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <math.h>
@@ -39,6 +40,7 @@ THE SOFTWARE.  */
 #include <htslib/vcfutils.h>
 #include <htslib/kfunc.h>
 #include <htslib/khash_str2int.h>
+#include <htslib/hts_endian.h>
 #include "bcftools.h"
 #include "variantkey.h"
 #include "convert.h"
@@ -174,23 +176,23 @@ static void process_filter(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isa
     }
     else kputc('.', str);
 }
-static inline int32_t bcf_array_ivalue(void *bcf_array, int type, int idx)
+static inline int32_t bcf_array_ivalue(uint8_t *bcf_array, int type, int idx)
 {
     if ( type==BCF_BT_INT8 )
     {
-        int8_t val = ((int8_t*)bcf_array)[idx];
+        int8_t val = le_to_i8(&bcf_array[idx * sizeof(val)]);
         if ( val==bcf_int8_missing ) return bcf_int32_missing;
         if ( val==bcf_int8_vector_end ) return bcf_int32_vector_end;
         return val;
     }
     if ( type==BCF_BT_INT16 )
     {
-        int16_t val = ((int16_t*)bcf_array)[idx];
+        int16_t val = le_to_i16(&bcf_array[idx * sizeof(val)]);
         if ( val==bcf_int16_missing ) return bcf_int32_missing;
         if ( val==bcf_int16_vector_end ) return bcf_int32_vector_end;
         return val;
     }
-    return ((int32_t*)bcf_array)[idx];
+    return le_to_i32(&bcf_array[idx * sizeof(int32_t)]);
 }
 static inline void _copy_field(char *src, uint32_t len, int idx, kstring_t *str)
 {
@@ -288,17 +290,17 @@ static void process_info(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isamp
             kputc('.', str);
             return;
         }
-        #define BRANCH(type_t, is_missing, is_vector_end, kprint) { \
-            type_t val = ((type_t *) info->vptr)[fmt->subscript]; \
+        #define BRANCH(type_t, convert, is_missing, is_vector_end, kprint) { \
+            type_t val = convert(&info->vptr[fmt->subscript * sizeof(type_t)]); \
             if ( is_missing || is_vector_end ) kputc('.',str); \
             else kprint; \
         }
         switch (info->type)
         {
-            case BCF_BT_INT8:  BRANCH(int8_t,  val==bcf_int8_missing,  val==bcf_int8_vector_end,  kputw(val, str)); break;
-            case BCF_BT_INT16: BRANCH(int16_t, val==bcf_int16_missing, val==bcf_int16_vector_end, kputw(val, str)); break;
-            case BCF_BT_INT32: BRANCH(int32_t, val==bcf_int32_missing, val==bcf_int32_vector_end, kputw(val, str)); break;
-            case BCF_BT_FLOAT: BRANCH(float,   bcf_float_is_missing(val), bcf_float_is_vector_end(val), kputd(val, str)); break;
+            case BCF_BT_INT8:  BRANCH(int8_t,  le_to_i8,  val==bcf_int8_missing,  val==bcf_int8_vector_end,  kputw(val, str)); break;
+            case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, val==bcf_int16_missing, val==bcf_int16_vector_end, kputw(val, str)); break;
+            case BCF_BT_INT32: BRANCH(int32_t, le_to_i32, val==bcf_int32_missing, val==bcf_int32_vector_end, kputw(val, str)); break;
+            case BCF_BT_FLOAT: BRANCH(float,   le_to_float, bcf_float_is_missing(val), bcf_float_is_vector_end(val), kputd(val, str)); break;
             case BCF_BT_CHAR:  _copy_field((char*)info->vptr, info->vptr_len, fmt->subscript, str); break;
             default: fprintf(stderr,"todo: type %d\n", info->type); exit(1); break;
         }
@@ -386,11 +388,12 @@ static void process_format(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isa
         }
         if ( fmt->fmt->type == BCF_BT_FLOAT )
         {
-            float *ptr = (float*)(fmt->fmt->p + isample*fmt->fmt->size);
-            if ( bcf_float_is_missing(ptr[fmt->subscript]) || bcf_float_is_vector_end(ptr[fmt->subscript]) )
+            uint8_t *ptr = fmt->fmt->p + isample*fmt->fmt->size;
+            float val = le_to_float(&ptr[fmt->subscript * sizeof(float)]);
+            if ( bcf_float_is_missing(val) || bcf_float_is_vector_end(val) )
                 kputc('.', str);
             else
-                kputd(ptr[fmt->subscript], str);
+                kputd(val, str);
         }
         else if ( fmt->fmt->type != BCF_BT_CHAR )
         {
@@ -503,14 +506,14 @@ static void process_tbcsq(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isam
 
     int mask = fmt->subscript==0 ? 3 : 1;   // merge both haplotypes if subscript==0
 
-    #define BRANCH(type_t, nbits) { \
-        type_t *x = (type_t*)(fmt->fmt->p + isample*fmt->fmt->size); \
+    #define BRANCH(type_t, convert, nbits) { \
+        uint8_t *x = fmt->fmt->p + isample*fmt->fmt->size; \
         int i,j; \
         if ( fmt->subscript<=0 || fmt->subscript==1 ) \
         { \
             for (j=0; j < fmt->fmt->n; j++) \
             { \
-                type_t val = x[j]; \
+                type_t val = convert(&x[j * sizeof(type_t)]); \
                 if ( !val ) continue; \
                 for (i=0; i<nbits; i+=2) \
                     if ( val & (mask<<i) ) { kputs(csq->str[(j*30+i)/2], &csq->hap1); kputc_(',', &csq->hap1); } \
@@ -520,7 +523,7 @@ static void process_tbcsq(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isam
         { \
             for (j=0; j < fmt->fmt->n; j++) \
             { \
-                type_t val = x[j]; \
+                type_t val = convert(&x[j * sizeof(type_t)]); \
                 if ( !val ) continue; \
                 for (i=1; i<nbits; i+=2) \
                     if ( val & (1<<i) ) { kputs(csq->str[(j*30+i)/2], &csq->hap2); kputc_(',', &csq->hap2); } \
@@ -529,9 +532,9 @@ static void process_tbcsq(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isam
     }
     switch (fmt->fmt->type)
     {
-        case BCF_BT_INT8:  BRANCH(uint8_t, 8); break;
-        case BCF_BT_INT16: BRANCH(uint16_t,16); break;
-        case BCF_BT_INT32: BRANCH(uint32_t,30); break;  // 2 bytes unused to account for the reserved BCF values
+        case BCF_BT_INT8:  BRANCH(uint8_t,  le_to_u8,   8); break;
+        case BCF_BT_INT16: BRANCH(uint16_t, le_to_u16, 16); break;
+        case BCF_BT_INT32: BRANCH(uint32_t, le_to_u32, 30); break;  // 2 bits unused to account for the reserved BCF values
         default: error("Unexpected type: %d\n", fmt->fmt->type); exit(1); break;
     }
     #undef BRANCH
@@ -1187,16 +1190,16 @@ static void process_pbinom(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isa
         int al = bcf_gt_allele(gt[i]);
         if ( al > line->n_allele || al >= fmt->fmt->n ) goto invalid;
 
-        #define BRANCH(type_t, missing, vector_end) { \
-            type_t val = ((type_t *) fmt->fmt->p)[al + isample*fmt->fmt->n]; \
+        #define BRANCH(type_t, convert, missing, vector_end) { \
+            type_t val = convert(&fmt->fmt->p[(al + isample*fmt->fmt->n)*sizeof(type_t)]); \
             if ( val==missing || val==vector_end ) goto invalid; \
             else n[i] = val; \
         }
         switch (fmt->fmt->type)
         {
-            case BCF_BT_INT8:  BRANCH(int8_t,  bcf_int8_missing,  bcf_int8_vector_end); break;
-            case BCF_BT_INT16: BRANCH(int16_t, bcf_int16_missing, bcf_int16_vector_end); break;
-            case BCF_BT_INT32: BRANCH(int32_t, bcf_int32_missing, bcf_int32_vector_end); break;
+            case BCF_BT_INT8:  BRANCH(int8_t,  le_to_i8,  bcf_int8_missing,  bcf_int8_vector_end); break;
+            case BCF_BT_INT16: BRANCH(int16_t, le_to_i16, bcf_int16_missing, bcf_int16_vector_end); break;
+            case BCF_BT_INT32: BRANCH(int32_t, le_to_i32, bcf_int32_missing, bcf_int32_vector_end); break;
             default: goto invalid; break;
         }
         #undef BRANCH

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -31,6 +31,7 @@ THE SOFTWARE.  */
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <stdint.h>
 #include <inttypes.h>
 #include <htslib/faidx.h>
 #include <htslib/vcf.h>
@@ -38,6 +39,7 @@ THE SOFTWARE.  */
 #include <htslib/synced_bcf_reader.h>
 #include <htslib/vcfutils.h>
 #include <htslib/kseq.h>
+#include <htslib/hts_endian.h>
 #include "bcftools.h"
 #include "filter.h"
 #include "convert.h"
@@ -209,7 +211,10 @@ static int _set_chrom_pos_ref_alt(tsv_t *tsv, bcf1_t *rec, void *usr)
     {
         long end = strtol(se+1,&ss,10);
         if ( ss==se+1 ) return -1;
-        bcf_update_info_int32(args->header, rec, "END", &end, 1);
+        if (end < 1 || end > INT32_MAX)
+            return -1;
+        int32_t e = end; // bcf_update_info_int32 needs an int32_t pointer
+        bcf_update_info_int32(args->header, rec, "END", &e, 1);
     }
 
     rec->rid = rid;


### PR DESCRIPTION
Use htslib/hts_endian.h functions to avoid problems with unaligned access, and to ensure numbers are byte swapped on platforms that need it.

Ensure the right pointer type is passed to bcf_update_info_int32() in vcfconvert.c's _set_chrom_pos_ref_alt() function.

This should fix any latent problems on 32-bit arm hard-float that were in areas not covered by pull request #2042

After applying this patch, all tests pass on big-endian platforms.