### PR TITLE
Remove -specs=...redhat-hardened... from Perl options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,11 @@ AS_IF([test "$enable_perl_filters" != "no" ], [dnl
         PERL_CCOPTS="`perl -MExtUtils::Embed -e ccopts | sed 's,-arch i386,,'`"
         PERL_LIBS="`perl -MExtUtils::Embed -e ldopts | sed 's,-arch i386,,'`"
     fi
+    AS_CASE([$PERL_LIBS],
+      [*redhat/redhat-hardened-ld*],[[
+        PERL_CCOPTS="`echo $PERL_CCOPTS | sed 's,-specs=[a-z/]*/redhat/redhat-hardened-[a-z0-9]* *,,g'`"
+        PERL_LIBS="`echo $PERL_LIBS | sed 's,-specs=[a-z/]*/redhat/redhat-hardened-[a-z0-9]* *,,g'`"]
+        AC_MSG_NOTICE([removing -specs=...redhat-hardened... from Perl options])])
     AC_SUBST([PERL_CCOPTS])
     AC_SUBST([PERL_LIBS])
 


### PR DESCRIPTION
As encountered in #1322, Red Hat's `ExtUtils::Embed` returns CLAGS & LDFLAGS that produce a PIE position-independent executable. However libhts.a and the rest of bcftools's *.o files are not compiled as PIC, so linking fails as these other object files use relocations that are invalid for PIE.

While bcftools could link against libhts.so and compile the rest of its objects with `-fpic`, the logistics are non-trivial. And frankly it's not really reasonable for `ExtUtils::Embed` to insist that other applications follow Perl/Red Hat's policy re PIE. So it's easier to omit the redhat-hardened-cc1 and redhat-hardened-ld specs that set up for building a PIE executable, and there is already precedent in _configure.ac_ to filter undesired options out of the `ExtUtils::Embed` output.