### PR TITLE
Allow bcftools reheader --fai to read its input file from a stream

### DIFF
--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -3142,7 +3142,7 @@ Modify header of VCF/BCF files, change sample names.
     "Not\ a\ good\ sample\ name".
 
 *-T, --temp-prefix* 'PATH'::
-    template for temporary file names, used with *-f*
+    this option is ignored, but left for compatibility with earlier versions of bcftools.
 
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*

--- a/reheader.c
+++ b/reheader.c
@@ -1,6 +1,6 @@
 /*  reheader.c -- reheader subcommand.
 
-    Copyright (C) 2014-2022 Genome Research Ltd.
+    Copyright (C) 2014-2022,2024 Genome Research Ltd.
 
     Author: Petr Danecek <pd3@sanger.ac.uk>
 
@@ -49,8 +49,9 @@ THE SOFTWARE.  */
 typedef struct _args_t
 {
     char **argv, *fname, *samples_fname, *header_fname, *output_fname;
-    char *fai_fname, *rm_tmpfile, *tmp_prefix;
+    char *fai_fname;
     htsFile *fp;
+    faidx_t *fai;
     htsFormat type;
     htsThreadPool *threads;
     int argc, n_threads;
@@ -168,33 +169,13 @@ char *init_tmp_prefix(const char *tmp_prefix)
     kputs("/bcftools.XXXXXX", &prefix);
     return prefix.s;
 }
-static void update_from_fai(args_t *args)
+static void update_from_fai(faidx_t *fai, kstring_t *hdr_txt)
 {
-    if ( !strcmp("-",args->fname) )
-        error("Cannot use the --fai option when reading from standard input.\n");
-
-    faidx_t *fai = fai_load3(args->fai_fname,args->fai_fname,NULL,FAI_FASTA);
-    if ( !fai ) error("Could not parse %s\n", args->fai_fname);
-    args->rm_tmpfile = init_tmp_prefix(args->tmp_prefix);
-    int fd = mkstemp(args->rm_tmpfile);
-    if ( fd<0 ) error("Could not open a temporary file for writing: %s\n", args->rm_tmpfile);
-
-    // get a template header: either from the original VCF or from --header
-    char *ori_hdr_fname = args->header_fname ? args->header_fname : args->fname;
-    htsFile *fp = hts_open(ori_hdr_fname,"r");
-    if ( !fp ) error("Failed to open: %s\n", ori_hdr_fname);
-    bcf_hdr_t *hdr = bcf_hdr_read(fp);
-    if ( !hdr ) error("Failed to read the header: %s\n", ori_hdr_fname);
-    hts_close(fp);  // no need to check the return status here
-
-    // put the header in a text buffer
-    kstring_t hdr_txt_ori = {0,0,0}, hdr_txt_new = {0,0,0};
-    bcf_hdr_format(hdr, 0, &hdr_txt_ori);
-    bcf_hdr_destroy(hdr);
+    kstring_t hdr_txt_new = {0,0,0};
 
     // update the existing contig lines and remove lines not present in the fai file
     void *chr_seen = khash_str2int_init();
-    char *tmp, *beg = hdr_txt_ori.s;
+    char *tmp, *beg = hdr_txt->s;
     while ( beg && *beg )
     {
         tmp = strstr(beg, "\n##contig=<");
@@ -216,13 +197,10 @@ static void update_from_fai(args_t *args)
     }
     kputs(tmp+1,&hdr_txt_new);
 
-    if ( write(fd, hdr_txt_new.s, hdr_txt_new.l)!=hdr_txt_new.l ) error("Failed to write %zu bytes to %s\n", hdr_txt_new.l,args->rm_tmpfile);
-    if ( close(fd)!=0 ) error("Failed to close %s\n", args->rm_tmpfile);
-    args->header_fname = args->rm_tmpfile;
+    // Switch the new header content for the old
+    free(hdr_txt->s);
+    memcpy(hdr_txt, &hdr_txt_new, sizeof(*hdr_txt));
 
-    free(hdr_txt_ori.s);
-    free(hdr_txt_new.s);
-    fai_destroy(fai);
     khash_str2int_destroy_free(chr_seen);
 }
 
