### PR TITLE
Fix a few warnings and ensure polysomy is built in the CI tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,16 +42,34 @@ compile_template: &COMPILE
     if test "$USE_CONFIG" = "yes"; then
       (cd $HTSDIR && autoreconf -i)
       autoreconf -i
-      ./configure --enable-werror || (cat config.log; /bin/false)
+      ./configure --enable-werror $CONFIG_OPTS \
+           ${CC:+CC="$CC"} \
+           ${CFLAGS:+CFLAGS="$CFLAGS"} \
+           ${CPPFLAGS:+CPPFLAGS="$CPPFLAGS"} \
+           ${LDFLAGS:+LDFLAGS="$LDFLAGS"} \
+         || (cat config.log; /bin/false)
       make -j3
     else
-      make -j3 plugindir=$CIRRUS_WORKING_DIR/plugins -e
+      make -j3 plugindir="$CIRRUS_WORKING_DIR/plugins" \
+           ${HTSDIR:+HTSDIR="$HTSDIR"} \
+           ${CC:+CC="$CC"} \
+           ${CFLAGS:+CFLAGS="$CFLAGS"} \
+           ${CPPFLAGS:+CPPFLAGS="$CPPFLAGS"} \
+           ${LDFLAGS:+LDFLAGS="$LDFLAGS"}
     fi
 
 test_template: &TEST
   test_script: |
-    make -e test
-
+    if test "$USE_CONFIG" = "yes"; then
+        make test
+    else
+        make test  \
+           ${HTSDIR:+HTSDIR="$HTSDIR"} \
+           ${CC:+CC="$CC"} \
+           ${CFLAGS:+CFLAGS="$CFLAGS"} \
+           ${CPPFLAGS:+CPPFLAGS="$CPPFLAGS"} \
+           ${LDFLAGS:+LDFLAGS="$LDFLAGS"}
+    fi
 
 #--------------------------------------------------
 # Task: linux builds.
@@ -68,15 +86,23 @@ gcc_task:
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./htslib
-    CFLAGS:  -fsanitize=address
-    LDFLAGS: -fsanitize=address
 
   matrix:
     - environment:
        USE_CONFIG: no
+       CFLAGS:  -g -Og -Wall -Werror -fsanitize=address
+       LDFLAGS: -fsanitize=address
     - environment:
        USE_CONFIG: yes
-       CFLAGS: -std=gnu99 -O0
+       CONFIG_OPTS: --enable-libgsl --enable-perl-filters 
+       CFLAGS: -std=gnu99 -g -Og -Wall -fsanitize=address
+       LDFLAGS: -fsanitize=address
+
+  install_script: |
+    apt-get update
+    apt-get install -y --no-install-suggests --no-install-recommends \
+        libdeflate-dev libperl-dev libgsl0-dev libio-pty-perl
+
 
   << : *COMPILE
   << : *TEST
@@ -92,7 +118,6 @@ ubuntu_task:
 
   environment:
     CC: clang
-    CFLAGS: -g -O2 -Werror -Wall -Wformat -Wformat=2
     LC_ALL: C
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./htslib
@@ -100,10 +125,12 @@ ubuntu_task:
   matrix:
     - environment:
        USE_CONFIG: no
+       CFLAGS: -g -O2 -Werror -Wall -Wformat -Wformat=2
     - container:
        memory: 2G
       environment:
        USE_CONFIG: yes
+       CONFIG_OPTS: --enable-libgsl --enable-perl-filters
        CFLAGS: -g -Wall -O3
        LDFLAGS: -Wl,-rpath,`pwd`/inst/lib
 
@@ -114,7 +141,7 @@ ubuntu_task:
     apt-get install -y --no-install-suggests --no-install-recommends \
         ca-certificates clang git autoconf automake  \
         make zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev   \
-        libssl-dev libdeflate-dev
+        libssl-dev libdeflate-dev libperl-dev libgsl0-dev libio-pty-perl
 
   << : *COMPILE
   << : *TEST
@@ -133,13 +160,14 @@ rockylinux_task:
     CIRRUS_CLONE_DEPTH: 1
     HTSDIR: ./htslib
     USE_CONFIG: yes
+    CONFIG_OPTS: --enable-libgsl --enable-perl-filters
 
   # NB: we could consider building a docker image with these
   # preinstalled and specifying that instead, to speed up testing.
   install_script: |
     yum install -y autoconf automake make gcc perl-Data-Dumper perl-FindBin \
         zlib-devel bzip2 bzip2-devel xz-devel curl-devel openssl-devel \
