### PR TITLE
Fix a regression with -Ou format being the same as -Ob.

### DIFF
--- a/version.c
+++ b/version.c
@@ -88,7 +88,8 @@ void set_wmode(char dst[8], int file_type, const char *fname, int clevel)
     const char *end = fname ? strstr(fname, HTS_IDX_DELIM) : NULL;
     if ( !end ) end = fname ? fname + strlen(fname) : fname;
     int len = end - fname;
-    if ( len >= 4 && !strncasecmp(".bcf",fname+len-4,4) ) ret = hts_bcf_wmode(FT_BCF|FT_GZ);
+    if ( len >= 4 && !strncasecmp(".bcf",fname+len-4,4) )
+        ret = hts_bcf_wmode(file_type & FT_BCF ? file_type : FT_BCF|FT_GZ);
     else if ( len >= 4 && !strncasecmp(".vcf",fname+len-4,4) ) ret = hts_bcf_wmode(FT_VCF);
     else if ( len >= 7 && !strncasecmp(".vcf.gz",fname+len-7,7) ) ret = hts_bcf_wmode(FT_VCF|FT_GZ);
     else if ( len >= 8 && !strncasecmp(".vcf.bgz",fname+len-8,8) ) ret = hts_bcf_wmode(FT_VCF|FT_GZ);


### PR DESCRIPTION
Commit 30dbc3c broke the -Ou option when a filename is given. So `bcftools sort -Ou -o out.bcf in.vcf` is treated as `-Ob` instead.

Hence this was a regression in functionality that arrived with bcftools 1.12.  The fix is simply to honour Ou vs Ob even when filenames are specified, and only use the filename suffix when it's incompatible with the data type specified.

Fixes #2263