### PR TITLE
CI improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ version: 'vers.{build}'
 branches:
     except:
       - gh-pages
+      - /.*/ # Appveyor builds are currently disabled.
 
 # Do not build on tags (GitHub and BitBucket)
 skip_tags: true

--- a/.ci_helpers/clone
+++ b/.ci_helpers/clone
@@ -5,9 +5,13 @@
 # omitted or if there is no branch with that name, checks out origin/HEAD
 # from the samtools/htslib repository.
 
-repository=$1
-localdir=$2
-branch=$3
+echo CLONE: ${@+"$@"}
+
+owner=$1
+repository="https://github.com/$owner/$2"
+localdir=$3
+branch=$4
+htslib_PR=$5
 
 ref=''
 [ -n "$branch" ] && ref=$(git ls-remote --heads "$repository" "$branch" 2>/dev/null)
@@ -15,3 +19,11 @@ ref=''
 
 set -x
 git clone --recurse-submodules --shallow-submodules --depth=1 ${ref:+--branch="$branch"} "$repository" "$localdir"
+
+# NB: "samtools" as the owner/organisation, not the repo name
+if [ "x$owner" = "xsamtools" -a -z "$ref" -a "x$htslib_PR" != "x" ]
+then
+    cd "$localdir"
+    git fetch origin "pull/$htslib_PR/head"
+    git checkout FETCH_HEAD
+fi

--- a/.ci_helpers/clone
+++ b/.ci_helpers/clone
@@ -18,7 +18,7 @@ ref=''
 [ -z "$ref" ] && repository='https://github.com/samtools/htslib.git'
 
 set -x
-git clone --recurse-submodules --shallow-submodules --depth=1 ${ref:+--branch="$branch"} "$repository" "$localdir"
+git clone --recurse-submodules --shallow-submodules --depth=2 ${ref:+--branch="$branch"} "$repository" "$localdir"
 
 # NB: "samtools" as the owner/organisation, not the repo name
 if [ "x$owner" = "xsamtools" -a -z "$ref" -a "x$htslib_PR" != "x" ]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,8 +21,16 @@ timeout_in: 10m
 # clone with our own commands too.
 clone_template: &HTSLIB_CLONE
   htslib_clone_script: |
-    .ci_helpers/clone "https://github.com/${CIRRUS_REPO_OWNER}/htslib" "${HTSDIR}" "${CIRRUS_BRANCH}"
-
+    # Tricky, but when run as a PR Cirrus-CI obscures the branch name and
+    # replaces it by pull/<num>.  This means we can't automatically get PRs
+    # to test whether the user has a similarly named branch to compiler and
+    # test against.
+    #
+    # Instead if we add htslib#NUM into the first line of the commit then
+    # we will use that PR from htslib instead.  This is only needed when
+    # making a PR, so for development prior to the PR being made the
+    # CIRRUS_BRANCH will be used in preference.
+    .ci_helpers/clone ${CIRRUS_REPO_OWNER} htslib "${HTSDIR}" "${CIRRUS_BRANCH}" `printenv CIRRUS_CHANGE_TITLE | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
 
 #--------------------------------------------------
 # Template: bcftools compile and test

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,9 @@
 .git*           export-ignore
 .ci_helpers     export-ignore
 README.md       export-ignore
+
+# Prevent Windows cr-lf endings.
+test/**        -text
+test/**.c       text
+test/**.h       text
+test/**.pl      text

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,52 @@
+name: Windows/MinGW-W64 CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Set up MSYS2 MinGW-W64
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        update: false
+        install: >-
+          mingw-w64-x86_64-toolchain
+          mingw-w64-x86_64-autotools
+          mingw-w64-x86_64-curl
+          mingw-w64-x86_64-libdeflate
+          mingw-w64-x86_64-tools-git
+          mingw-w64-x86_64-zlib
+          mingw-w64-x86_64-bzip2
+          mingw-w64-x86_64-xz
+    - name: Clone htslib
+      shell: msys2 {0}
+      run: |
+        export PATH="$PATH:/mingw64/bin:/c/Program Files/Git/bin"
+        export MSYSTEM=MINGW64
+        htslib_pr=`git log -2 --format='%s' | sed -n 's/.*htslib#\([0-9]*\).*/\1/p'`
+        .ci_helpers/clone ${GITHUB_REPOSITORY_OWNER} htslib htslib ${GITHUB_HEAD_REF:-$GITHUB_REF_NAME} $htslib_pr
+        pushd .
+        cd htslib
+        autoreconf -i
+        popd
+    - name: Compile bcftools
+      shell: msys2 {0}
+      run: |
+        export PATH="$PATH:/mingw64/bin:/c/Program Files/Git/bin"
+        export MSYSTEM=MINGW64
+        autoheader
+        autoconf -Wno-syntax
+        ./configure --enable-werror
+        make -j4
+    - name: Check bcftools
+      shell: msys2 {0}
+      run: |
+        export PATH="$PATH:/mingw64/bin:/c/Program Files/Git/bin"
+        export MSYSTEM=MINGW64
+        make check
+


### PR DESCRIPTION
- Improve cirrus-CI for shared htslib/bcftools PRs.   If the first line of the PR commit contains htslib#NUM then the htslib PR of that number is checked out when building bcftools.  This allows for testing of the same branch in both (which happens automatically for a user's fork, but not once PRs are made)

- Replace AppVeyor with GitHub actions for speed and consistency with samtools.