### PR TITLE
Make --write-index=tbi work.

### DIFF
--- a/bcftools.h
+++ b/bcftools.h
@@ -50,7 +50,15 @@ void error(const char *format, ...) HTS_NORETURN HTS_FORMAT(HTS_PRINTF_FMT, 1, 2
 void error_errno(const char *format, ...) HTS_NORETURN HTS_FORMAT(HTS_PRINTF_FMT, 1, 2);
 
 // For on the fly index creation with --write-index
-int init_index(htsFile *fh, bcf_hdr_t *hdr, const char *fname, char **idx_fname);
+int init_index2(htsFile *fh, bcf_hdr_t *hdr, const char *fname,
+                char **idx_fname, int idx_fmt);
+int init_index(htsFile *fh, bcf_hdr_t *hdr, const char *fname,
+               char **idx_fname);
+
+// Used to set args->write_index in CLI.
+// It will be true if set correctly.
+// Note due to HTS_FMT_CSI being zero we have to use an additional bit.
+int write_index_parse(char *arg);
 
 void bcf_hdr_append_version(bcf_hdr_t *hdr, int argc, char **argv, const char *cmd);
 const char *hts_bcf_wmode(int file_type);

--- a/csq.c
+++ b/csq.c
@@ -3495,7 +3495,7 @@ int main_csq(int argc, char *argv[])
     }
     else fname = argv[optind];
     if ( argc - optind>1 ) error("%s", usage());
-    if ( !args->fa_fname ) error("Missing the --fa-ref option\n");
+    if ( !args->fa_fname ) error("Missing the --fasta-ref option\n");
     if ( !args->gff_fname ) error("Missing the --gff option\n");
     args->sr = bcf_sr_init();
     if ( targets_list )

--- a/csq.c
+++ b/csq.c
@@ -3330,7 +3330,7 @@ static const char *usage(void)
         "       --targets-overlap 0|1|2       Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
         "       --threads INT                 Use multithreading with <int> worker threads [0]\n"
         "   -v, --verbose INT                 Verbosity level 0-2 [1]\n"
-        "       --write-index[=FMT]           Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]           Automatically index the output files [off]\n"
         "\n"
         "Example:\n"
         "   bcftools csq -f hs37d5.fa -g Homo_sapiens.GRCh37.82.gff3.gz in.vcf\n"
@@ -3381,7 +3381,7 @@ int main_csq(int argc, char *argv[])
         {"targets-file",1,0,'T'},
         {"targets-overlap",required_argument,NULL,5},
         {"no-version",no_argument,NULL,3},
-        {"write-index",optional_argument,NULL,6},
+        {"write-index",optional_argument,NULL,'W'},
         {"dump-gff",required_argument,NULL,7},
         {"unify-chr-names",required_argument,NULL,8},
         {0,0,0,0}
@@ -3390,7 +3390,7 @@ int main_csq(int argc, char *argv[])
     int regions_overlap = 1;
     int targets_overlap = 0;
     char *targets_list = NULL, *regions_list = NULL, *tmp;
