### PR TITLE
Fix a trivial undefined behaviour sanitizer issue.

### DIFF
--- a/vcfstats.c
+++ b/vcfstats.c
@@ -408,7 +408,8 @@ static void init_user_stats(args_t *args, bcf_hdr_t *hdr, stats_t *stats)
 {
     stats->nusr = args->nusr;
     stats->usr = (user_stats_t*)malloc(sizeof(user_stats_t)*args->nusr);
-    memcpy(stats->usr,args->usr,args->nusr*sizeof(user_stats_t));
+    if (args->nusr)
+        memcpy(stats->usr,args->usr,args->nusr*sizeof(user_stats_t));
     int i;
     for (i=0; i<stats->nusr; i++)
     {


### PR DESCRIPTION
Memcpy strictly forbids passing in NULL as an argument, even when the size of data to copy is 0.  It works on our systems and quite likely on everybodies, and the compiler is highly unlikely to be able to optimise this away ever as it's user-data driven.  However this is the only place in the entire test harness that hits clang's ubsan, clearing the way to potentially adding it to CI at some point.