### PR TITLE
Prevent bcftools sort from opening too many temporary files, and make it stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ vcfroh.o: vcfroh.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kstrin
 vcfcnv.o: vcfcnv.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_kstring_h) $(htslib_kfunc_h) $(htslib_khash_str2int_h) $(bcftools_h) HMM.h rbuf.h
 vcfhead.o: vcfhead.c $(htslib_kstring_h) $(htslib_vcf_h) $(bcftools_h)
 vcfsom.o: vcfsom.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(bcftools_h)
-vcfsort.o: vcfsort.c $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_hts_os_h) kheap.h $(bcftools_h)
+vcfsort.o: vcfsort.c $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_hts_os_h) $(htslib_bgzf_h) kheap.h $(bcftools_h)
 vcfstats.o: vcfstats.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(htslib_faidx_h) $(bcftools_h) $(filter_h) bin.h dist.h
 vcfview.o: vcfview.c $(htslib_vcf_h) $(htslib_synced_bcf_reader_h) $(htslib_vcfutils_h) $(bcftools_h) $(filter_h) $(htslib_khash_str2int_h) $(htslib_kbitset_h)
 reheader.o: reheader.c $(htslib_vcf_h) $(htslib_bgzf_h) $(htslib_tbx_h) $(htslib_kseq_h) $(htslib_thread_pool_h) $(htslib_faidx_h) $(htslib_khash_str2int_h) $(bcftools_h) $(khash_str2str_h)

--- a/vcfsort.c
+++ b/vcfsort.c
@@ -41,6 +41,7 @@
 #include <htslib/vcf.h>
 #include <htslib/kstring.h>
 #include <htslib/hts_os.h>
+#include <htslib/bgzf.h>
 #include "kheap.h"
 #include "bcftools.h"
 
@@ -52,10 +53,22 @@ typedef struct
 {
     char *fname;
     htsFile *fh;
+    BGZF *bgz;
     size_t idx;
     bcf1_t *rec;
+    int is_merged;
 }
 blk_t;
+
+typedef struct
+{
+    size_t len;
+    hts_pos_t pos;
+    int rid;
+    float qual;
+    uint8_t data[];
+}
+packed_bcf_t;
 
 typedef struct _args_t
 {
@@ -63,7 +76,7 @@ typedef struct _args_t
     char **argv, *fname, *output_fname, *tmp_dir;
     int argc, output_type, clevel;
     size_t max_mem, mem;
-    bcf1_t **buf;
+    packed_bcf_t **buf;
     uint8_t *mem_block;
 
     size_t nbuf, mbuf, nblk, tmp_count;
@@ -133,94 +146,280 @@ int cmp_bcf_pos_ref_alt(const void *aptr, const void *bptr)
     if ( a->n_allele < b->n_allele ) return -1;
     return 0;
 }
-static int cmp_bcf_pos_ref_alt_stable(const void *aptr, const void *bptr)
+
+static int cmp_packed_bcf_pos_ref_alt(const void *aptr, const void *bptr)
+{
+    packed_bcf_t *a = *(packed_bcf_t **) aptr;
+    packed_bcf_t *b = *(packed_bcf_t **) bptr;
+
+    if ( a->rid < b->rid ) return -1;
+    if ( a->rid > b->rid ) return 1;
+    if ( a->pos < b->pos ) return -1;
+    if ( a->pos > b->pos ) return 1;
+    
+    // Sort lexicographically by ref,alt.  These are stored tab-separated
+    // as the first item in packed_bcf_t::data
+    return strcmp((char *) a->data, (char *) b->data);
+}
+
+static int cmp_packed_bcf_pos_ref_alt_stable(const void *aptr, const void *bptr)
 {
     // cmp_bcf_pos_ref_alt() with tie-breaker to make qsort stable
-    int res = cmp_bcf_pos_ref_alt(aptr, bptr);
+    int res = cmp_packed_bcf_pos_ref_alt(aptr, bptr);
     if (res != 0) return res;
 
     // Got a tie - use the position in the original input to break it.
     // As everything is read into a big memory buffer, for most records
     // we can just compare the pointers directly.  The exception is
     // any record that didn't quite fit in the memory buffer, causing it to be
-    // flushed.  Those are flagged by setting bcf1_t::errcode == -1, and
-    // as they were the last record in the segment, they should always go
-    // at the end.
+    // flushed.  Those are flagged by setting packed_bcf_t::len = SIZE_MAX, and
+    // as they were the last record in the segment, they should always sort
+    // after unflagged records.
 
-    bcf1_t *a = *((bcf1_t**)aptr);
-    bcf1_t *b = *((bcf1_t**)bptr);
-    if (a->errcode == -1) return 1;
-    if (b->errcode == -1) return -1;
+    packed_bcf_t *a = *(packed_bcf_t **) aptr;
+    packed_bcf_t *b = *(packed_bcf_t **) bptr;
+
+    if (a->len == SIZE_MAX) return 1;
+    if (b->len == SIZE_MAX) return -1;
 
     return a < b ? -1 : 1;
 }
