### PR TITLE
Fix typos on documentation in the gh-pages branch

### DIFF
--- a/howtos/FAQ.html
+++ b/howtos/FAQ.html
@@ -110,7 +110,7 @@ its definition in the header. For example, one may see an error like</p>
 </div>
 </div>
 <div class="paragraph">
-<p>The error above is printed when different number of values is encoutered, for example <code>AC=1</code> or <code>AC=1,1,1</code> in the example above.</p>
+<p>The error above is printed when different number of values is encountered, for example <code>AC=1</code> or <code>AC=1,1,1</code> in the example above.</p>
 </div>
 <div class="paragraph">
 <p>Other such definitions are <code>Number=R</code> (there must be as many values as there are REF+ALT alleles in total),

--- a/howtos/FAQ.txt
+++ b/howtos/FAQ.txt
@@ -20,7 +20,7 @@ and expects a value for each ALT allele, for example
 ----
 chr1  64334  .  A  C,T  .  .  AC=1,1  GT  0/1  0/1
 ----
-The error above is printed when different number of values is encoutered, for example `AC=1` or `AC=1,1,1` in the example above.
+The error above is printed when different number of values is encountered, for example `AC=1` or `AC=1,1,1` in the example above.
 
 Other such definitions are `Number=R` (there must be as many values as there are REF+ALT alleles in total),
 and `Number=G` (this is more complicated, see the section 1.4.2 of the link:http://samtools.github.io/hts-specs/VCFv4.3.pdf[VCF specification]).

--- a/howtos/bcftools.txt
+++ b/howtos/bcftools.txt
@@ -408,7 +408,7 @@ Add or remove annotations.
 
     # Annotate from a tab-delimited file with regions (1-based coordinates, inclusive)
     tabix -s1 -b2 -e3 annots.tab.gz 
-    bcftools annotate -a annots.tab.gz -h annots.hdr -c CHROM,FROM,TO,TAG inut.vcf
+    bcftools annotate -a annots.tab.gz -h annots.hdr -c CHROM,FROM,TO,TAG input.vcf
 
     # Annotate from a bed file (0-based coordinates, half-closed, half-open intervals)
     bcftools annotate -a annots.bed.gz -h annots.hdr -c CHROM,FROM,TO,TAG input.vcf
@@ -1022,7 +1022,7 @@ See the usage examples below.
     #   %TBCSQ    .. print consequences in both haplotypes in separate columns
     #   %TBCSQ{0} .. print the first haplotype only
     #   %TBCSQ{1} .. print the second haplotype only
-    #   %TBCSQ{*} .. print a list of unique consquences present in either haplotype
+    #   %TBCSQ{*} .. print a list of unique consequences present in either haplotype
     bcftools query -f'[%CHROM\t%POS\t%SAMPLE\t%TBCSQ\n]' out.bcf
 ----
 
@@ -2069,7 +2069,7 @@ Extracts fields from VCF or BCF files and outputs them in user-defined format.
     %SAMPLE         Sample name
     %POS0           POS in 0-based coordinates
     %END            End position of the REF allele
-    %END0           End position of the REF allele in 0-based cordinates
+    %END0           End position of the REF allele in 0-based coordinates
     \n              new line
     \t              tab character
 

--- a/howtos/cnv-calling.html
+++ b/howtos/cnv-calling.html
@@ -181,7 +181,7 @@ variation. The command is</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>bcftools cnv -c conrol_sample -s query_sample -o outdir/ -p 0 file.vcf</pre>
+<pre>bcftools cnv -c control_sample -s query_sample -o outdir/ -p 0 file.vcf</pre>
 </div>
 </div>
 <div class="paragraph">

--- a/howtos/cnv-calling.txt
+++ b/howtos/cnv-calling.txt
@@ -81,7 +81,7 @@ differences between two samples. This greatly helps to reduce the number of
 false calls and also allows one to distinguish between normal and novel copy number
 variation. The command is
 ----
-bcftools cnv -c conrol_sample -s query_sample -o outdir/ -p 0 file.vcf 
+bcftools cnv -c control_sample -s query_sample -o outdir/ -p 0 file.vcf 
 ----
 The ``-p 0`` option tells the program to automatically call matplotlib and
 produce plots like the one in this example:

--- a/howtos/index.html
+++ b/howtos/index.html
@@ -97,7 +97,7 @@ it and sending a pull request or by opening an issue on
 <p>BCFtools is  a program for variant calling and manipulating files in the
 Variant Call Format (VCF) and its binary counterpart BCF. All commands work
 transparently with both VCFs and BCFs, both uncompressed and BGZF-compressed.
-In order to avoid tedious repetion, throughout this document we will use
+In order to avoid tedious repetition, throughout this document we will use
 "VCF" and "BCF" interchangeably, unless specifically noted.</p>
 </div>
 <div class="paragraph">

--- a/howtos/index.txt
+++ b/howtos/index.txt
@@ -15,7 +15,7 @@ https://github.com/samtools/bcftools/issues[github].
 BCFtools is  a program for variant calling and manipulating files in the
 Variant Call Format (VCF) and its binary counterpart BCF. All commands work
 transparently with both VCFs and BCFs, both uncompressed and BGZF-compressed.
-In order to avoid tedious repetion, throughout this document we will use
+In order to avoid tedious repetition, throughout this document we will use
 "VCF" and "BCF" interchangeably, unless specifically noted.
 
 Most commands accept VCF, bgzipped VCF and BCF with filetype detected

--- a/howtos/plugin.fixref.html
+++ b/howtos/plugin.fixref.html
@@ -155,7 +155,7 @@ bcftools sort fixref.bcf -Ob -o fixref.sorted.bcf</pre>
 </div>
 <div class="paragraph">
 <p>In the most extreme case when nothing else is working, one can simply force
-the unambigous alleles onto the forward strand and drop the ambigous genotypes.</p>
+the unambiguous alleles onto the forward strand and drop the ambiguous genotypes.</p>
 </div>
 <div class="listingblock">
 <div class="content">

--- a/howtos/plugin.fixref.txt
+++ b/howtos/plugin.fixref.txt
@@ -54,7 +54,7 @@ bcftools sort fixref.bcf -Ob -o fixref.sorted.bcf
 
 
 In the most extreme case when nothing else is working, one can simply force
-the unambigous alleles onto the forward strand and drop the ambigous genotypes.
+the unambiguous alleles onto the forward strand and drop the ambiguous genotypes.
 ----
 bcftools +fixref test.bcf -Ob -o output.bcf -- -f ref.fa -m flip -d
 ----

--- a/howtos/query.html
+++ b/howtos/query.html
@@ -111,7 +111,7 @@ For a full list of options, see the <a href="../bcftools.html#query">manual page
 </div>
 </div>
 <div class="paragraph">
-<p>In this example, the <code>-f</code> otion defines the output format. The <code>%POS</code> string
+<p>In this example, the <code>-f</code> option defines the output format. The <code>%POS</code> string
 indicates that for each VCF line we want the POS column printed. The <code>\n</code>
 stands for a newline character, a notation commonly used in the
 world of computer programming. Any characters without a special meaning

--- a/howtos/query.txt
+++ b/howtos/query.txt
@@ -25,7 +25,7 @@ bcftools query -l file.bcf | wc -l
 ----
 bcftools query -f '%POS\n' file.bcf
 ----
-In this example, the `-f` otion defines the output format. The `%POS` string
+In this example, the `-f` option defines the output format. The `%POS` string
 indicates that for each VCF line we want the POS column printed. The `\n` 
 stands for a newline character, a notation commonly used in the
 world of computer programming. Any characters without a special meaning

--- a/howtos/roh-calling.html
+++ b/howtos/roh-calling.html
@@ -230,7 +230,7 @@ program.  For example in this run many sites were filtered:</p>
 </div>
 </div>
 <div class="paragraph">
-<p>If the number of the processed sites is too low, check what was the reason for exluding
+<p>If the number of the processed sites is too low, check what was the reason for excluding
 them. This command should give the number of sites that were processed:</p>
 </div>
 <div class="listingblock">

--- a/howtos/roh-calling.txt
+++ b/howtos/roh-calling.txt
@@ -148,7 +148,7 @@ program.  For example in this run many sites were filtered:
 Number of lines: total/processed: 599218/37730
 ----
 
-If the number of the processed sites is too low, check what was the reason for exluding
+If the number of the processed sites is too low, check what was the reason for excluding 
 them. This command should give the number of sites that were processed:
 
 ----


### PR DESCRIPTION
I ran the typos-cli tool (https://github.com/crate-ci/typos/tree/master/src/bin/typos-cli) over the docs in the gh-pages branch after seeing a typo on the webpage. 

To my knowledge, the gh-pages branch is manually maintained separate from the develop branch (e.g. the docs aren't on the develop branch) so this PR targets the gh-pages branch 