-    while ((c = getopt_long(argc, argv, "?hr:R:t:T:i:e:f:o:O:g:s:S:p:qc:ln:bB:v:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "?hr:R:t:T:i:e:f:o:O:g:s:S:p:qc:ln:bB:v:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -3472,7 +3472,7 @@ int main_csq(int argc, char *argv[])
                 targets_overlap = parse_overlap_option(optarg);
                 if ( targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
-            case  6 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -303,8 +303,11 @@ Such a file can be easily created from a VCF using:
     Use multithreading with 'INT' worker threads. The option is currently used only for the compression of the
     output stream, only when '--output-type' is 'b' or 'z'. Default: 0.
 
-*--write-index*::
-    Automatically index the output files. Can be used only for compressed BCF and VCF output.
+*--write-index[=FMT]*::
+    Automatically index the output files. FMT is optional and can be
+    one of tbi or csi depending on output file format. Defaults to
+    CSI unless specified otherwise. Can be used only for compressed
+    BCF and VCF output.
 
 
 [[annotate]]
@@ -509,8 +512,9 @@ Add or remove annotations.
     "^INFO/FOO,INFO/BAR" (and similarly for FORMAT and FILTER).
     "INFO" can be abbreviated to "INF" and "FORMAT" to "FMT".
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 *Examples:*
 ----
@@ -615,8 +619,9 @@ demand. The original calling model can be invoked with the *-c* option.
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 ==== Input/output options:
 
@@ -895,8 +900,9 @@ are concatenated without being recompressed, which is very fast..
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 
 [[consensus]]
@@ -1051,8 +1057,9 @@ Note that the *-H, --haplotype* option requires the *-s, --samples* option, unle
 *--targets-overlap* '0'|'1'|'2'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 ==== VCF output options:
 
@@ -1452,8 +1459,9 @@ output VCF and are ignored for the prediction analysis.
     and VCF, such as "chrX" vs "X". The chromosome names in the output VCF will match
     that of the input VCF. The default is to attempt the automatic translation.
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 *Examples:*
 ----
@@ -1622,8 +1630,9 @@ And similarly here, the second is filtered:
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 
 
@@ -1921,8 +1930,10 @@ in the other files.
     comma-separated list of input files to output given as 1-based indices. With *-p* and no
     *-w*, all files are written.
 
-*--write-index*::
-    Automatically index the output file. This is done automatically with the *-p* option.
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and defaults
+    to tbi for vcf.gz and csi for bcf.  This is done automatically
+    with the *-p* option if the output format is compressed.
 
 ==== Examples:
 
@@ -2079,8 +2090,9 @@ For "vertical" merge take a look at *<<concat,bcftools concat>>* or *<<norm,bcft
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 [[mpileup]]
 === bcftools mpileup ['OPTIONS'] *-f* 'ref.fa' 'in.bam' ['in2.bam' [...]]
@@ -2343,8 +2355,9 @@ INFO/DPR    .. Deprecated in favor of INFO/AD; Number of high-quality bases for 
     used by the earlier Bcftools releases.  For excample BQBZ becomes
     BQB.
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 ==== Options for SNP/INDEL genotype likelihood computation
 
@@ -2632,8 +2645,9 @@ the *<<fasta_ref,--fasta-ref>>* option is supplied.
     maximum distance between two records to consider when locally
     sorting variants which changed position during the realignment
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 [[plugin]]
 
@@ -2691,8 +2705,9 @@ the usage examples that each plugin comes with.
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 ==== Plugin options:
 
@@ -3327,8 +3342,9 @@ Transition probabilities:
     Use this directory to store temporary files. If the last six characters of the string DIR are XXXXXX,
     then these are replaced with a string that makes the directory name unique.
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 
 
@@ -3477,8 +3493,9 @@ Convert between VCF and BCF. Former *bcftools subset*.
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index*::
-    Automatically index the output file
+*--write-index[=FMT]*::
+    Automatically index the output file.  FMT is optional and can be
+    one of tbi or csi depending on output file format.
 
 
 ==== Subset options:

--- a/doc/bcftools.txt
+++ b/doc/bcftools.txt
@@ -303,9 +303,9 @@ Such a file can be easily created from a VCF using:
     Use multithreading with 'INT' worker threads. The option is currently used only for the compression of the
     output stream, only when '--output-type' is 'b' or 'z'. Default: 0.
 
-*--write-index[=FMT]*::
-    Automatically index the output files. FMT is optional and can be
-    one of tbi or csi depending on output file format. Defaults to
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output files. 'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format. Defaults to
     CSI unless specified otherwise. Can be used only for compressed
     BCF and VCF output.
 
@@ -512,9 +512,9 @@ Add or remove annotations.
     "^INFO/FOO,INFO/BAR" (and similarly for FORMAT and FILTER).
     "INFO" can be abbreviated to "INF" and "FORMAT" to "FMT".
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 *Examples:*
 ----
@@ -619,9 +619,9 @@ demand. The original calling model can be invoked with the *-c* option.
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 ==== Input/output options:
 
@@ -900,9 +900,9 @@ are concatenated without being recompressed, which is very fast..
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 
 [[consensus]]
@@ -1057,9 +1057,9 @@ Note that the *-H, --haplotype* option requires the *-s, --samples* option, unle
 *--targets-overlap* '0'|'1'|'2'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 ==== VCF output options:
 
@@ -1459,9 +1459,9 @@ output VCF and are ignored for the prediction analysis.
     and VCF, such as "chrX" vs "X". The chromosome names in the output VCF will match
     that of the input VCF. The default is to attempt the automatic translation.
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 *Examples:*
 ----
@@ -1630,9 +1630,9 @@ And similarly here, the second is filtered:
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 
 
@@ -1930,8 +1930,8 @@ in the other files.
     comma-separated list of input files to output given as 1-based indices. With *-p* and no
     *-w*, all files are written.
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and defaults
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and defaults
     to tbi for vcf.gz and csi for bcf.  This is done automatically
     with the *-p* option if the output format is compressed.
 
@@ -2041,7 +2041,7 @@ For "vertical" merge take a look at *<<concat,bcftools concat>>* or *<<norm,bcft
 
 *-m, --merge* 'snps'|'indels'|'both'|'snp-ins-del'|'all'|'none'|'id'[,'*']::
     The option controls what types of multiallelic records can be created. If single asterisk
-    '*' is appended, the unobserved allele '<*>' or '<NON_REF>' will be removed at variant sites;
+    '\*' is appended, the unobserved allele '<*>' or '<NON_REF>' will be removed at variant sites;
     if two asterisks '**' are appended, the unobserved allele will be removed all sites.
 ----
 -m none        ..  no new multiallelics, output multiple records instead
@@ -2090,9 +2090,9 @@ For "vertical" merge take a look at *<<concat,bcftools concat>>* or *<<norm,bcft
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 [[mpileup]]
 === bcftools mpileup ['OPTIONS'] *-f* 'ref.fa' 'in.bam' ['in2.bam' [...]]
@@ -2355,9 +2355,9 @@ INFO/DPR    .. Deprecated in favor of INFO/AD; Number of high-quality bases for 
     used by the earlier Bcftools releases.  For excample BQBZ becomes
     BQB.
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 ==== Options for SNP/INDEL genotype likelihood computation
 
@@ -2645,9 +2645,9 @@ the *<<fasta_ref,--fasta-ref>>* option is supplied.
     maximum distance between two records to consider when locally
     sorting variants which changed position during the realignment
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 [[plugin]]
 
@@ -2705,9 +2705,9 @@ the usage examples that each plugin comes with.
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 ==== Plugin options:
 
@@ -3342,9 +3342,9 @@ Transition probabilities:
     Use this directory to store temporary files. If the last six characters of the string DIR are XXXXXX,
     then these are replaced with a string that makes the directory name unique.
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 
 
@@ -3493,9 +3493,9 @@ Convert between VCF and BCF. Former *bcftools subset*.
 *--threads* 'INT'::
     see *<<common_options,Common Options>>*
 
-*--write-index[=FMT]*::
-    Automatically index the output file.  FMT is optional and can be
-    one of tbi or csi depending on output file format.
+*-W*['FMT']*, -W*[='FMT']*, --write-index*[='FMT']::
+    Automatically index the output file.  'FMT' is optional and can be
+    one of "tbi" or "csi" depending on output file format.
 
 
 ==== Subset options:

--- a/filter.c
+++ b/filter.c
@@ -3655,7 +3655,8 @@ static filter_t *filter_init_(bcf_hdr_t *hdr, const char *str, int exit_on_error
         if ( !out[i].tag ) continue;
         if ( out[i].setter==filters_set_type )
         {
-            if ( i+1==nout ) error("Could not parse the expression: %s\n", filter->str);
+            if ( i+1==nout || !out[i+1].key )
+                error("Could not parse the expression: %s\n", filter->str);
             int itok, ival;
             if ( out[i+1].tok_type==TOK_EQ || out[i+1].tok_type==TOK_NE ) ival = i - 1, itok = i + 1;
             else if ( out[i+1].tok_type==TOK_LIKE || out[i+1].tok_type==TOK_NLIKE ) ival = i - 1, itok = i + 1;

--- a/mpileup.c
+++ b/mpileup.c
@@ -1258,7 +1258,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
         "  -O, --output-type TYPE  'b' compressed BCF; 'u' uncompressed BCF;\n"
         "                          'z' compressed VCF; 'v' uncompressed VCF; 0-9 compression level [v]\n"
         "      --threads INT       Use multithreading with INT worker threads [0]\n"
-        "      --write-index[=FMT] Automatically index the output files [off]\n"
+        "  -W, --write-index[=FMT] Automatically index the output files [off]\n"
         "\n"
         "SNP/INDEL genotype likelihoods options:\n"
         "  -X, --config STR        Specify platform profile (use \"-X list\" for details)\n"
@@ -1447,7 +1447,7 @@ int main_mpileup(int argc, char *argv[])
         {"seed", required_argument, NULL, 13},
         {"ambig-reads", required_argument, NULL, 14},
         {"ar", required_argument, NULL, 14},
-        {"write-index",optional_argument,NULL,21},
+        {"write-index",optional_argument,NULL,'W'},
         {"del-bias", required_argument, NULL, 23},
         {"poly-mqual", no_argument, NULL, 24},
         {"no-poly-mqual", no_argument, NULL, 26},
@@ -1455,7 +1455,7 @@ int main_mpileup(int argc, char *argv[])
         {"seqq-offset", required_argument, NULL, 28},
         {NULL, 0, NULL, 0}
     };
-    while ((c = getopt_long(argc, argv, "Ag:f:r:R:q:Q:C:BDd:L:b:P:po:e:h:Im:F:EG:6O:xa:s:S:t:T:M:X:U",lopts,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "Ag:f:r:R:q:Q:C:BDd:L:b:P:po:e:h:Im:F:EG:6O:xa:s:S:t:T:M:X:UW::",lopts,NULL)) >= 0) {
         switch (c) {
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;
         case  16 :
@@ -1596,7 +1596,7 @@ int main_mpileup(int argc, char *argv[])
             }
             break;
         case  20: mplp.indels_v20 = 1; mplp.edlib = 0; break;
-        case  21:
+        case 'W':
             if (!(mplp.write_index = write_index_parse(optarg)))
                 error("Unsupported index format '%s'\n", optarg);
             break;

--- a/mpileup.c
+++ b/mpileup.c
@@ -863,7 +863,9 @@ static int mpileup(mplp_conf_t *conf)
     for (i=0; i<nsmpl; i++)
         bcf_hdr_add_sample(conf->bcf_hdr, smpl[i]);
     if ( bcf_hdr_write(conf->bcf_fp, conf->bcf_hdr)!=0 ) error("[%s] Error: failed to write the header to %s\n",__func__,conf->output_fname?conf->output_fname:"standard output");
-    if ( conf->write_index && init_index(conf->bcf_fp,conf->bcf_hdr,conf->output_fname,&conf->index_fn)<0 ) error("Error: failed to initialise index for %s\n",conf->output_fname);
+    if ( init_index2(conf->bcf_fp,conf->bcf_hdr,conf->output_fname,
+                     &conf->index_fn, conf->write_index) < 0 )
+        error("Error: failed to initialise index for %s\n",conf->output_fname);
 
     conf->bca = bcf_call_init(-1., conf->min_baseQ, conf->max_baseQ,
                               conf->delta_baseQ);
@@ -1256,7 +1258,7 @@ static void print_usage(FILE *fp, const mplp_conf_t *mplp)
         "  -O, --output-type TYPE  'b' compressed BCF; 'u' uncompressed BCF;\n"
         "                          'z' compressed VCF; 'v' uncompressed VCF; 0-9 compression level [v]\n"
         "      --threads INT       Use multithreading with INT worker threads [0]\n"
-        "      --write-index       Automatically index the output files [off]\n"
+        "      --write-index[=FMT] Automatically index the output files [off]\n"
         "\n"
         "SNP/INDEL genotype likelihoods options:\n"
         "  -X, --config STR        Specify platform profile (use \"-X list\" for details)\n"
@@ -1445,7 +1447,7 @@ int main_mpileup(int argc, char *argv[])
         {"seed", required_argument, NULL, 13},
         {"ambig-reads", required_argument, NULL, 14},
         {"ar", required_argument, NULL, 14},
-        {"write-index",no_argument,NULL,21},
+        {"write-index",optional_argument,NULL,21},
         {"del-bias", required_argument, NULL, 23},
         {"poly-mqual", no_argument, NULL, 24},
         {"no-poly-mqual", no_argument, NULL, 26},
@@ -1594,7 +1596,10 @@ int main_mpileup(int argc, char *argv[])
             }
             break;
         case  20: mplp.indels_v20 = 1; mplp.edlib = 0; break;
-        case  21: mplp.write_index = 1; break;
+        case  21:
+            if (!(mplp.write_index = write_index_parse(optarg)))
+                error("Unsupported index format '%s'\n", optarg);
+            break;
         case  22: mplp.edlib = 1; mplp.indels_v20 = 0; break;
         case  25: mplp.edlib = 0; break;
         case  28:

--- a/plugins/contrast.c
+++ b/plugins/contrast.c
@@ -110,7 +110,7 @@ static const char *usage_text(void)
         "   -t, --targets REG                Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE          Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2      Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
-        "       --write-index[=FMT]          Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]          Automatically index the output files [off]\n"
         "\n"
         "Example:\n"
         "   # Test if any of the samples a,b is different from the samples c,d,e\n"
@@ -487,12 +487,12 @@ int run(int argc, char **argv)
         {"targets",1,0,'t'},
         {"targets-file",1,0,'T'},
         {"targets-overlap",required_argument,NULL,4},
-        {"write-index",optional_argument,NULL,5},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "O:o:i:e:r:R:t:T:0:1:a:f:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "O:o:i:e:r:R:t:T:0:1:a:f:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -538,7 +538,7 @@ int run(int argc, char **argv)
                 args->targets_overlap = parse_overlap_option(optarg);
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
-            case  5 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/contrast.c
+++ b/plugins/contrast.c
@@ -110,7 +110,7 @@ static const char *usage_text(void)
         "   -t, --targets REG                Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE          Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2      Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
-        "       --write-index                Automatically index the output files [off]\n"
+        "       --write-index[=FMT]          Automatically index the output files [off]\n"
         "\n"
         "Example:\n"
         "   # Test if any of the samples a,b is different from the samples c,d,e\n"
@@ -236,7 +236,9 @@ static void init_data(args_t *args)
     args->out_fh = hts_open(args->output_fname ? args->output_fname : "-", wmode);
     if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
     if ( bcf_hdr_write(args->out_fh, args->hdr_out)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->hdr_out,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->hdr_out,args->output_fname,
+                     &args->index_fn, args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
 
     if ( args->max_AC_str )
     {
@@ -485,7 +487,7 @@ int run(int argc, char **argv)
         {"targets",1,0,'t'},
         {"targets-file",1,0,'T'},
         {"targets-overlap",required_argument,NULL,4},
-        {"write-index",no_argument,NULL,5},
+        {"write-index",optional_argument,NULL,5},
         {NULL,0,NULL,0}
     };
     int c;
@@ -536,7 +538,10 @@ int run(int argc, char **argv)
                 args->targets_overlap = parse_overlap_option(optarg);
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
-            case  5 : args->write_index = 1; break;
+            case  5 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;

--- a/plugins/gvcfz.c
+++ b/plugins/gvcfz.c
@@ -102,7 +102,7 @@ static const char *usage_text(void)
         "   -g, --group-by EXPR             Group gVCF blocks according to the expression\n"
         "   -o, --output FILE               Write gVCF output to the FILE\n"
         "   -O, --output-type u|b|v|z[0-9]  u/b: un/compressed BCF, v/z: un/compressed VCF, 0-9: compression level [v]\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "Examples:\n"
         "   # Compress blocks by GQ and DP. Multiple blocks separated by a semicolon can be defined\n"
         "   bcftools +gvcfz input.bcf -g'PASS:GQ>60 & DP<20; PASS:GQ>40 & DP<15; Flt1:QG>20; Flt2:-'\n"
@@ -335,12 +335,12 @@ int run(int argc, char **argv)
         {"stats",required_argument,NULL,'s'},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",optional_argument,NULL,1},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "vr:R:t:T:o:O:g:i:e:a",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "vr:R:t:T:o:O:g:i:e:aW::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -371,7 +371,7 @@ int run(int argc, char **argv)
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  1 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/isecGT.c
+++ b/plugins/isecGT.c
@@ -69,7 +69,7 @@ static const char *usage_text(void)
         "   -R, --regions-file FILE         Restrict to regions listed in a file\n"
         "   -t, --targets REGION            Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n";
 }
 
@@ -87,7 +87,7 @@ int run(int argc, char **argv)
         {"targets-file",required_argument,NULL,'T'},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",no_argument,NULL,1},
+        {"write-index",optional_argument,NULL,1},
         {NULL,0,NULL,0}
     };
     int c;
@@ -119,7 +119,10 @@ int run(int argc, char **argv)
             case 'R': args->regions_list = optarg; args->regions_is_file = 1; break;
             case 't': args->targets_list = optarg; break;
             case 'T': args->targets_list = optarg; args->targets_is_file = 1; break;
-            case  1 : args->write_index = 1; break;
+            case  1 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;
@@ -151,7 +154,9 @@ int run(int argc, char **argv)
     args->out_fh = hts_open(args->output_fname ? args->output_fname : "-", wmode);
     if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
     if ( bcf_hdr_write(args->out_fh, args->hdr_a)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->hdr_a,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->hdr_a,args->output_fname,
+                     &args->index_fn, args->write_index)<0 )
+      error("Error: failed to initialise index for %s\n",args->output_fname);
 
     while ( bcf_sr_next_line(args->sr) )
     {

--- a/plugins/isecGT.c
+++ b/plugins/isecGT.c
@@ -69,7 +69,7 @@ static const char *usage_text(void)
         "   -R, --regions-file FILE         Restrict to regions listed in a file\n"
         "   -t, --targets REGION            Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n";
 }
 
@@ -87,12 +87,12 @@ int run(int argc, char **argv)
         {"targets-file",required_argument,NULL,'T'},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",optional_argument,NULL,1},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "o:O:r:R:t:T:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "o:O:r:R:t:T:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -119,7 +119,7 @@ int run(int argc, char **argv)
             case 'R': args->regions_list = optarg; args->regions_is_file = 1; break;
             case 't': args->targets_list = optarg; break;
             case 'T': args->targets_list = optarg; args->targets_is_file = 1; break;
-            case  1 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/mendelian2.c
+++ b/plugins/mendelian2.c
@@ -142,7 +142,7 @@ static const char *usage_text(void)
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
         "       --no-version                Do not append version and command line to the header\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Options:\n"
         "   -m, --mode c|[adeEgmMS]         Output mode, the default is `-m c`. Multiple modes can be combined in VCF/BCF\n"
@@ -479,7 +479,9 @@ static void init_data(args_t *args)
         args->out_fh = hts_open(args->output_fname ? args->output_fname : "-", wmode);
         if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
         if ( bcf_hdr_write(args->out_fh, args->hdr_out)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-        if ( args->write_index && init_index(args->out_fh,args->hdr_out,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+        if ( init_index2(args->out_fh,args->hdr_out,args->output_fname,
+                         &args->index_fn, args->write_index)<0 )
+          error("Error: failed to initialise index for %s\n",args->output_fname);
     }
 }
 
@@ -796,7 +798,7 @@ int run(int argc, char **argv)
         {"targets-overlap",required_argument,NULL,15},
         {"include",required_argument,0,'i'},
         {"exclude",required_argument,0,'e'},
-        {"write-index",no_argument,NULL,3},
+        {"write-index",optional_argument,NULL,3},
         {0,0,0,0}
     };
     int c;
@@ -856,7 +858,10 @@ int run(int argc, char **argv)
             case 'p': args->pfm = optarg; break;
             case  1 : args->rules_str = optarg; break;
             case  2 : args->rules_fname = optarg; break;
-            case  3 : args->write_index = 1; break;
+            case  3 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s",usage_text()); break;

--- a/plugins/mendelian2.c
+++ b/plugins/mendelian2.c
@@ -142,7 +142,7 @@ static const char *usage_text(void)
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
         "       --no-version                Do not append version and command line to the header\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Options:\n"
         "   -m, --mode c|[adeEgmMS]         Output mode, the default is `-m c`. Multiple modes can be combined in VCF/BCF\n"
@@ -798,12 +798,12 @@ int run(int argc, char **argv)
         {"targets-overlap",required_argument,NULL,15},
         {"include",required_argument,0,'i'},
         {"exclude",required_argument,0,'e'},
-        {"write-index",optional_argument,NULL,3},
+        {"write-index",optional_argument,NULL,'W'},
         {0,0,0,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "?hp:P:m:o:O:i:e:t:T:r:R:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "?hp:P:m:o:O:i:e:t:T:r:R:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -858,7 +858,7 @@ int run(int argc, char **argv)
             case 'p': args->pfm = optarg; break;
             case  1 : args->rules_str = optarg; break;
             case  2 : args->rules_fname = optarg; break;
-            case  3 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/prune.c
+++ b/plugins/prune.c
@@ -105,7 +105,7 @@ static const char *usage_text(void)
         "   -t, --targets REGION            Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "   -w, --window INT[bp|kb|Mb]      The window size of INT sites or INT bp/kb/Mb for the -n/-l options [100kb]\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "Examples:\n"
         "   # Discard records with r2 bigger than 0.6 in a window of 1000 sites\n"
         "   bcftools +prune -m 0.6 -w 1000 input.bcf -Ob -o output.bcf\n"
@@ -318,12 +318,12 @@ int run(int argc, char **argv)
         {"nsites-per-win",required_argument,NULL,'n'},
         {"nsites-per-win-mode",required_argument,NULL,'N'},
         {"window",required_argument,NULL,'w'},
-        {"write-index",optional_argument,NULL,4},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "vr:R:t:T:m:o:O:a:f:i:e:n:N:w:k",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "vr:R:t:T:m:o:O:a:f:i:e:n:N:w:kW::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -333,7 +333,7 @@ int run(int argc, char **argv)
                 args->rseed = strtol(optarg,&tmp,10);
                 if ( tmp==optarg || *tmp ) error("Could not parse: --random-seed %s\n", optarg);
                 break;
-            case  4 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/prune.c
+++ b/plugins/prune.c
@@ -105,7 +105,7 @@ static const char *usage_text(void)
         "   -t, --targets REGION            Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "   -w, --window INT[bp|kb|Mb]      The window size of INT sites or INT bp/kb/Mb for the -n/-l options [100kb]\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "Examples:\n"
         "   # Discard records with r2 bigger than 0.6 in a window of 1000 sites\n"
         "   bcftools +prune -m 0.6 -w 1000 input.bcf -Ob -o output.bcf\n"
@@ -186,7 +186,9 @@ static void init_data(args_t *args)
         }
     }
     if ( bcf_hdr_write(args->out_fh, args->hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->hdr,args->output_fname,
+                     &args->index_fn, args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
     args->ld_filter_id = -1;
     if ( args->ld_filter && strcmp(".",args->ld_filter) )
         args->ld_filter_id = bcf_hdr_id2int(args->hdr, BCF_DT_ID, args->ld_filter);
@@ -316,7 +318,7 @@ int run(int argc, char **argv)
         {"nsites-per-win",required_argument,NULL,'n'},
         {"nsites-per-win-mode",required_argument,NULL,'N'},
         {"window",required_argument,NULL,'w'},
-        {"write-index",no_argument,NULL,4},
+        {"write-index",optional_argument,NULL,4},
         {NULL,0,NULL,0}
     };
     int c;
@@ -331,7 +333,10 @@ int run(int argc, char **argv)
                 args->rseed = strtol(optarg,&tmp,10);
                 if ( tmp==optarg || *tmp ) error("Could not parse: --random-seed %s\n", optarg);
                 break;
-            case  4 : args->write_index = 1; break;
+            case  4 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'k': args->keep_sites = 1; break;
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");

--- a/plugins/remove-overlaps.c
+++ b/plugins/remove-overlaps.c
@@ -82,7 +82,7 @@ static const char *usage_text(void)
         "   -R, --regions-file FILE         restrict to regions listed in a file\n"
         "   -t, --targets REGION            similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         similar to -R but streams rather than index-jumps\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n";
 }
 
@@ -183,12 +183,12 @@ int run(int argc, char **argv)
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
         {"verbose",no_argument,NULL,'v'},
-        {"write-index",optional_argument,NULL,1},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "r:R:t:T:o:O:i:e:vpd",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "r:R:t:T:o:O:i:e:vpdW::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -224,7 +224,7 @@ int run(int argc, char **argv)
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  1 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/remove-overlaps.c
+++ b/plugins/remove-overlaps.c
@@ -82,7 +82,7 @@ static const char *usage_text(void)
         "   -R, --regions-file FILE         restrict to regions listed in a file\n"
         "   -t, --targets REGION            similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         similar to -R but streams rather than index-jumps\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n";
 }
 
@@ -103,7 +103,9 @@ static void init_data(args_t *args)
     args->out_fh = hts_open(args->output_fname ? args->output_fname : "-", wmode);
     if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
     if ( bcf_hdr_write(args->out_fh, args->hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->hdr,args->output_fname,&args->index_fn,
+                     args->write_index)<0 )
+      error("Error: failed to initialise index for %s\n",args->output_fname);
 
     args->vcfbuf = vcfbuf_init(args->hdr, 0);
     if ( args->rmdup )
@@ -181,7 +183,7 @@ int run(int argc, char **argv)
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
         {"verbose",no_argument,NULL,'v'},
-        {"write-index",no_argument,NULL,1},
+        {"write-index",optional_argument,NULL,1},
         {NULL,0,NULL,0}
     };
     int c;