-htsFile * open_tmp_file(args_t *args, char **fname_out, size_t *idx_out)
+
+static uint8_t *pack_unsigned(uint8_t *data, uint64_t val)
 {
-    htsFile *fh = NULL;
+    do {
+        *data++ = (val & 0x7f) | ((val > 0x7f) ? 0x80 : 0);
+        val >>= 7;
+    } while (val > 0);
+    return data;    
+}
+
+static uint8_t *pack_hts_pos(uint8_t *data, hts_pos_t val)
+{
+    uint64_t sign = val < 0;
+    uint64_t v = val < 0 ? -(val + 1) : val;
+    v = v << 1 | sign;
+    return pack_unsigned(data, v);
+}
+
+static uint8_t *pack_bcf_data(packed_bcf_t *dest, const bcf1_t *src,
+                              int outside_buffer)
+{
+    uint32_t i;
+    uint8_t *data = dest->data;
+    uint8_t *start = dest->data;
+    dest->pos = src->pos;
+    dest->rid = src->rid;
+    dest->qual = src->qual;
+
+    // Copy in alleles, for the comparison function
+    for (i = 0; i < src->n_allele; i++)
+    {
+        size_t l = strlen(src->d.allele[i]);
+        if (i > 0) *data++ = '\t';
+        memcpy(data, src->d.allele[i], l);
+        data += l;
+    }
+    *data++ = '\0';
+
+    if (outside_buffer)
+    {
+        dest->len = SIZE_MAX;
+        memcpy(data, &src, sizeof(src));
+        data += sizeof(src);
+        return data;
+    }
+
+    data = pack_hts_pos(data, src->rlen);
+    data = pack_unsigned(data, src->n_info);
+    data = pack_unsigned(data, src->n_allele);
+    data = pack_unsigned(data, src->n_fmt);
+    data = pack_unsigned(data, src->n_sample);
+    data = pack_unsigned(data, src->shared.l);
+    data = pack_unsigned(data, src->indiv.l);
+    if (src->shared.l)
+        memcpy(data, src->shared.s, src->shared.l);
+    data += src->shared.l;
+    if (src->indiv.l)
+        memcpy(data, src->indiv.s, src->indiv.l);
+    data += src->indiv.l;
+    dest->len = data - start;
+    return data;
+}
+
+static int write_packed_bcf(BGZF *fp, packed_bcf_t *src)
+{
+    // Write pos, rid, qual
+    size_t len = src->data - (uint8_t *) &src->pos;
+    if (bgzf_write_small(fp, &src->pos, len) < len)
+        return -1;
+
+    // Skip the copy of the alleles
+    size_t skip = strlen((char *) src->data) + 1;
+ 
+    // Write everything else
+    if (src->len < SIZE_MAX)
+    {
+        // In main memory block
+        len = src->len - skip;
+        if (bgzf_write_small(fp, src->data + skip, len) < len)
+            return -1;
+    }
+    else
+    {
+        // Record didn't fit in the main block.  To minimize the
+        // overflow, its packed_bcf_t data will be imcomplete.  A pointer to
+        // its bcf1_t struct will have been placed after the allele data
+        // so we can finish the packing job and write it in the same format
+        // the rest of the data
+        bcf1_t *rec;
+        uint8_t tmp[100], *data = tmp;
+        memcpy(&rec, src->data + skip, sizeof(rec));
+
+        data = pack_hts_pos(data, rec->rlen);
+        data = pack_unsigned(data, rec->n_info);
+        data = pack_unsigned(data, rec->n_allele);
+        data = pack_unsigned(data, rec->n_fmt);
+        data = pack_unsigned(data, rec->n_sample);
+        data = pack_unsigned(data, rec->shared.l);
+        data = pack_unsigned(data, rec->indiv.l);
+        if (bgzf_write_small(fp, tmp, data - tmp) < data - tmp)
+            return -1;
+        if (rec->shared.l > 0 &&
+            bgzf_write_small(fp, rec->shared.s, rec->shared.l) < rec->shared.l)
+            return -1;
+        if (rec->indiv.l > 0 &&
+            bgzf_write_small(fp, rec->indiv.s, rec->indiv.l) < rec->indiv.l)
+            return -1;
+    }
+
+    return 0;
+}
+
+static uint64_t unpack_unsigned(BGZF *fp, int *err)
+{
+    uint8_t data;
+    uint64_t val = 0;
+    uint32_t i = 0;
+
+    if (bgzf_read_small(fp, &data, sizeof(data)) <= 0)
+        goto short_read;
+
+    while (data & 0x80)
+    {
+        val |= (uint64_t)(data & 0x7f) << i;
+        i += 7;
+        if (bgzf_read_small(fp, &data, sizeof(data)) <= 0)
+            goto short_read;
+    }
+    val |= (uint64_t)data << i;
+    return val;
+
+ short_read:
+    *err = 1;
+    return 0;
+}
+
+static hts_pos_t unpack_hts_pos(BGZF *fp, int *err)
+{
+    uint64_t v = unpack_unsigned(fp, err);
+
+    if ((v & 1) == 0)
+        return (hts_pos_t)(v >> 1);
+    else
+        return -(hts_pos_t)(v >> 1) - 1;
+}
+
+static int read_packed_bcf(BGZF *fp, bcf1_t *dest)
+{
+    int err = 0;
+    packed_bcf_t tmp;
+    size_t len = tmp.data - (uint8_t *) &tmp.pos;
+    
+    bcf_clear(dest);
+    ssize_t got = bgzf_read_small(fp, &tmp.pos, len);
+    if (got == 0)
+        return -1;  // EOF
+    if (got < len)
+        return -2;  // Error or short read
+    dest->pos = tmp.pos;
+    dest->rid = tmp.rid;
+    dest->qual = tmp.qual;
+    dest->rlen = unpack_hts_pos(fp, &err);
+    dest->n_info = unpack_unsigned(fp, &err);
+    dest->n_allele = unpack_unsigned(fp, &err);
+    dest->n_fmt = unpack_unsigned(fp, &err);
+    dest->n_sample = unpack_unsigned(fp, &err);
+    len = unpack_unsigned(fp, &err);
+    if (ks_resize(&dest->shared, len) != 0)
+        return -2;
+    dest->shared.l = len;
+    len = unpack_unsigned(fp, &err);
+    if (ks_resize(&dest->indiv, len) != 0)
+        return -2;
+    dest->indiv.l = len;
+    err |= bgzf_read_small(fp, dest->shared.s, dest->shared.l) < dest->shared.l;
+    err |= bgzf_read_small(fp, dest->indiv.s, dest->indiv.l) < dest->indiv.l;
+    return err == 0 ? 0 : -2;
+}
+
+void open_tmp_file(args_t *args, blk_t *blk, int is_merged)
+{
     kstring_t str = {0,0,0};
     int tries = 1000;
 
+    blk->fh = NULL;
+    blk->bgz = NULL;
+
     do {
-        if (ksprintf(ks_clear(&str), "%s/%05zd.bcf",
-                     args->tmp_dir, args->tmp_count++) < 0) {
+        if (ksprintf(ks_clear(&str), "%s/%05zd%s",
+                     args->tmp_dir, args->tmp_count++,
+                     is_merged ? ".bcf" : "") < 0) {
             clean_files_and_throw(args, "%s", strerror(errno));
         }
 
-        fh = hts_open(str.s, "wbx1");
-        if ( fh == NULL && (errno != EEXIST || --tries <= 0)) {
+        if (is_merged)
+            blk->fh = hts_open(str.s, "wbx1");
+        else
+            blk->bgz = bgzf_open(str.s, "wx1");
+        if ( blk->fh == NULL && blk->bgz == NULL && (errno != EEXIST || --tries <= 0)) {
             clean_files_and_throw(args, "Cannot write %s: %s\n",
                                   str.s, strerror(errno));
         }
-    } while (fh == NULL);
+    } while (blk->fh == NULL && blk->bgz == NULL);
 
-    *fname_out = ks_release(&str);
-    *idx_out = args->tmp_count - 1;
-
-    return fh;
+    blk->fname = ks_release(&str);
+    blk->idx = args->tmp_count - 1;
 }
 
 void do_partial_merge(args_t *args);
 
 void buf_flush(args_t *args, bcf1_t *last_rec)
 {
-    int errcode_copy;
-
     if ( !args->nbuf ) return;
 
-    if (last_rec) {
-        // If the last record isn't in the big memory buffer, it needs to
-        // be flagged so the comparison function handles it correctly
-        // ( See cmp_bcf_pos_ref_alt_stable() ).  Borrow the errcode field
-        // to do this.  It should never be set to -1, so we can use that as
-        // a sentinel.
-        errcode_copy = last_rec->errcode;
-        last_rec->errcode = -1;
-    }
-
-    qsort(args->buf, args->nbuf, sizeof(*args->buf), cmp_bcf_pos_ref_alt_stable);
-
-    if (last_rec)
-        last_rec->errcode = errcode_copy;
+    qsort(args->buf, args->nbuf, sizeof(*args->buf), cmp_packed_bcf_pos_ref_alt_stable);
 
     if (args->tmp_layers[0] >= MAX_TMP_FILES_PER_LAYER)
         do_partial_merge(args);
 
     assert(args->nblk < MAX_TMP_FILES);
     blk_t *blk = &args->blk[args->nblk];
+    blk->is_merged = 0;
     args->nblk++;
     args->tmp_layers[0]++;
 
-    assert(blk->fname == NULL && blk->fh == NULL);
+    assert(blk->fname == NULL && blk->fh == NULL && blk->bgz == NULL);
 
-    htsFile *fh = open_tmp_file(args, &blk->fname, &blk->idx);
-    if ( bcf_hdr_write(fh, args->hdr)!=0 ) clean_files_and_throw(args, "[%s] Error: cannot write to %s\n", __func__,blk->fname);
-
+    open_tmp_file(args, blk, 0);
     int i;
     for (i=0; i<args->nbuf; i++)
     {
-        if ( bcf_write(fh, args->hdr, args->buf[i])!=0 ) clean_files_and_throw(args, "[%s] Error: cannot write to %s\n", __func__,blk->fname);
+        if ( write_packed_bcf(blk->bgz, args->buf[i])!=0 ) clean_files_and_throw(args, "[%s] Error: cannot write to %s\n", __func__,blk->fname);
     }
-    if ( hts_close(fh)!=0 ) clean_files_and_throw(args, "[%s] Error: close failed .. %s\n", __func__,blk->fname);
+
+    if ( bgzf_close(blk->bgz)!=0 ) clean_files_and_throw(args, "[%s] Error: close failed .. %s\n", __func__,blk->fname);
+    blk->bgz = NULL;
 
     args->nbuf = 0;
     args->mem  = 0;
@@ -232,19 +431,38 @@ static inline uint8_t *_align_up(uint8_t *ptr)
     return (uint8_t*)(((size_t)ptr + 8 - 1) & ~((size_t)(8 - 1)));
 }
 
+#define varint_size(X) ((sizeof(X) * 8 + 7) / 7) // worst case
+
 void buf_push(args_t *args, bcf1_t *rec)
 {
-    size_t delta = sizeof(bcf1_t) + rec->shared.l + rec->indiv.l + rec->unpack_size[0] + rec->unpack_size[1]
-        + sizeof(*rec->d.allele)*rec->d.m_allele
-        + sizeof(bcf1_t*)       // args->buf
+    size_t delta = sizeof(rec->pos)
+        + sizeof(rec->rid)
+        + sizeof(rec->qual)
+        + varint_size(rec->rlen)
+        + varint_size(2) // n_info
+        + varint_size(2) // n_allele
+        + varint_size(1) // n_fmt
+        + varint_size(3) // n_sample
+        + varint_size(rec->shared.l)
+        + varint_size(rec->indiv.l)
+        + rec->shared.l + rec->indiv.l
+        + rec->unpack_size[1]   // Alleles
         + 8;                    // the number of _align_up() calls
 
     if ( delta > args->max_mem - args->mem )
     {
+        packed_bcf_t *tmp = malloc(sizeof(*tmp) + rec->unpack_size[1] * sizeof(bcf1_t *));
+        if (!tmp)
+            clean_files_and_throw(args, "[%s] Out of memory\n", __func__);
+        pack_bcf_data(tmp, rec, 1);
+
         args->nbuf++;
         hts_expand(bcf1_t*, args->nbuf, args->mbuf, args->buf);
-        args->buf[args->nbuf-1] = rec;
+        args->buf[args->nbuf-1] = tmp;
+
         buf_flush(args, rec);
+
+        free(tmp);
         bcf_destroy(rec);
         return;
     }
@@ -254,48 +472,13 @@ void buf_push(args_t *args, bcf1_t *rec)
 
     uint8_t *ptr_beg = args->mem_block + args->mem;
     uint8_t *ptr = _align_up(ptr_beg);
-    bcf1_t *new_rec = (bcf1_t*)ptr;
-    memcpy(new_rec,rec,sizeof(*rec));
-    ptr += sizeof(*rec);
+    packed_bcf_t *packed_rec = (packed_bcf_t *) ptr;
 
-    // The array of allele pointers does not need alignment as bcf1_t is already padded to the biggest
-    // data type in the structure
-    char **allele = (char**)ptr;
-    ptr += rec->n_allele*sizeof(*allele);
-
-    // This is just to prevent valgrind from complaining about memcpy, unpack_size is a high-water mark
-    // and the end may be uninitialized
-    delta = rec->d.allele[rec->n_allele-1] - rec->d.allele[0];
-    while ( delta < rec->unpack_size[1] ) if ( !rec->d.als[delta++] ) break;
-    memcpy(ptr,rec->d.als,delta);
-    new_rec->d.als = (char*)ptr;
-    ptr = ptr + delta;
-
-    int i;
-    for (i=0; i<rec->n_allele; i++) allele[i] = new_rec->d.als + (ptrdiff_t)(rec->d.allele[i] - rec->d.allele[0]);
-    new_rec->d.allele = allele;
-
-    memcpy(ptr,rec->shared.s,rec->shared.l);
-    new_rec->shared.s = (char*)ptr;
-    new_rec->shared.m = rec->shared.l;
-    ptr += rec->shared.l;
-
-    memcpy(ptr,rec->indiv.s,rec->indiv.l);
-    new_rec->indiv.s = (char*)ptr;
-    new_rec->indiv.m = rec->indiv.l;
-    ptr += rec->indiv.l;
-
-    // This is just to prevent valgrind from complaining about memcpy, unpack_size is a high-water mark
-    // and the end may be uninitialized
-    i = 0;
-    while ( i < rec->unpack_size[0] ) if ( !rec->d.id[i++] ) break;
-    memcpy(ptr,rec->d.id,i);
-    new_rec->d.id = (char*)ptr;
-    ptr += i;
+    ptr = pack_bcf_data(packed_rec, rec, 0);
 
     args->nbuf++;
     hts_expand(bcf1_t*, args->nbuf, args->mbuf, args->buf);
-    args->buf[args->nbuf-1] = new_rec;
+    args->buf[args->nbuf-1] = packed_rec;
 
     delta = ptr - ptr_beg;
     args->mem += delta;
@@ -345,14 +528,33 @@ KHEAP_INIT(blk, blk_t*, blk_is_smaller)
 
 void blk_read(args_t *args, khp_blk_t *bhp, bcf_hdr_t *hdr, blk_t *blk)
 {
-    if ( !blk->fh ) return;
-    int ret = bcf_read(blk->fh, hdr, blk->rec);
+    int ret;
+    if (blk->is_merged)
+    {
+        if ( !blk->fh ) return;
+        ret = bcf_read(blk->fh, hdr, blk->rec);
+    }
+    else
+    {
+        if ( !blk->bgz ) return;
+        ret = read_packed_bcf(blk->bgz, blk->rec);
+    }
     if ( ret < -1 ) clean_files_and_throw(args, "Error reading %s\n", blk->fname);
     if ( ret == -1 )
     {
-        if ( hts_close(blk->fh)!=0 ) clean_files_and_throw(args, "Close failed: %s\n", blk->fname);
-        blk->fh = 0;
-        return;
+        if (blk->is_merged)
+        {
+            if ( hts_close(blk->fh)!=0 ) clean_files_and_throw(args, "Close failed: %s\n", blk->fname);
+            blk->fh = NULL;
+            return;
+        }
+        else
+        {
+            if ( bgzf_close(blk->bgz) != 0)
+                clean_files_and_throw(args, "Close failed: %s\n", blk->fname);
+            blk->bgz = NULL;
+            return;
+        }
     }
     bcf_unpack(blk->rec, BCF_UN_STR);
     khp_insert(blk, bhp, &blk);
@@ -368,10 +570,19 @@ void merge_blocks(args_t *args, htsFile *out, const char *output_fname,
     for (i=from; i<args->nblk; i++)
     {
         blk_t *blk = &args->blk[i];
-        blk->fh = hts_open(blk->fname, "r");
-        if ( !blk->fh ) clean_files_and_throw(args, "Could not read %s: %s\n", blk->fname, strerror(errno));
-        bcf_hdr_t *hdr = bcf_hdr_read(blk->fh);
-        bcf_hdr_destroy(hdr);
+        if (blk->is_merged)
+        {
+            blk->fh = hts_open(blk->fname, "r");
+            if ( !blk->fh ) clean_files_and_throw(args, "Could not read %s: %s\n", blk->fname, strerror(errno));
+            bcf_hdr_t *hdr = bcf_hdr_read(blk->fh);
+            bcf_hdr_destroy(hdr);
+        }
+        else
+        {
+            blk->bgz = bgzf_open(blk->fname, "r");
+            if (!blk->bgz)
+                clean_files_and_throw(args, "Could not read %s: %s\n", blk->fname, strerror(errno));
+        }
         blk_read(args, bhp, args->hdr, blk);
     }
 
@@ -445,17 +656,18 @@ void do_partial_merge(args_t *args)
     }
 
     char *fname = NULL;
-    size_t blk_idx = 0;
-    htsFile *fh = open_tmp_file(args, &fname, &blk_idx);
-    merge_blocks(args, fh, fname, 0, args->nblk - to_merge);
-    if (hts_close(fh) != 0)
+    blk_t tmp = { NULL };
+    open_tmp_file(args, &tmp, 1);
+    merge_blocks(args, tmp.fh, tmp.fname, 0, args->nblk - to_merge);
+    if (hts_close(tmp.fh) != 0)
         clean_files_and_throw(args, "Close failed: %s\n", fname);
 
     args->nblk -= to_merge;
     assert(args->blk[args->nblk].fh == NULL);
     assert(args->blk[args->nblk].fname == NULL);
-    args->blk[args->nblk].idx = blk_idx;
-    args->blk[args->nblk++].fname = fname;
+    args->blk[args->nblk].is_merged = 1;
+    args->blk[args->nblk].idx = tmp.idx;
+    args->blk[args->nblk++].fname = tmp.fname;
     args->tmp_layers[to_layer]++;
 }
 


### PR DESCRIPTION
* Consolidate temporary files when they become two numerous

Consolidation happens in layers of up to `MAX_TMP_FILES_PER_LAYER` (32) files.  Files in full layers are merged into the next layer with a free slot.  This ensures the number of comparisons remains O(n log n) even if lots of merges have to be done.  The cost of doing this is the time needed to write and read back the data, and is in the worst case number of layers used * the size of the input.  The benefit is to avoid I/O thrashing due top too many files; or completely failing due to running out of file descriptors.

This also turns on compression for the temporary files.  There is a time penalty for this, but in testing it reduces the amount of storage needed by a factor of about four.

* Make bcftools sort stable, so ties always retain the ordering they had in the input file

Neither `qsort()` nor heap sort are guaranteed to be stable.  To ensure stability, add tie-breakers for `qsort()` based on the location in the memory buffer, and for heap sort based on the number of the input file records came from.

* Pack more records in memory when sorting

As bcf1_t is quite a big structure, it adds quite a lot of overhead if the records being sorted are small (e.g. single sample gVCF).  This overhead can be reduced by storing the data in a more compact form.  On a test file with approx. 61 characters per VCF line, up to four times as many records could be stored before having to spill them.