### PR TITLE
Fix REF indel calls for multi-sample calling.

### DIFF
--- a/bam2bcf_edlib.c
+++ b/bam2bcf_edlib.c
@@ -567,6 +567,7 @@ static char **bcf_cgp_consensus(int n, int *n_plp, bam_pileup1_t **plp,
         }
         max_len += ins;
     }
+    max_len += MAX(0, type); // incase type inserted bases never occur
     cons = malloc((max_len+1)*2 + sizeof(char *)*2);
     if (!cons)
         goto err;
@@ -676,6 +677,16 @@ static char **bcf_cgp_consensus(int n, int *n_plp, bam_pileup1_t **plp,
             int max_v_ins = 0, max_j_ins = 0;
             int tot_ins = 0;
             for (j = 0; j < NI; j++) {
+                if (i+left==pos+1)
+                if (type > 0 && i+left == pos+1
+                    && cons_ins[i].len[j] < type && j == 0) {
+                    cons_ins[i].str[j] = realloc(cons_ins[i].str[j], type);
+                    if (!cons_ins[i].str[j])
+                        goto err;
+                    memset(cons_ins[i].str[j] + cons_ins[i].len[j],
+                           'N', type - cons_ins[i].len[j]);
+                    cons_ins[i].len[j] = type;
+                }
                 if (!cons_ins[i].str[j])
                     break;
                 if (cons_ins[i].freq[j] == 0)


### PR DESCRIPTION
This applies where there are zero observed indels in a sample (but they are in other samples).  It's odd how this appears to be a pretty rare change, as we'd expect a significant change to FP, but it's tiny.  Genotype assignment error changes a lot, but only in one of the 3 samples I tested.

On HG002, I see the following differences to calling rates.

```
Previous     All     QUAL>=100
InDel TP   11823 /   11798
InDel FP    5374 /    4898
InDel GT     296 /     291
InDel FN     115 /     140

New          All     QUAL>=100
InDel TP   11822 /   11795
InDel FP    5313 /    4805
InDel GT      80 /      74
InDel FN     116 /     143
```

This was HG002 called in conjunction with HG003 and HG004, but not as a trio (so no pedegree supplied).  Oddly despite that HG002 is much more accurate than HG003 and HG004, with GT assignment error rates an order of magnitude higher.  This PR makes them a bit higher still (maybe another 20%).  I cannot explain either of these, but perhaps it's simply down to the accuracy of the truth set as HG002 is by far the most widely curated of the three.  Either that or my analysis has a flaw somewhere.

Fixes #2130.