@@ -222,7 +224,10 @@ int run(int argc, char **argv)
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  1 : args->write_index = 1; break;
+            case  1 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;

--- a/plugins/scatter.c
+++ b/plugins/scatter.c
@@ -97,7 +97,7 @@ static const char *usage_text(void)
         "   -x, --extra STRING              Output records not overlapping listed regions in separate file\n"
         "   -p, --prefix STRING             Prepend string to output VCF names\n"
         "       --hts-opts LIST             Low-level options to pass to HTSlib, e.g. block_size=32768\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Examples:\n"
         "   # Scatter a VCF file by shards with 10000 variants each\n"
@@ -203,7 +203,9 @@ static void open_set(subset_t *set, args_t *args)
         if ( args->record_cmd_line ) bcf_hdr_append_version(args->hdr, args->argc, args->argv, "bcftools_plugin");
     }
     if ( bcf_hdr_write(set->fh, args->hdr)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__, args->str.s);
-    if ( args->write_index && init_index(set->fh,args->hdr,args->str.s,&set->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->str.s);
+    if ( init_index2(set->fh,args->hdr,args->str.s,&set->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->str.s);
 }
 
 static void init_data(args_t *args)
@@ -352,7 +354,7 @@ int run(int argc, char **argv)
         {"extra",required_argument,NULL,'x'},
         {"prefix",required_argument,NULL,'p'},
         {"hts-opts",required_argument,NULL,5},
-        {"write-index",no_argument,NULL,6},
+        {"write-index",optional_argument,NULL,6},
         {NULL,0,NULL,0}
     };
     int c;
