### PR TITLE
Improve docs on --soft-filter argument.

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -1598,7 +1598,7 @@ And similarly here, the second is filtered:
 
 *-s, --soft-filter* 'STRING'|'+'::
     annotate FILTER column with 'STRING' or, with '+', a unique filter name generated
-    by the program ("Filter%d").
+    by the program ("Filter%d"). Applies to records that do not meet filter expression.
 
 *-S, --set-GTs* '.'|'0'::
     set genotypes of failed samples to missing value ('.') or reference allele ('0')


### PR DESCRIPTION
I experienced some confusion trying to figure out why my filter tags were inversely being applied when using `--soft-filter`. I was under the initial impression that it applied `STRING` to records that meet the filter expression, just like how it applies `STRING` to any records that are in `--mask-file`.

In hindsight it makes sense that it is applied to things that fail to meet the expression, but I thought the documentation on --soft-filter could be improved to consider this discrepancy in behaviour between `--mask-file` and `--include/--exclude`. Especially considering it may not be immediately obvious as no errors are thrown.