### PR TITLE
Check fclose(stdout) at the end of main() [and miscellanea]

### DIFF
--- a/csq.c
+++ b/csq.c
@@ -149,6 +149,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <strings.h>
 #include "bcftools.h"
 #include "filter.h"
 #include "regidx.h"

--- a/gff.c
+++ b/gff.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <string.h>
+#include <strings.h>
 #include <htslib/hts.h>
 #include <htslib/khash.h>
 #include <htslib/khash_str2int.h>

--- a/plugins/tag2tag.c
+++ b/plugins/tag2tag.c
@@ -24,6 +24,7 @@ DEALINGS IN THE SOFTWARE.  */
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <getopt.h>
 #include <math.h>
 #include <inttypes.h>


### PR DESCRIPTION
Similar to samtools/samtools#1909, this is a companion pull request to samtools/htslib#1665. Now that `hts_open("-", "w")` / `hts_close()` no longer actually closes stdout. Close it explicitly at the end of `main()` when a subcommand may have written to stdout, so there is an opportunity to detect I/O errors in previously-uncommitted writes.

Ignore EBADF as other code may have already closed stdout, e.g., either particular subcommands or when (dynamically) linked against an older version of HTSlib.

Also trivially: include `<strings.h>` where needed to ensure `strcasecmp()` et al are declared. (`<strings.h>` is often a byproduct of `<string.h>` but POSIX doesn't require that.) 