### PR TITLE
Fix bug in vcfnorm's strdup_alt_svlen()

### DIFF
--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -2028,7 +2028,10 @@ static char *strdup_alt_svlen(args_t *args, bcf1_t *rec, int ial)
 {
     if ( rec->d.allele[ial][0]!='<' ) return strdup(rec->d.allele[ial]);
 
-    int n = bcf_get_info_int32(args->hdr, rec, "SVLEN", &args->tmp_arr1, &args->ntmp_arr1);
+    int ntmp = args->ntmp_arr1 / sizeof(int32_t);
+    int n = bcf_get_info_int32(args->hdr, rec, "SVLEN", &args->tmp_arr1, &ntmp);
+    args->ntmp_arr1 = ntmp * sizeof(int32_t);
+    int32_t *svlen = (int32_t *) args->tmp_arr1;
     if ( n<=0 ) return strdup(rec->d.allele[ial]);
 
     if ( n+1 != rec->n_allele )
@@ -2043,7 +2046,7 @@ static char *strdup_alt_svlen(args_t *args, bcf1_t *rec, int ial)
     }
 
     kstring_t str = {0,0,0};
-    ksprintf(&str,"%s.%d",rec->d.allele[ial],args->tmp_arr1[ial-1]);
+    ksprintf(&str,"%s.%d",rec->d.allele[ial],svlen[ial-1]);
     return str.s;
 }
 static void cmpals_add(args_t *args, cmpals_t *ca, bcf1_t *rec)


### PR DESCRIPTION
Read SVLEN as four bytes of `int32_t` rather than just one byte. Previously the returned string's `%d` was formatted with a value representing only the first 8 bits of the full 32-bit SVLEN value.

Fixes a bug recently introduced in 6d53540567e0241ebb53c723e1352c71d571ca46. This was returning strings like `<DEL>.24` instead of `<DEL>.-1000` on little endian machines. On big-endian machines, it was returning `<DEL>.255` for all of -1000, -2000, -3000, leading to test case failures.