### PR TITLE
test update with updated rlen calculation in htslib

### DIFF
--- a/test/norm.rmdup.3.1.out
+++ b/test/norm.rmdup.3.1.out
@@ -3,7 +3,7 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##contig=<ID=1>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	1	.	A	<DEL>	.	.	SVLEN=-1000
-1	1	.	A	<DEL>	.	.	SVLEN=-2000
-1	1	.	A	<DEL>	.	.	SVLEN=-3000
+1	8	.	T	<DEL>	.	.	SVLEN=-10
+1	8	.	T	<DEL>	.	.	SVLEN=-11
+1	8	.	T	<DEL>	.	.	SVLEN=-12
 1	18	.	AC	A	.	.	.

--- a/test/norm.rmdup.3.2.out
+++ b/test/norm.rmdup.3.2.out
@@ -3,5 +3,5 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##contig=<ID=1>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	1	.	A	<DEL>	.	.	SVLEN=-1000
+1	8	.	T	<DEL>	.	.	SVLEN=-10
 1	18	.	AC	A	.	.	.

--- a/test/norm.rmdup.3.vcf
+++ b/test/norm.rmdup.3.vcf
@@ -2,14 +2,14 @@
 ##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
 ##contig=<ID=1>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
-1	10	.	C	<DEL>	.	.	SVLEN=-1000
-1	10	.	C	<DEL>	.	.	SVLEN=-1000
-1	10	.	C	<DEL>	.	.	SVLEN=-2000
-1	10	.	C	<DEL>	.	.	SVLEN=-1000
-1	10	.	C	<DEL>	.	.	SVLEN=-3000
-1	10	.	C	<DEL>	.	.	SVLEN=-2000
-1	10	.	C	<DEL>	.	.	SVLEN=-1000
-1	10	.	C	<DEL>	.	.	SVLEN=-3000
-1	10	.	C	<DEL>	.	.	SVLEN=-2000
+1	10	.	C	<DEL>	.	.	SVLEN=-10
+1	10	.	C	<DEL>	.	.	SVLEN=-10
+1	10	.	C	<DEL>	.	.	SVLEN=-11
+1	10	.	C	<DEL>	.	.	SVLEN=-10
+1	10	.	C	<DEL>	.	.	SVLEN=-12
+1	10	.	C	<DEL>	.	.	SVLEN=-11
+1	10	.	C	<DEL>	.	.	SVLEN=-10
+1	10	.	C	<DEL>	.	.	SVLEN=-12
+1	10	.	C	<DEL>	.	.	SVLEN=-11
 1	20	.	CCC	CC	.	.	.
 1	20	.	CC	C	.	.	.


### PR DESCRIPTION
HTSLib is being updated to calculate rlen as per vcf 4.4 and 4.5 (htslib PR 1897)

Many times the vcf version are not kept updated and hence the calculation update is made irrespective of version, i.e. all of SVLEN, END, format LEN and reference length are used for rlen calculation. This change causes test failure in bcftools as rlen being different.

This PR updates the failing source vcf and its expected results to test the realignment in normalise operation with updated rlen calculations.
This PR is relevant only after the htslib PR 1897 is merged to htslib.
