### PR TITLE
bcftools sort has duplicate -O in the usage

### DIFF
--- a/vcfsort.c
+++ b/vcfsort.c
@@ -337,7 +337,6 @@ static void usage(args_t *args)
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "    -m, --max-mem FLOAT[kMG]       maximum memory to use [768M]\n");    // using metric units, 1M=1e6
     fprintf(stderr, "    -o, --output FILE              output file name [stdout]\n");
-    fprintf(stderr, "    -O, --output-type b|u|z|v      b: compressed BCF, u: uncompressed BCF, z: compressed VCF, v: uncompressed VCF [v]\n");
     fprintf(stderr, "    -O, --output-type u|b|v|z[0-9] u/b: un/compressed BCF, v/z: un/compressed VCF, 0-9: compression level [v]\n");
 
 #ifdef _WIN32


### PR DESCRIPTION
github blame shows this as the first commit: https://github.com/samtools/bcftools/commit/530623aa003dabc9d6bcef3f40699e1c1b3a95f0