-        git diffutils
+        git diffutils gsl-devel perl-ExtUtils-Embed
 
   << : *COMPILE
   << : *TEST

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -179,7 +179,7 @@ rockylinux_task:
 macosx_task:
   name: macosx + clang
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+    image: ghcr.io/cirruslabs/macos-runner:sonoma
 
   environment:
     CC: clang

--- a/plugins/split-vep.c
+++ b/plugins/split-vep.c
@@ -30,6 +30,7 @@
 #include <getopt.h>
 #include <unistd.h>     // for isatty
 #include <inttypes.h>
+#include <assert.h>
 #include <htslib/hts.h>
 #include <htslib/vcf.h>
 #include <htslib/bgzf.h>
@@ -606,7 +607,7 @@ static void parse_column_str(args_t *args)
         char keep = *ep;
         *ep = 0;
         int type = -1;
-        int idx_beg, idx_end;
+        int idx_beg = 0, idx_end = -1;
         if ( !strcmp("-",bp) )
         {
             kstring_t str = {0,0,0};
@@ -973,11 +974,12 @@ static void init_data(args_t *args)
     else
     {
         int len = strlen(sel_csq);
-        int severity, modifier = '=';
+        int severity = -1, modifier = '=';
         if ( sel_csq[len-1]=='+' ) { modifier = '+'; sel_csq[len-1] = 0; }
         else if ( sel_csq[len-1]=='-' ) { modifier = '-'; sel_csq[len-1] = 0; }
         if ( khash_str2int_get(args->csq2severity, sel_csq, &severity)!=0 )
             error("Error: the consequence \"%s\" is not recognised. Run \"bcftools +split-vep -S ?\" to see the default list.\n", sel_csq);
+        assert(severity >= 0);
         if ( modifier=='=' ) { args->min_severity = severity; args->max_severity = severity; }
         else if ( modifier=='+' ) { args->min_severity = severity; args->max_severity = INT_MAX; }
         else if ( modifier=='-' ) { args->min_severity = 0; args->max_severity = severity; }

--- a/polysomy.c
+++ b/polysomy.c
@@ -200,17 +200,13 @@ static void init_data(args_t *args)
     for (i=0; i<args->nbins; i++) args->xvals[i] = 1.0*i/(args->nbins-1);
 
     // collect BAF distributions for all chromosomes
-    int idist = -1, nbaf = 0, nprocessed = 0, ntotal = 0, prev_chr = -1;
+    int idist = -1, nbaf = 0, prev_chr = -1;
     float *baf = NULL;
     while ( bcf_sr_next_line(files) )
     {
-        ntotal++;
-
         bcf1_t *line = bcf_sr_get_line(files,0);
         if ( bcf_get_format_float(hdr,line,"BAF",&baf,&nbaf) != 1 ) continue;
         if ( bcf_float_is_missing(baf[0]) ) continue;
-
-        nprocessed++;
 
         if ( prev_chr==-1 || prev_chr!=line->rid )
         {

--- a/read_consensus.c
+++ b/read_consensus.c
@@ -521,7 +521,7 @@ static int create_haplotype_frequency_spectrum(read_cns_t *rcns)
             }
             else if ( cvar->vtype==ins )
             {
-                int len;
+                int len = 0;
                 ins_freq_t *ifrq = &rcns->ins_freq[cvar->pos - rcns->beg];
                 int iseq = cstate_seek_op_fwd(&cigar, cvar->pos+1, BAM_CINS, &len);
                 if ( iseq==-2 ) break;
@@ -533,7 +533,7 @@ static int create_haplotype_frequency_spectrum(read_cns_t *rcns)
             }
             else if ( cvar->vtype==del )
             {
-                int len;
+                int len = 0;
                 del_freq_t *dfrq = &rcns->del_freq[cvar->pos - rcns->beg];
                 int ret = cstate_seek_op_fwd(&cigar, cvar->pos+1, BAM_CDEL, &len);
                 if ( ret==-2 ) break;


### PR DESCRIPTION
Fix a couple of warnings that appeared when using `./configure --enable-libgsl` or with optimisation `-Og`.  Also tidies up the CI builds a bit as compiler flags weren't being applied consistently, and updates the MacOS build to Sonoma.