### PR TITLE
Remove the mpileup BAM_CREF_SKIP filter.

### DIFF
--- a/bam2bcf_edlib.c
+++ b/bam2bcf_edlib.c
@@ -1559,18 +1559,9 @@ int bcf_edlib_gap_prep(int n, int *n_plp, bam_pileup1_t **plp, int pos,
                     }
                 }
 
-                int qbeg, qpos, qend, tbeg, tend, kk;
+                int qbeg, qpos, qend, tbeg, tend;
                 uint8_t *seq = bam_get_seq(p->b);
-                uint32_t *cigar = bam_get_cigar(p->b);
                 if (p->b->core.flag & BAM_FUNMAP) continue;
-
-                // FIXME: the following loop should be better moved outside;
-                // nonetheless, realignment should be much slower anyway.
-                for (kk = 0; kk < p->b->core.n_cigar; ++kk)
-                    if ((cigar[kk]&BAM_CIGAR_MASK) == BAM_CREF_SKIP)
-                        break;
-                if (kk < p->b->core.n_cigar)
-                    continue;
 
                 // determine the start and end of sequences for alignment
                 int left2 = left, right2 = right;

--- a/bam2bcf_indel.c
+++ b/bam2bcf_indel.c
@@ -845,18 +845,9 @@ int bcf_call_gap_prep(int n, int *n_plp, bam_pileup1_t **plp, int pos,
                     }
                 }
 
-                int qbeg, qpos, qend, tbeg, tend, kk;
+                int qbeg, qpos, qend, tbeg, tend;
                 uint8_t *seq = bam_get_seq(p->b);
-                uint32_t *cigar = bam_get_cigar(p->b);
                 if (p->b->core.flag & BAM_FUNMAP) continue;
-
-                // FIXME: the following loop should be better moved outside;
-                // nonetheless, realignment should be much slower anyway.
-                for (kk = 0; kk < p->b->core.n_cigar; ++kk)
-                    if ((cigar[kk]&BAM_CIGAR_MASK) == BAM_CREF_SKIP)
-                        break;
-                if (kk < p->b->core.n_cigar)
-                    continue;
 
                 // determine the start and end of sequences for alignment
                 // FIXME: loops over CIGAR multiple times


### PR DESCRIPTION
Mpileup removes alignments using the cigar ref skip operator ("N"). This was originally added in 2011 in samtools/samtools#d1643d6 with the commit message of "fixed a bug in indel calling related to unmapped and refskip reads".

Unfortunately I don't know what that bug was, but removing the code shows it still works (at least for some data!).  We need better understanding of what's going on and why it was added, so perhaps we should add a command line option to control this instead?

Fixes #2277