@@ -420,6 +398,10 @@ static void reheader_vcf_gz(args_t *args)
         free(hdr.s); hdr.s = NULL; hdr.l = hdr.m = 0;
         read_header_file(args->header_fname, &hdr);
     }
+
+    if ( args->fai )
+        update_from_fai(args->fai, &hdr);
+
     if ( samples )
     {
         set_samples(samples, nsamples, &hdr);
@@ -479,6 +461,10 @@ static void reheader_vcf(args_t *args)
         free(hdr.s); hdr.s = NULL; hdr.l = hdr.m = 0;
         read_header_file(args->header_fname, &hdr);
     }
+
+    if ( args->fai )
+        update_from_fai(args->fai, &hdr);
+
     if ( samples )
     {
         set_samples(samples, nsamples, &hdr);
@@ -586,6 +572,10 @@ static void reheader_bcf(args_t *args, int is_compressed)
         free(htxt.s); htxt.s = NULL; htxt.l = htxt.m = 0;
         read_header_file(args->header_fname, &htxt);
     }
+
+    if ( args->fai )
+        update_from_fai(args->fai, &htxt);
+
     if ( samples )
     {
         set_samples(samples, nsamples, &htxt);
@@ -675,11 +665,7 @@ static void usage(args_t *args)
     fprintf(stderr, "    -h, --header FILE          new header\n");
     fprintf(stderr, "    -o, --output FILE          write output to a file [standard output]\n");
     fprintf(stderr, "    -s, --samples FILE         new sample names\n");
-#ifdef _WIN32
-    fprintf(stderr, "    -T, --temp-prefix PATH     template for temporary file name [/bcftools.XXXXXX]\n");
-#else
-    fprintf(stderr, "    -T, --temp-prefix PATH     template for temporary file name [/tmp/bcftools.XXXXXX]\n");
-#endif
+    fprintf(stderr, "    -T, --temp-prefix PATH     ignored; was template for temporary file name\n");
     fprintf(stderr, "        --threads INT          use multithreading with <int> worker threads (BCF only) [0]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Example:\n");
@@ -716,7 +702,7 @@ int main_reheader(int argc, char *argv[])
         switch (c)
         {
             case  1 : args->n_threads = strtol(optarg, 0, 0); break;
-            case 'T': args->tmp_prefix = optarg; break;
+            case 'T': break; // unused - was temp file prefix
             case 'f': args->fai_fname = optarg; break;
             case 'o': args->output_fname = optarg; break;
             case 's': args->samples_fname = optarg; break;
@@ -733,8 +719,11 @@ int main_reheader(int argc, char *argv[])
     }
     else args->fname = argv[optind];
 
-    if ( args->fai_fname ) update_from_fai(args);
-    if ( !args->samples_fname && !args->header_fname ) usage(args);
+    if ( args->fai_fname ) {
+        args->fai = fai_load3(args->fai_fname,args->fai_fname,NULL,FAI_FASTA);
+        if ( !args->fai ) error("Could not parse %s\n", args->fai_fname);
+    }
+    if ( !args->samples_fname && !args->header_fname && !args->fai) usage(args);
     if ( !args->fname ) usage(args);
 
     args->fp = hts_open(args->fname,"r");
@@ -755,11 +744,8 @@ int main_reheader(int argc, char *argv[])
     else
         reheader_bcf(args, args->type.compression==bgzf || args->type.compression==gzip);
 
-    if ( args->rm_tmpfile )
-    {
-        unlink(args->rm_tmpfile);
-        free(args->rm_tmpfile);
-    }
+    if (args->fai)
+        fai_destroy(args->fai);
     free(args);
     return 0;
 }


### PR DESCRIPTION
This didn't work in the past because update_from_fai() opened, read the header from, and then closed the input file, preventing the reheader_* functions from accessing the rest of the file contents when the input is a stream.  As all the reheader_* functions read the header into a kstring, it's possible to make streaming work by passing this kstring into update_from_fai() and adjusting it to work directly on that copy of the data.

As update_from_fai() no longer needs to write a temporary file, args_t::rm_tmpfile and args_t::tmp_prefix can be removed.  The -T option is ignored as it's no longer needed, but is still accepted for compatibility.  The init_tmp_prefix() function is still used by some other bcftools subcommands, so is left in place for now.

Fixes #2088