@@ -410,7 +412,10 @@ int run(int argc, char **argv)
             case 'x': args->extra = optarg;  break;
             case 'p': args->prefix = optarg;  break;
             case  5 : args->hts_opts = hts_readlist(optarg, 0, &args->nhts_opts); break;
-            case  6 : args->write_index = 1; break;
+            case  6 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;

--- a/plugins/scatter.c
+++ b/plugins/scatter.c
@@ -97,7 +97,7 @@ static const char *usage_text(void)
         "   -x, --extra STRING              Output records not overlapping listed regions in separate file\n"
         "   -p, --prefix STRING             Prepend string to output VCF names\n"
         "       --hts-opts LIST             Low-level options to pass to HTSlib, e.g. block_size=32768\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Examples:\n"
         "   # Scatter a VCF file by shards with 10000 variants each\n"
@@ -359,12 +359,12 @@ int run(int argc, char **argv)
         {"extra",required_argument,NULL,'x'},
         {"prefix",required_argument,NULL,'p'},
         {"hts-opts",required_argument,NULL,5},
-        {"write-index",optional_argument,NULL,6},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "e:i:o:O:r:R:t:T:n:s:S:x:p:h?", loptions, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "e:i:o:O:r:R:t:T:n:s:S:x:p:W::h?", loptions, NULL)) >= 0)
     {
         switch (c)
         {
@@ -417,7 +417,7 @@ int run(int argc, char **argv)
             case 'x': args->extra = optarg;  break;
             case 'p': args->prefix = optarg;  break;
             case  5 : args->hts_opts = hts_readlist(optarg, 0, &args->nhts_opts); break;
-            case  6 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/scatter.c
+++ b/plugins/scatter.c
@@ -306,7 +306,12 @@ static void process(args_t *args)
         args->rec_cnt++;
         if (args->rec_cnt == args->nsites) {
           args->rec_cnt = 0;
+          int err = 0;
+          if ( args->write_index && bcf_idx_save(set->fh) < 0)
+              err = 1;
           if ( hts_close(set->fh)!=0 ) error("Error: close failed .. %s\n", set->fname);
+          if (err)
+              error("Error: cannot write to index %s\n", set->index_fn);
           free(set->fname);
           set->fname = NULL;
           args->chunk_cnt++;

--- a/plugins/split-vep.c
+++ b/plugins/split-vep.c
@@ -264,7 +264,7 @@ static const char *usage_text(void)
         "   -t, --targets REG               Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Examples:\n"
         "   # List available fields of the INFO/CSQ or INFO/BCSQ annotation\n"
@@ -1525,12 +1525,12 @@ int run(int argc, char **argv)
         {"targets-overlap",required_argument,NULL,4},
         {"no-version",no_argument,NULL,2},
         {"allow-undef-tags",no_argument,0,'u'},
-        {"write-index",optional_argument,NULL,6},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c, drop_sites = -1;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "o:O:i:e:r:R:t:T:lS:s:c:p:a:f:dA:xXuHg:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "o:O:i:e:r:R:t:T:lS:s:c:p:a:f:dA:xXuHg:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -1592,7 +1592,7 @@ int run(int argc, char **argv)
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
             case  5 : args->gene_fields_str = optarg; break;
-            case  6 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/split-vep.c
+++ b/plugins/split-vep.c
@@ -264,7 +264,7 @@ static const char *usage_text(void)
         "   -t, --targets REG               Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Examples:\n"
         "   # List available fields of the INFO/CSQ or INFO/BCSQ annotation\n"
@@ -1525,7 +1525,7 @@ int run(int argc, char **argv)
         {"targets-overlap",required_argument,NULL,4},
         {"no-version",no_argument,NULL,2},
         {"allow-undef-tags",no_argument,0,'u'},
-        {"write-index",no_argument,NULL,6},
+        {"write-index",optional_argument,NULL,6},
         {NULL,0,NULL,0}
     };
     int c, drop_sites = -1;
@@ -1592,7 +1592,10 @@ int run(int argc, char **argv)
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
             case  5 : args->gene_fields_str = optarg; break;
-            case  6 : args->write_index = 1; break;
+            case  6 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;
@@ -1655,7 +1658,9 @@ int run(int argc, char **argv)
             args->fh_vcf = hts_open(args->output_fname ? args->output_fname : "-", wmode);
             if ( args->record_cmd_line ) bcf_hdr_append_version(args->hdr_out, args->argc, args->argv, "bcftools_split-vep");
             if ( bcf_hdr_write(args->fh_vcf, args->hdr_out)!=0 ) error("Failed to write the header to %s\n", args->output_fname);
-            if ( args->write_index && init_index(args->fh_vcf,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+            if ( init_index2(args->fh_vcf,args->hdr,args->output_fname,
+                             &args->index_fn, args->write_index)<0 )
+                error("Error: failed to initialise index for %s\n",args->output_fname);
         }
         while ( bcf_sr_next_line(args->sr) )
             process_record(args, bcf_sr_get_line(args->sr,0));

--- a/plugins/split.c
+++ b/plugins/split.c
@@ -126,7 +126,7 @@ static const char *usage_text(void)
         "       --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "       --hts-opts LIST             Low-level options to pass to HTSlib, e.g. block_size=32768\n"
-        "       --write-index               Automatically index the output files [off]\n"
+        "       --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Examples:\n"
         "   # Split a VCF file\n"
@@ -488,7 +488,9 @@ static void init_data(args_t *args)
         for (j=0; j<set->nsmpl; j++)
             set->hdr->samples[j] = set->rename ? set->rename[j] : args->hdr_in->samples[set->smpl[j]];
         if ( bcf_hdr_write(set->fh, set->hdr)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__,str.s);
-        if ( args->write_index && init_index(set->fh,set->hdr,str.s,&set->index_fn)<0 ) error("Error: failed to initialise index for %s\n",str.s);
+        if ( init_index2(set->fh,set->hdr,str.s,&set->index_fn,
+                         args->write_index)<0 )
+            error("Error: failed to initialise index for %s\n",str.s);
         if ( args->filter_str )
             set->filter = filter_init(set->hdr, args->filter_str);
     }
@@ -654,7 +656,7 @@ int run(int argc, char **argv)
         {"groups-file",required_argument,NULL,'G'},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",no_argument,NULL,4},
+        {"write-index",optional_argument,NULL,4},
         {NULL,0,NULL,0}
     };
     int c;
@@ -704,7 +706,10 @@ int run(int argc, char **argv)
                 args->targets_overlap = parse_overlap_option(optarg);
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
-            case  4 : args->write_index = 1; break;
+            case  4 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;

--- a/plugins/split.c
+++ b/plugins/split.c
@@ -126,7 +126,7 @@ static const char *usage_text(void)
         "       --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
         "   -T, --targets-file FILE         Similar to -R but streams rather than index-jumps\n"
         "       --hts-opts LIST             Low-level options to pass to HTSlib, e.g. block_size=32768\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Examples:\n"
         "   # Split a VCF file\n"
@@ -656,12 +656,12 @@ int run(int argc, char **argv)
         {"groups-file",required_argument,NULL,'G'},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",optional_argument,NULL,4},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "vr:R:t:T:o:O:i:e:k:S:G:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "vr:R:t:T:o:O:i:e:k:S:G:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -706,7 +706,7 @@ int run(int argc, char **argv)
                 args->targets_overlap = parse_overlap_option(optarg);
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
-            case  4 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/trio-dnm2.c
+++ b/plugins/trio-dnm2.c
@@ -181,7 +181,7 @@ static const char *usage_text(void)
         "       --use-NAIVE                 A naive calling model which uses only FMT/GT to determine DNMs\n"
         "       --with-pAD                  Do not use FMT/QS but parental FMT/AD\n"
         "       --with-pPL                  Do not use FMT/QS but parental FMT/PL. Equals to DNG with bugs fixed (more FPs, fewer FNs)\n"
-        "       --write-index[=FMT]         Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]         Automatically index the output files [off]\n"
         "\n"
         "Example:\n"
         "   # Annotate VCF with FORMAT/DNM, run for a single trio\n"
@@ -1605,13 +1605,13 @@ int run(int argc, char **argv)
         {"targets",1,0,'t'},
         {"targets-file",1,0,'T'},
         {"targets-overlap",required_argument,NULL,15},
-        {"write-index",optional_argument,NULL,16},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
     double pn_abs, pn_frac;
-    while ((c = getopt_long(argc, argv, "p:P:o:O:s:i:e:r:R:t:T:m:au:X:n",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "p:P:o:O:s:i:e:r:R:t:T:m:au:X:nW::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -1694,7 +1694,7 @@ int run(int argc, char **argv)
                 args->targets_overlap = parse_overlap_option(optarg);
                 if ( args->targets_overlap < 0 ) error("Could not parse: --targets-overlap %s\n",optarg);
                 break;
-            case 16 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/plugins/variant-distance.c
+++ b/plugins/variant-distance.c
@@ -93,7 +93,7 @@ static const char *usage_text(void)
         "   -t, --targets REGION             Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE          Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2      Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
-        "       --write-index                Automatically index the output files [off]\n"
+        "       --write-index[=FMT]          Automatically index the output files [off]\n"
         "Examples:\n"
         "   bcftools +variant-distance input.bcf -Ob -o output.bcf\n"
         "\n";
@@ -129,7 +129,9 @@ static void init_data(args_t *args)
     if ( args->out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->output_fname, strerror(errno));
 
     if ( bcf_hdr_write(args->out_fh, args->hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->hdr,args->output_fname,&args->index_fn,
+                     args->write_index)<0 )
+      error("Error: failed to initialise index for %s\n",args->output_fname);
 
     args->buf = vcfbuf_init(args->hdr, 0);
     vcfbuf_set_opt(args->buf,int,VCFBUF_DUMMY,1)
@@ -246,7 +248,7 @@ int run(int argc, char **argv)
         {"targets-overlap",required_argument,NULL,2},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",no_argument,NULL,4},
+        {"write-index",optional_argument,NULL,4},
         {NULL,0,NULL,0}
     };
     int c;
@@ -300,7 +302,10 @@ int run(int argc, char **argv)
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  4 : args->write_index = 1; break;
+            case  4 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?':
             default: error("%s", usage_text()); break;

--- a/plugins/variant-distance.c
+++ b/plugins/variant-distance.c
@@ -93,7 +93,7 @@ static const char *usage_text(void)
         "   -t, --targets REGION             Similar to -r but streams rather than index-jumps\n"
         "   -T, --targets-file FILE          Similar to -R but streams rather than index-jumps\n"
         "       --targets-overlap 0|1|2      Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n"
-        "       --write-index[=FMT]          Automatically index the output files [off]\n"
+        "   -W, --write-index[=FMT]          Automatically index the output files [off]\n"
         "Examples:\n"
         "   bcftools +variant-distance input.bcf -Ob -o output.bcf\n"
         "\n";
@@ -248,12 +248,12 @@ int run(int argc, char **argv)
         {"targets-overlap",required_argument,NULL,2},
         {"output",required_argument,NULL,'o'},
         {"output-type",required_argument,NULL,'O'},
-        {"write-index",optional_argument,NULL,4},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     int c;
     char *tmp;
-    while ((c = getopt_long(argc, argv, "r:R:t:T:o:O:n:d:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "r:R:t:T:o:O:n:d:W::",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -302,7 +302,7 @@ int run(int argc, char **argv)
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  4 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -3398,7 +3398,7 @@ static void usage(args_t *args)
     fprintf(stderr, "       --single-overlaps           Keep memory low by avoiding complexities arising from handling multiple overlapping intervals\n");
     fprintf(stderr, "   -x, --remove LIST               List of annotations (e.g. ID,INFO/DP,FORMAT/DP,FILTER) to remove (or keep with \"^\" prefix). See man page for details\n");
     fprintf(stderr, "       --threads INT               Number of extra output compression threads [0]\n");
-    fprintf(stderr, "       --write-index[=FMT]         Automatically index the output files [off]\n");
+    fprintf(stderr, "   -W, --write-index[=FMT]         Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "   http://samtools.github.io/bcftools/howtos/annotate.html\n");
@@ -3455,11 +3455,11 @@ int main_vcfannotate(int argc, char *argv[])
         {"min-overlap",required_argument,NULL,12},
         {"no-version",no_argument,NULL,8},
         {"force",no_argument,NULL,'f'},
-        {"write-index",optional_argument,NULL,13},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "h:H:?o:O:r:R:a:x:c:C:i:e:S:s:I:m:kl:f",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "h:H:?o:O:r:R:a:x:c:C:i:e:S:s:I:m:kl:fW::",loptions,NULL)) >= 0)
     {
         switch (c) {
             case 'f': args->force = 1; break;
@@ -3532,7 +3532,7 @@ int main_vcfannotate(int argc, char *argv[])
             case 10 : args->single_overlaps = 1; break;
             case 11 : args->rename_annots = optarg; break;
             case 12 : args->min_overlap_str = optarg; break;
-            case 13 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -2929,7 +2929,9 @@ static void init_data(args_t *args)
         if ( args->n_threads )
             hts_set_opt(args->out_fh, HTS_OPT_THREAD_POOL, args->files->p);
         if ( bcf_hdr_write(args->out_fh, args->hdr_out)!=0 ) error("[%s] Error: failed to write the header to %s\n", __func__,args->output_fname);
-        if ( args->write_index && init_index(args->out_fh,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+        if ( init_index2(args->out_fh,args->hdr,args->output_fname,
+                         &args->index_fn, args->write_index) < 0 )
+            error("Error: failed to initialise index for %s\n",args->output_fname);
     }
 }
 
@@ -3396,7 +3398,7 @@ static void usage(args_t *args)
     fprintf(stderr, "       --single-overlaps           Keep memory low by avoiding complexities arising from handling multiple overlapping intervals\n");
     fprintf(stderr, "   -x, --remove LIST               List of annotations (e.g. ID,INFO/DP,FORMAT/DP,FILTER) to remove (or keep with \"^\" prefix). See man page for details\n");
     fprintf(stderr, "       --threads INT               Number of extra output compression threads [0]\n");
-    fprintf(stderr, "       --write-index               Automatically index the output files [off]\n");
+    fprintf(stderr, "       --write-index[=FMT]         Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "   http://samtools.github.io/bcftools/howtos/annotate.html\n");
@@ -3453,7 +3455,7 @@ int main_vcfannotate(int argc, char *argv[])
         {"min-overlap",required_argument,NULL,12},
         {"no-version",no_argument,NULL,8},
         {"force",no_argument,NULL,'f'},
-        {"write-index",no_argument,NULL,13},
+        {"write-index",optional_argument,NULL,13},
         {NULL,0,NULL,0}
     };
     char *tmp;
@@ -3530,7 +3532,10 @@ int main_vcfannotate(int argc, char *argv[])
             case 10 : args->single_overlaps = 1; break;
             case 11 : args->rename_annots = optarg; break;
             case 12 : args->min_overlap_str = optarg; break;
-            case 13 : args->write_index = 1; break;
+            case 13 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);
         }

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -718,7 +718,9 @@ static void init_data(args_t *args)
 
     if (args->record_cmd_line) bcf_hdr_append_version(args->aux.hdr, args->argc, args->argv, "bcftools_call");
     if ( bcf_hdr_write(args->out_fh, args->aux.hdr)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->aux.hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->aux.hdr,args->output_fname,
+                     &args->index_fn, args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
 
     if ( args->flag&CF_INS_MISSED ) init_missed_line(args);
 }
@@ -922,7 +924,7 @@ static void usage(args_t *args)
     fprintf(stderr, "   -M, --keep-masked-ref           Keep sites with masked reference allele (REF=N)\n");
     fprintf(stderr, "   -V, --skip-variants TYPE        Skip indels/snps\n");
     fprintf(stderr, "   -v, --variants-only             Output variant sites only\n");
-    fprintf(stderr, "       --write-index               Automatically index the output files [off]\n");
+    fprintf(stderr, "       --write-index[=FMT]         Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Consensus/variant calling options:\n");
     fprintf(stderr, "   -c, --consensus-caller          The original calling method (conflicts with -m)\n");
@@ -1006,7 +1008,7 @@ int main_vcfcall(int argc, char *argv[])
         {"chromosome-X",no_argument,NULL,'X'},
         {"chromosome-Y",no_argument,NULL,'Y'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",no_argument,NULL,10},
+        {"write-index",optional_argument,NULL,10},
         {NULL,0,NULL,0}
     };
 
@@ -1094,7 +1096,10 @@ int main_vcfcall(int argc, char *argv[])
                 args.regions_overlap = parse_overlap_option(optarg);
                 if ( args.regions_overlap < 0 ) error("Could not parse: --regions-overlap %s\n",optarg);
                 break;
-            case  10: args.write_index = 1; break;
+            case  10:
+                if (!(args.write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             default: usage(&args);
         }
     }

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -924,7 +924,7 @@ static void usage(args_t *args)
     fprintf(stderr, "   -M, --keep-masked-ref           Keep sites with masked reference allele (REF=N)\n");
     fprintf(stderr, "   -V, --skip-variants TYPE        Skip indels/snps\n");
     fprintf(stderr, "   -v, --variants-only             Output variant sites only\n");
-    fprintf(stderr, "       --write-index[=FMT]         Automatically index the output files [off]\n");
+    fprintf(stderr, "   -W, --write-index[=FMT]         Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Consensus/variant calling options:\n");
     fprintf(stderr, "   -c, --consensus-caller          The original calling method (conflicts with -m)\n");
@@ -1008,12 +1008,12 @@ int main_vcfcall(int argc, char *argv[])
         {"chromosome-X",no_argument,NULL,'X'},
         {"chromosome-Y",no_argument,NULL,'Y'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,10},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
 
     char *tmp = NULL;
-    while ((c = getopt_long(argc, argv, "h?o:O:r:R:s:S:t:T:A*NMV:vcmp:C:n:P:f:a:ig:XYF:G:", loptions, NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "h?o:O:r:R:s:S:t:T:A*NMV:vcmp:C:n:P:f:a:ig:XYF:G:W::", loptions, NULL)) >= 0)
     {
         switch (c)
         {
@@ -1096,7 +1096,7 @@ int main_vcfcall(int argc, char *argv[])
                 args.regions_overlap = parse_overlap_option(optarg);
                 if ( args.regions_overlap < 0 ) error("Could not parse: --regions-overlap %s\n",optarg);
                 break;
-            case  10:
+            case 'W':
                 if (!(args.write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfcnv.c
+++ b/vcfcnv.c
@@ -1297,7 +1297,7 @@ int main_vcfcnv(int argc, char *argv[])
         {0,0,0,0}
     };
     char *tmp = NULL;
-    while ((c = getopt_long(argc, argv, "h?r:R:t:T:s:o:p:l:T:c:b:P:x:e:O:W:f:a:L:d:k:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "h?r:R:t:T:s:o:p:l:T:c:b:P:x:e:O:W::f:a:L:d:k:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'L': 
                 args->lrr_smooth_win = strtol(optarg,&tmp,10);

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -987,7 +987,7 @@ static void usage(args_t *args)
     fprintf(stderr, "       --regions-overlap 0|1|2    Include if POS in the region (0), record overlaps (1), variant overlaps (2) [1]\n");
     fprintf(stderr, "       --threads INT              Use multithreading with <int> worker threads [0]\n");
     fprintf(stderr, "   -v, --verbose 0|1              Set verbosity level [1]\n");
-    fprintf(stderr, "       --write-index[=FMT]        Automatically index the output files [off]\n");
+    fprintf(stderr, "   -W, --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -1026,12 +1026,12 @@ int main_vcfconcat(int argc, char *argv[])
         {"file-list",required_argument,NULL,'f'},
         {"min-PQ",required_argument,NULL,'q'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,13},
+        {"write-index",optional_argument,NULL,'W'},
         {"drop-genotypes",no_argument,NULL,'G'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "h:?o:O:f:alq:Dd:Gr:R:cnv:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "h:?o:O:f:alq:Dd:Gr:R:cnv:W::",loptions,NULL)) >= 0)
     {
         switch (c) {
             case 'c': args->compact_PS = 1; break;
@@ -1081,7 +1081,7 @@ int main_vcfconcat(int argc, char *argv[])
                       args->verbose = strtol(optarg, &tmp, 0);
                       if ( *tmp || args->verbose<0 || args->verbose>1 ) error("Error: currently only --verbose 0 or --verbose 1 is supported\n");
                       break;
-            case 13 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -159,7 +159,9 @@ static void init_data(args_t *args)
         hts_set_opt(args->out_fh, HTS_OPT_THREAD_POOL, args->tpool);
     }
     if ( bcf_hdr_write(args->out_fh, args->out_hdr)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->out_hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->out_hdr,args->output_fname,
+                     &args->index_fn, args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
 
     if ( args->allow_overlaps )
     {
@@ -985,7 +987,7 @@ static void usage(args_t *args)
     fprintf(stderr, "       --regions-overlap 0|1|2    Include if POS in the region (0), record overlaps (1), variant overlaps (2) [1]\n");
     fprintf(stderr, "       --threads INT              Use multithreading with <int> worker threads [0]\n");
     fprintf(stderr, "   -v, --verbose 0|1              Set verbosity level [1]\n");
-    fprintf(stderr, "       --write-index              Automatically index the output files [off]\n");
+    fprintf(stderr, "       --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -1024,7 +1026,7 @@ int main_vcfconcat(int argc, char *argv[])
         {"file-list",required_argument,NULL,'f'},
         {"min-PQ",required_argument,NULL,'q'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",no_argument,NULL,13},
+        {"write-index",optional_argument,NULL,13},
         {"drop-genotypes",no_argument,NULL,'G'},
         {NULL,0,NULL,0}
     };
@@ -1079,7 +1081,10 @@ int main_vcfconcat(int argc, char *argv[])
                       args->verbose = strtol(optarg, &tmp, 0);
                       if ( *tmp || args->verbose<0 || args->verbose>1 ) error("Error: currently only --verbose 0 or --verbose 1 is supported\n");
                       break;
-            case 13 : args->write_index = 1; break;
+            case 13 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -1625,7 +1625,7 @@ static void usage(void)
     fprintf(stderr, "   -o, --output FILE              Output file name [stdout]\n");
     fprintf(stderr, "   -O, --output-type u|b|v|z[0-9] u/b: un/compressed BCF, v/z: un/compressed VCF, 0-9: compression level [v]\n");
     fprintf(stderr, "       --threads INT              Use multithreading with INT worker threads [0]\n");
-    fprintf(stderr, "       --write-index[=FMT]        Automatically index the output files [off]\n");
+    fprintf(stderr, "   -W, --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "GEN/SAMPLE conversion (input/output from IMPUTE2):\n");
     fprintf(stderr, "   -G, --gensample2vcf ...        <PREFIX>|<GEN-FILE>,<SAMPLE-FILE>\n");
@@ -1719,11 +1719,11 @@ int main_vcfconvert(int argc, char *argv[])
         {"fasta-ref",required_argument,NULL,'f'},
         {"no-version",no_argument,NULL,10},
         {"keep-duplicates",no_argument,NULL,12},
-        {"write-index",optional_argument,NULL,16},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "?h:r:R:s:S:t:T:i:e:g:G:o:O:c:f:H:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "?h:r:R:s:S:t:T:i:e:g:G:o:O:c:f:H:W::",loptions,NULL)) >= 0) {
         switch (c) {
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");
@@ -1748,7 +1748,7 @@ int main_vcfconvert(int argc, char *argv[])
             case  7 : args->convert_func = vcf_to_hapsample; args->outfname = optarg; break;
             case  8 : error("The --chrom option has been deprecated, please use --3N6 instead\n"); break;
             case 15 : args->gen_3N6 = 1; break;
-            case 16 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -495,7 +495,9 @@ static void gensample_to_vcf(args_t *args)
     if ( out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->outfname, strerror(errno));
     if ( args->n_threads ) hts_set_threads(out_fh, args->n_threads);
     if ( bcf_hdr_write(out_fh,args->header)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__,args->outfname);
-    if ( args->write_index && init_index(out_fh,args->header,args->outfname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->outfname);
+    if ( init_index2(out_fh,args->header,args->outfname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->outfname);
     bcf1_t *rec = bcf_init();
 
     nsamples -= 2;
@@ -639,7 +641,9 @@ static void haplegendsample_to_vcf(args_t *args)
     if ( out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->outfname, strerror(errno));
     if ( args->n_threads ) hts_set_threads(out_fh, args->n_threads);
     if ( bcf_hdr_write(out_fh,args->header)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__,args->outfname);
-    if ( args->write_index && init_index(out_fh,args->header,args->outfname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->outfname);
+    if ( init_index2(out_fh,args->header,args->outfname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->outfname);
     bcf1_t *rec = bcf_init();
 
     args->gts = (int32_t *) malloc(sizeof(int32_t)*nsamples*2);
@@ -791,7 +795,9 @@ static void hapsample_to_vcf(args_t *args)
     if ( out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->outfname, strerror(errno));
     if ( args->n_threads ) hts_set_threads(out_fh, args->n_threads);
     if ( bcf_hdr_write(out_fh,args->header)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->outfname);
-    if ( args->write_index && init_index(out_fh,args->header,args->outfname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->outfname);
+    if ( init_index2(out_fh,args->header,args->outfname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->outfname);
     bcf1_t *rec = bcf_init();
 
     nsamples -= 2;
@@ -1394,7 +1400,9 @@ static void tsv_to_vcf(args_t *args)
     if ( out_fh == NULL ) error("Can't write to \"%s\": %s\n", args->outfname, strerror(errno));
     if ( args->n_threads ) hts_set_threads(out_fh, args->n_threads);
     if ( bcf_hdr_write(out_fh,args->header)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->outfname);
-    if ( args->write_index && init_index(out_fh,args->header,args->outfname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->outfname);
+    if ( init_index2(out_fh,args->header,args->outfname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->outfname);
 
     tsv_t *tsv = tsv_init(args->columns ? args->columns : "ID,CHROM,POS,AA");
     if ( tsv_register(tsv, "CHROM", tsv_setter_chrom, args->header) < 0 ) error("Expected CHROM column\n");
@@ -1473,7 +1481,9 @@ static void vcf_to_vcf(args_t *args)
 
     bcf_hdr_t *hdr = bcf_sr_get_header(args->files,0);
     if ( bcf_hdr_write(out_fh,hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->outfname);
-    if ( args->write_index && init_index(out_fh,args->header,args->outfname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->outfname);
+    if ( init_index2(out_fh,args->header,args->outfname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->outfname);
 
     while ( bcf_sr_next_line(args->files) )
     {
@@ -1515,7 +1525,9 @@ static void gvcf_to_vcf(args_t *args)
     bcf_hdr_t *hdr = bcf_sr_get_header(args->files,0);
     if (args->record_cmd_line) bcf_hdr_append_version(hdr, args->argc, args->argv, "bcftools_convert");
     if ( bcf_hdr_write(out_fh,hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->outfname);
-    if ( args->write_index && init_index(out_fh,hdr,args->outfname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->outfname);
+    if ( init_index2(out_fh,hdr,args->outfname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->outfname);
 
     int32_t *itmp = NULL, nitmp = 0;
 
@@ -1613,7 +1625,7 @@ static void usage(void)
     fprintf(stderr, "   -o, --output FILE              Output file name [stdout]\n");
     fprintf(stderr, "   -O, --output-type u|b|v|z[0-9] u/b: un/compressed BCF, v/z: un/compressed VCF, 0-9: compression level [v]\n");
     fprintf(stderr, "       --threads INT              Use multithreading with INT worker threads [0]\n");
-    fprintf(stderr, "       --write-index              Automatically index the output files [off]\n");
+    fprintf(stderr, "       --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "GEN/SAMPLE conversion (input/output from IMPUTE2):\n");
     fprintf(stderr, "   -G, --gensample2vcf ...        <PREFIX>|<GEN-FILE>,<SAMPLE-FILE>\n");
@@ -1707,7 +1719,7 @@ int main_vcfconvert(int argc, char *argv[])
         {"fasta-ref",required_argument,NULL,'f'},
         {"no-version",no_argument,NULL,10},
         {"keep-duplicates",no_argument,NULL,12},
-        {"write-index",no_argument,NULL,16},
+        {"write-index",optional_argument,NULL,16},
         {NULL,0,NULL,0}
     };
     char *tmp;
@@ -1736,7 +1748,10 @@ int main_vcfconvert(int argc, char *argv[])
             case  7 : args->convert_func = vcf_to_hapsample; args->outfname = optarg; break;
             case  8 : error("The --chrom option has been deprecated, please use --3N6 instead\n"); break;
             case 15 : args->gen_3N6 = 1; break;
-            case 16 : args->write_index = 1; break;
+            case 16 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'H': args->convert_func = haplegendsample_to_vcf; args->infname = optarg; break;
             case 'f': args->ref_fname = optarg; break;
             case 'c': args->columns = optarg; break;

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -493,7 +493,7 @@ static void usage(args_t *args)
     fprintf(stderr, "    -T, --targets-file FILE        Similar to -R but streams rather than index-jumps\n");
     fprintf(stderr, "        --targets-overlap 0|1|2    Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n");
     fprintf(stderr, "        --threads INT              Use multithreading with <int> worker threads [0]\n");
-    fprintf(stderr, "        --write-index[=FMT]        Automatically index the output files [off]\n");
+    fprintf(stderr, "    -W, --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -536,11 +536,11 @@ int main_vcffilter(int argc, char *argv[])
         {"SnpGap",required_argument,NULL,'g'},
         {"IndelGap",required_argument,NULL,'G'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,12},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "e:i:t:T:r:R:h?s:m:M:o:O:g:G:S:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "e:i:t:T:r:R:h?s:m:M:o:O:g:G:S:W::",loptions,NULL)) >= 0) {
         switch (c) {
             case 'g':
                 args->snp_gap = strtol(optarg,&tmp,10);
@@ -629,7 +629,7 @@ int main_vcffilter(int argc, char *argv[])
                 else if ( !strcasecmp(optarg,"2") ) args->mask_overlap = 2;
                 else error("Could not parse: --mask-overlap %s\n",optarg);
                 break;
-            case  12 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -493,7 +493,7 @@ static void usage(args_t *args)
     fprintf(stderr, "    -T, --targets-file FILE        Similar to -R but streams rather than index-jumps\n");
     fprintf(stderr, "        --targets-overlap 0|1|2    Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n");
     fprintf(stderr, "        --threads INT              Use multithreading with <int> worker threads [0]\n");
-    fprintf(stderr, "        --write-index              Automatically index the output files [off]\n");
+    fprintf(stderr, "        --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -536,7 +536,7 @@ int main_vcffilter(int argc, char *argv[])
         {"SnpGap",required_argument,NULL,'g'},
         {"IndelGap",required_argument,NULL,'G'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",no_argument,NULL,12},
+        {"write-index",optional_argument,NULL,12},
         {NULL,0,NULL,0}
     };
     char *tmp;
@@ -629,7 +629,10 @@ int main_vcffilter(int argc, char *argv[])
                 else if ( !strcasecmp(optarg,"2") ) args->mask_overlap = 2;
                 else error("Could not parse: --mask-overlap %s\n",optarg);
                 break;
-            case  12 : args->write_index = 1; break;
+            case  12 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);
@@ -677,7 +680,9 @@ int main_vcffilter(int argc, char *argv[])
 
     init_data(args);
     if ( bcf_hdr_write(args->out_fh, args->hdr)!=0 ) error("[%s] Error: cannot write the header to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out_fh,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out_fh,args->hdr,args->output_fname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
     while ( bcf_sr_next_line(args->files) )
     {
         bcf1_t *line = bcf_sr_get_line(args->files, 0);

--- a/vcfisec.c
+++ b/vcfisec.c
@@ -503,7 +503,7 @@ static void usage(void)
     fprintf(stderr, "        --targets-overlap 0|1|2    Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n");
     fprintf(stderr, "        --threads INT              Use multithreading with <int> worker threads [0]\n");
     fprintf(stderr, "    -w, --write LIST               List of files to write with -p given as 1-based indexes. By default, all files are written\n");
-    fprintf(stderr, "        --write-index[=FMT]        Automatically index the output files [off]\n");
+    fprintf(stderr, "    -W, --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "   # Create intersection and complements of two sets saving the output in dir/*\n");
@@ -561,11 +561,11 @@ int main_vcfisec(int argc, char *argv[])
         {"output-type",required_argument,NULL,'O'},
         {"threads",required_argument,NULL,9},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,10},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "hc:r:R:p:n:w:t:T:Cf:o:O:i:e:l:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hc:r:R:p:n:w:t:T:Cf:o:O:i:e:l:W::",loptions,NULL)) >= 0) {
         switch (c) {
             case 'o': args->output_fname = optarg; break;
             case 'O':
@@ -637,7 +637,7 @@ int main_vcfisec(int argc, char *argv[])
                 break;
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
-            case 10 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfisec.c
+++ b/vcfisec.c
@@ -457,12 +457,14 @@ static void destroy_data(args_t *args)
         {
             if ( !args->fnames[i] ) continue;
             if ( hts_close(args->fh_out[i])!=0 ) error("[%s] Error: close failed .. %s\n", __func__,args->fnames[i]);
-            if ( args->output_type==FT_VCF_GZ )
+            int is_tbi = !args->write_index 
+                      || (args->write_index&127) == HTS_FMT_TBI;
+            if ( args->output_type==FT_VCF_GZ && is_tbi )
             {
                 tbx_conf_t conf = tbx_conf_vcf;
                 tbx_index_build(args->fnames[i], -1, &conf);
             }
-            else if ( args->output_type==FT_BCF_GZ )
+            else if ( args->output_type==FT_BCF_GZ || !is_tbi )
             {
                 if ( bcf_index_build(args->fnames[i],14) ) error("Could not index %s\n", args->fnames[i]);
             }

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -3489,7 +3489,7 @@ static void usage(void)
     fprintf(stderr, "    -R, --regions-file FILE           Restrict to regions listed in a file\n");
     fprintf(stderr, "        --regions-overlap 0|1|2       Include if POS in the region (0), record overlaps (1), variant overlaps (2) [1]\n");
     fprintf(stderr, "        --threads INT                 Use multithreading with INT worker threads [0]\n");
-    fprintf(stderr, "        --write-index[=FMT]           Automatically index the output files [off]\n");
+    fprintf(stderr, "    -W, --write-index[=FMT]           Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -3534,11 +3534,11 @@ int main_vcfmerge(int argc, char *argv[])
         {"force-no-index",no_argument,NULL,10},
         {"force-single",no_argument,NULL,12},
         {"filter-logic",required_argument,NULL,'F'},
-        {"write-index",optional_argument,NULL,11},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "hm:f:r:R:o:O:i:M:l:g:F:0L:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hm:f:r:R:o:O:i:M:l:g:F:0L:W::",loptions,NULL)) >= 0) {
         switch (c) {
             case 'L':
                 args->local_alleles = strtol(optarg,&tmp,10);
@@ -3613,7 +3613,7 @@ int main_vcfmerge(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 10 : args->no_index = 1; break;
-            case 11 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -3401,7 +3401,9 @@ void merge_vcf(args_t *args)
         if ( hts_close(args->out_fh)!=0 ) error("[%s] Error: close failed .. %s\n", __func__,args->output_fname);
         return;
     }
-    else if ( args->write_index && init_index(args->out_fh,args->out_hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    else if ( init_index2(args->out_fh,args->out_hdr,args->output_fname,
+                          &args->index_fn, args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
 
     args->vcmp = vcmp_init();
     args->maux = maux_init(args);
@@ -3487,7 +3489,7 @@ static void usage(void)
     fprintf(stderr, "    -R, --regions-file FILE           Restrict to regions listed in a file\n");
     fprintf(stderr, "        --regions-overlap 0|1|2       Include if POS in the region (0), record overlaps (1), variant overlaps (2) [1]\n");
     fprintf(stderr, "        --threads INT                 Use multithreading with INT worker threads [0]\n");
-    fprintf(stderr, "        --write-index                 Automatically index the output files [off]\n");
+    fprintf(stderr, "        --write-index[=FMT]           Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -3532,7 +3534,7 @@ int main_vcfmerge(int argc, char *argv[])
         {"force-no-index",no_argument,NULL,10},
         {"force-single",no_argument,NULL,12},
         {"filter-logic",required_argument,NULL,'F'},
-        {"write-index",no_argument,NULL,11},
+        {"write-index",optional_argument,NULL,11},
         {NULL,0,NULL,0}
     };
     char *tmp;
@@ -3611,7 +3613,10 @@ int main_vcfmerge(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 10 : args->no_index = 1; break;
-            case 11 : args->write_index = 1; break;
+            case 11 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 12 : args->force_single = 1; break;
             case 'h':
             case '?': usage(); break;

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -2271,7 +2271,9 @@ static void normalize_vcf(args_t *args)
         hts_set_opt(args->out, HTS_OPT_THREAD_POOL, args->files->p);
     if (args->record_cmd_line) bcf_hdr_append_version(args->out_hdr, args->argc, args->argv, "bcftools_norm");
     if ( bcf_hdr_write(args->out, args->out_hdr)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(args->out,args->out_hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(args->out,args->out_hdr,args->output_fname,
+                     &args->index_fn, args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
 
     while (1)
     {
@@ -2359,7 +2361,7 @@ static void usage(void)
     fprintf(stderr, "        --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n");
     fprintf(stderr, "        --threads INT               Use multithreading with INT worker threads [0]\n");
     fprintf(stderr, "    -w, --site-win INT              Buffer for sorting lines which changed position during realignment [1000]\n");
-    fprintf(stderr, "        --write-index               Automatically index the output files [off]\n");
+    fprintf(stderr, "        --write-index[=FMT]         Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "   # normalize and left-align indels\n");
@@ -2422,7 +2424,7 @@ int main_vcfnorm(int argc, char *argv[])
         {"check-ref",required_argument,NULL,'c'},
         {"strict-filter",no_argument,NULL,'s'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",no_argument,NULL,14},
+        {"write-index",optional_argument,NULL,14},
         {NULL,0,NULL,0}
     };
     char *tmp;
@@ -2447,7 +2449,10 @@ int main_vcfnorm(int argc, char *argv[])
                 else if ( optarg[0]=='.' ) args->ma_use_ref_allele = 0;
                 else error("Invalid argument to --multi-overlaps\n");
                 break;
-            case 14 : args->write_index = 1; break;
+            case 14 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 15 : args->right_align = 1; break;
             case 'N': args->do_indels = 0; break;
             case 'd':

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -2361,7 +2361,7 @@ static void usage(void)
     fprintf(stderr, "        --targets-overlap 0|1|2     Include if POS in the region (0), record overlaps (1), variant overlaps (2) [0]\n");
     fprintf(stderr, "        --threads INT               Use multithreading with INT worker threads [0]\n");
     fprintf(stderr, "    -w, --site-win INT              Buffer for sorting lines which changed position during realignment [1000]\n");
-    fprintf(stderr, "        --write-index[=FMT]         Automatically index the output files [off]\n");
+    fprintf(stderr, "    -W, --write-index[=FMT]         Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Examples:\n");
     fprintf(stderr, "   # normalize and left-align indels\n");
@@ -2424,11 +2424,11 @@ int main_vcfnorm(int argc, char *argv[])
         {"check-ref",required_argument,NULL,'c'},
         {"strict-filter",no_argument,NULL,'s'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,14},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "hr:R:f:w:Dd:o:O:c:m:t:T:sNag:",loptions,NULL)) >= 0) {
+    while ((c = getopt_long(argc, argv, "hr:R:f:w:Dd:o:O:c:m:t:T:sNag:W::",loptions,NULL)) >= 0) {
         switch (c) {
             case  10:
                 // possibly generalize this also to INFO/AD and other tags
@@ -2449,7 +2449,7 @@ int main_vcfnorm(int argc, char *argv[])
                 else if ( optarg[0]=='.' ) args->ma_use_ref_allele = 0;
                 else error("Invalid argument to --multi-overlaps\n");
                 break;
-            case 14 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfplugin.c
+++ b/vcfplugin.c
@@ -615,7 +615,7 @@ static void usage(args_t *args)
     fprintf(stderr, "   -l, --list-plugins             List available plugins. See BCFTOOLS_PLUGINS environment variable and man page for details\n");
     fprintf(stderr, "   -v, --verbose                  Print verbose information, -vv increases verbosity\n");
     fprintf(stderr, "   -V, --version                  Print version string and exit\n");
-    fprintf(stderr, "       --write-index[=FMT]        Automatically index the output files [off]\n");
+    fprintf(stderr, "   -W, --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -693,11 +693,11 @@ int main_plugin(int argc, char *argv[])
         {"targets-file",required_argument,NULL,'T'},
         {"targets-overlap",required_argument,NULL,2},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,10},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "h?o:O:r:R:t:T:li:e:vV",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "h?o:O:r:R:t:T:li:e:vVW::",loptions,NULL)) >= 0)
     {
         switch (c) {
             case 'V': version_only = 1; break;
@@ -742,7 +742,7 @@ int main_plugin(int argc, char *argv[])
                 break;
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
-            case 10 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfsort.c
+++ b/vcfsort.c
@@ -302,7 +302,9 @@ void merge_blocks(args_t *args)
     set_wmode(wmode,args->output_type,args->output_fname,args->clevel);
     htsFile *out = hts_open(args->output_fname ? args->output_fname : "-", wmode);
     if ( bcf_hdr_write(out, args->hdr)!=0 ) clean_files_and_throw(args, "[%s] Error: cannot write to %s\n", __func__,args->output_fname);
-    if ( args->write_index && init_index(out,args->hdr,args->output_fname,&args->index_fn)<0 ) error("Error: failed to initialise index for %s\n",args->output_fname);
+    if ( init_index2(out,args->hdr,args->output_fname,&args->index_fn,
+                     args->write_index)<0 )
+        error("Error: failed to initialise index for %s\n",args->output_fname);
     while ( bhp->ndat )
     {
         blk_t *blk = bhp->dat[0];
@@ -344,7 +346,7 @@ static void usage(args_t *args)
 #else
     fprintf(stderr, "    -T, --temp-dir DIR             temporary files [/tmp/bcftools.XXXXXX]\n");
 #endif
-    fprintf(stderr, "        --write-index              Automatically index the output files [off]\n");
+    fprintf(stderr, "        --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -407,7 +409,7 @@ int main_sort(int argc, char *argv[])
         {"output-file",required_argument,NULL,'o'},
         {"output",required_argument,NULL,'o'},
         {"help",no_argument,NULL,'h'},
-        {"write-index",no_argument,NULL,1},
+        {"write-index",optional_argument,NULL,1},
         {0,0,0,0}
     };
     char *tmp;
@@ -436,7 +438,10 @@ int main_sort(int argc, char *argv[])
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  1 : args->write_index = 1; break;
+            case  1 :
+                if (!(args->write_index = write_index_parse(optarg)))
+                    error("Unsupported index format '%s'\n", optarg);
+                break;
             case 'h':
             case '?': usage(args); break;
             default: error("Unknown argument: %s\n", optarg);

--- a/vcfsort.c
+++ b/vcfsort.c
@@ -346,7 +346,7 @@ static void usage(args_t *args)
 #else
     fprintf(stderr, "    -T, --temp-dir DIR             temporary files [/tmp/bcftools.XXXXXX]\n");
 #endif
-    fprintf(stderr, "        --write-index[=FMT]        Automatically index the output files [off]\n");
+    fprintf(stderr, "    -W, --write-index[=FMT]        Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -409,11 +409,11 @@ int main_sort(int argc, char *argv[])
         {"output-file",required_argument,NULL,'o'},
         {"output",required_argument,NULL,'o'},
         {"help",no_argument,NULL,'h'},
-        {"write-index",optional_argument,NULL,1},
+        {"write-index",optional_argument,NULL,'W'},
         {0,0,0,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "m:T:O:o:h?",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "m:T:O:o:W::h?",loptions,NULL)) >= 0)
     {
         switch (c)
         {
@@ -438,7 +438,7 @@ int main_sort(int argc, char *argv[])
                           if ( *tmp || args->clevel<0 || args->clevel>9 ) error("Could not parse argument: --compression-level %s\n", optarg+1);
                       }
                       break;
-            case  1 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/vcfview.c
+++ b/vcfview.c
@@ -550,7 +550,7 @@ static void usage(args_t *args)
     fprintf(stderr, "    -u/U, --uncalled/--exclude-uncalled    Select/exclude sites without a called genotype\n");
     fprintf(stderr, "    -v/V, --types/--exclude-types LIST     Select/exclude comma-separated list of variant types: snps,indels,mnps,ref,bnd,other [null]\n");
     fprintf(stderr, "    -x/X, --private/--exclude-private      Select/exclude sites where the non-reference alleles are exclusive (private) to the subset samples\n");
-    fprintf(stderr, "          --write-index[=FMT]              Automatically index the output files [off]\n");
+    fprintf(stderr, "    -W,   --write-index[=FMT]              Automatically index the output files [off]\n");
     fprintf(stderr, "\n");
     exit(1);
 }
@@ -617,11 +617,11 @@ int main_vcfview(int argc, char *argv[])
         {"phased",no_argument,NULL,'p'},
         {"exclude-phased",no_argument,NULL,'P'},
         {"no-version",no_argument,NULL,8},
-        {"write-index",optional_argument,NULL,10},
+        {"write-index",optional_argument,NULL,'W'},
         {NULL,0,NULL,0}
     };
     char *tmp;
-    while ((c = getopt_long(argc, argv, "l:t:T:r:R:o:O:s:S:Gf:knv:V:m:M:aAuUhHc:C:Ii:e:xXpPq:Q:g:",loptions,NULL)) >= 0)
+    while ((c = getopt_long(argc, argv, "l:t:T:r:R:o:O:s:S:Gf:knv:V:m:M:aAuUhHc:C:Ii:e:xXpPq:Q:g:W::",loptions,NULL)) >= 0)
     {
         char allele_type[9] = "nref";
         switch (c)
@@ -750,7 +750,7 @@ int main_vcfview(int argc, char *argv[])
                 break;
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
-            case 10 :
+            case 'W':
                 if (!(args->write_index = write_index_parse(optarg)))
                     error("Unsupported index format '%s'\n", optarg);
                 break;

--- a/version.c
+++ b/version.c
@@ -112,27 +112,55 @@ int parse_overlap_option(const char *arg)
     else return -1;
 }
 
+// Used to set args->write_index in CLI.
+// It will be true if set correctly.
+// Note due to HTS_FMT_CSI being zero we have to use an additional bit.
+int write_index_parse(char *arg) {
+    int fmt = HTS_FMT_CSI;
+
+    if (arg) {
+        if (strcmp(arg, "csi") == 0)
+            fmt = HTS_FMT_CSI;
+        else if (strcmp(arg, "tbi") == 0)
+            fmt = HTS_FMT_TBI;
+        else
+            return 0;
+    }
+
+    return 128 | fmt;
+}
+
 // See also samtools/sam_utils.c auto_index()
-int init_index(htsFile *fh, bcf_hdr_t *hdr, const char *fname, char **idx_fname)
-{
-    int min_shift = 14; // CSI
+int init_index2(htsFile *fh, bcf_hdr_t *hdr, const char *fname,
+                char **idx_fname, int idx_fmt) {
+    // Nothing to do == success.  This simplifies the main code simpler.
+    if (!idx_fmt)
+        return 0;
+
+    int min_shift;
+    char *idx_suffix;
+
+    if (idx_fmt && (idx_fmt&127) == HTS_FMT_TBI && fh->format.format == vcf) {
+        min_shift = 0;  // TBI
+        idx_suffix = "tbi";
+    } else {
+        min_shift = 14; // CSI
+        idx_suffix = "csi";
+    }
 
     if ( !fname || !*fname || !strcmp(fname, "-") ) return -1;
 
     char *delim = strstr(fname, HTS_IDX_DELIM);
-    if (delim)
-    {
+    if (delim) {
         delim += strlen(HTS_IDX_DELIM);
         *idx_fname = strdup(delim);
         if ( !*idx_fname ) return -1;
 
         size_t l = strlen(*idx_fname);
         if ( l >= 4 && strcmp(*idx_fname + l - 4, ".tbi")==0 ) min_shift = 0;
-    }
-    else
-    {
+    } else {
         if ( !(*idx_fname = malloc(strlen(fname)+6)) ) return -1;
-        sprintf(*idx_fname, "%s.csi", fname);
+        sprintf(*idx_fname, "%s.%s", fname, idx_suffix);
     }
 
     if ( bcf_idx_init(fh, hdr, min_shift, *idx_fname) < 0 ) return -1;
@@ -140,4 +168,7 @@ int init_index(htsFile *fh, bcf_hdr_t *hdr, const char *fname, char **idx_fname)
     return 0;
 }
 
-
+int init_index(htsFile *fh, bcf_hdr_t *hdr, const char *fname, char **idx_fname)
+{
+    return init_index2(fh,hdr, fname, idx_fname, HTS_FMT_CSI);
+}

--- a/version.c
+++ b/version.c
@@ -119,9 +119,9 @@ int write_index_parse(char *arg) {
     int fmt = HTS_FMT_CSI;
 
     if (arg) {
-        if (strcmp(arg, "csi") == 0)
+        if (strcmp(arg, "csi") == 0 || strcmp(arg, "=csi") == 0)
             fmt = HTS_FMT_CSI;
-        else if (strcmp(arg, "tbi") == 0)
+        else if (strcmp(arg, "tbi") == 0 || strcmp(arg, "=tbi") == 0)
             fmt = HTS_FMT_TBI;
         else
             return 0;


### PR DESCRIPTION
This adds a new function `init_index2` with an additional index format field, which is set by another new function `write_index_parse`.  I could have modified the existing `init_index` function, but I was unsure if this is meant to be a public API or not.  Eg do people write their own plugins and use this?  If not, we could just rename it back.

The PR makes `--write-index` take an optional `--write-index[=FMT]` syntax, eg `--write-index=tbi`.  As this is a long option, the optional argument is easy to define.  (They don't work well on short opts, being space concious.)  The default of not specified =FMT is whatever the tool did before.  This is almost always CSI, except for isec which is TBI if VCF.  I don't know why that single command has a different default, but I didn't want to second guess the logic so I left it unchanged.

I tested all subcommands capable of writing indices, including plugins (although just fill-tags for the generic writing in plugin.c as it's shared by many).  I also fixed a number of bugs, not all index related.

- `bcftools +scatter -n 100 --write-index` only generated an index for ther last file.
- `bcftools isec --write-index` only worked when outputting a single file.  It now honours the write-index when running in directory mode too, but as mentioned above for some reason single-file isec was always tbi so I kept this behaviour intact.
- The malformed `bcftools filter -i 'type=INDEL'` no longer core dumps.  (The correct syntax is type="INDEL")

Fixes #2008