### PR TITLE
Fix gmake 4.4 "pattern recipe did not update peer target" warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,10 @@ libbcftools.a: $(OBJS)
 
 vcfplugin.o: EXTRA_CPPFLAGS += -DPLUGINPATH='"$(pluginpath)"'
 
-%.dll %.cygdll: %.c version.h version.c libbcftools.a $(HTSLIB_DLL)
+%.dll: %.c version.h version.c libbcftools.a $(HTSLIB_DLL)
+	$(CC) $(PLUGIN_FLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CPPFLAGS) $(LDFLAGS) -o $@ version.c $< $(PLUGIN_LIBS)
+
+%.cygdll: %.c version.h version.c libbcftools.a $(HTSLIB_DLL)
 	$(CC) $(PLUGIN_FLAGS) $(CFLAGS) $(ALL_CPPFLAGS) $(EXTRA_CPPFLAGS) $(LDFLAGS) -o $@ version.c $< $(PLUGIN_LIBS)
 
 %.so: %.c version.h version.c


### PR DESCRIPTION
Due to an upcoming change in how GNU make will handle pattern rules with multiple targets, GNU make 4.4 warns when pattern recipes don't update all targets listed.  See https://lists.gnu.org/archive/html/help-make/2022-10/msg00020.html for more information.

Such a case existed in bcftools' Makefile in a rule intended to make either `.dll` or `.cygdll` targets depending on the value of the `PLUGIN_EXT` variable.  As `PLUGIN_EXT` could also be `.so` (handled by another rule) the easiest solution is to spilt the single rule into two, each having a single pattern target.