### PR TITLE
Work around an incompatibility between Perl and clang warnings.

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -45,6 +45,11 @@ THE SOFTWARE.  */
 #include "bcftools.h"
 
 #if ENABLE_PERL_FILTERS
+// Work around clang warning problems
+#  if defined(__clang__)
+#    define PERL_GCC_BRACE_GROUPS_FORBIDDEN
+#  endif
+
 #  define filter_t perl_filter_t
 #  include <EXTERN.h>
 #  include <perl.h>


### PR DESCRIPTION
A trivial issue, but with an equally trivial workaround.

Certain versions of perl trigger clang warnings about bracing:

    In file included from filter.c:55:
    ...
    /usr/lib/x86_64-linux-gnu/perl/5.34/CORE/zaphod32_hash.h:150:5: error: '(' and '{' tokens introducing statement expression appear in different macro expansion contexts [-Werror,-Wcompound-token-split-by-macro]
      150 |     ZAPHOD32_SCRAMBLE32(state[0],0x9fade23b);
          |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/lib/x86_64-linux-gnu/perl/5.34/CORE/zaphod32_hash.h:80:38: note: expanded from macro 'ZAPHOD32_SCRAMBLE32'
       80 | #define ZAPHOD32_SCRAMBLE32(v,prime) STMT_START {  \

The perl headers can optionally omit the use of "({ statement })" in macros, so we use this so we can do clang builds with --enable-perl-filters without excessive warnings (or errors if using -Werror).

Fixed in later perls. See also https://github.com/Perl/perl5/issues/18780