### PR TITLE
Fix big-endian test failures and use-after-free issues in error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ bam_sample_h = bam_sample.h $(htslib_sam_h)
 cigar_state_h = cigar_state.h $(htslib_hts_h) $(htslib_sam_h)
 read_consensus_h = read_consensus.h $(htslib_hts_h) $(htslib_sam_h)
 str_finder_h = str_finder.h utlist.h
+mpileup2_mpileup_h = mpileup2/mpileup.h $(htslib_sam_h)
 
 str_finder.o: str_finder.c $(str_finder_h) utlist.h
 main.o: main.c $(htslib_hts_h) config.h version.h $(bcftools_h)
@@ -287,14 +288,14 @@ cols.o: cols.c cols.h
 regidx.o: regidx.c $(htslib_hts_h) $(htslib_kstring_h) $(htslib_kseq_h) $(htslib_khash_str2int_h) regidx.h
 consensus.o: consensus.c $(htslib_vcf_h) $(htslib_kstring_h) $(htslib_synced_bcf_reader_h) $(htslib_kseq_h) $(htslib_bgzf_h) regidx.h $(bcftools_h) rbuf.h $(filter_h) $(smpl_ilist_h)
 mpileup.o: mpileup.c $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_khash_str2int_h) $(htslib_hts_os_h) regidx.h $(bcftools_h) $(bam2bcf_h) $(bam_sample_h) $(gvcf_h)
-mpileup2/mpileup.o: mpileup2/mpileup.h mpileup2/mpileup.c $(htslib_sam_h) $(htslib_faidx_h) $(htslib_kstring_h) $(htslib_khash_str2int_h) $(htslib_hts_os_h) $(bcftools_h) $(bam2bcf_h) $(bam_sample_h)
+mpileup2/mpileup.o: mpileup2/mpileup.c $(htslib_hts_h) $(htslib_sam_h) $(htslib_faidx_h) regidx.h $(mpileup2_mpileup_h) $(bam_sample_h)
 bam2bcf.o: bam2bcf.c $(htslib_hts_h) $(htslib_sam_h) $(htslib_kstring_h) $(htslib_kfunc_h) $(bam2bcf_h) mw.h
 bam2bcf_indel.o: bam2bcf_indel.c $(htslib_hts_h) $(htslib_sam_h) $(htslib_khash_str2int_h) $(bam2bcf_h) $(htslib_ksort_h) $(str_finder_h)
 bam2bcf_iaux.o: bam2bcf_iaux.c $(htslib_hts_h) $(htslib_sam_h) $(htslib_khash_str2int_h) $(bcftools_h) $(bam2bcf_h) $(htslib_ksort_h) $(read_consensus_h) $(cigar_state_h)
 bam2bcf_edlib.o: bam2bcf_edlib.c $(htslib_hts_h) $(htslib_sam_h) $(htslib_khash_str2int_h) $(bam2bcf_h) $(str_finder_h) $(htslib_ksort_h) edlib.h
 read_consensus.o: read_consensus.c $(read_consensus_h) $(cigar_state_h) $(bcftools_h) kheap.h
 bam_sample.o: bam_sample.c $(htslib_hts_h) $(htslib_kstring_h) $(htslib_khash_str2int_h) $(khash_str2str_h) $(bam_sample_h) $(bcftools_h)
-version.o: version.h version.c
+version.o: version.c $(htslib_hts_h) $(bcftools_h) version.h
 hclust.o: hclust.c $(htslib_hts_h) $(htslib_kstring_h) $(bcftools_h) hclust.h
 HMM.o: HMM.c $(htslib_hts_h) HMM.h
 vcfbuf.o: vcfbuf.c $(htslib_vcf_h) $(htslib_vcfutils_h) $(htslib_hts_os_h) $(htslib_kbitset_h) $(bcftools_h) $(vcfbuf_h) rbuf.h
@@ -359,7 +360,7 @@ install: $(PROGRAMS) $(PLUGINS)
 	$(INSTALL_PROGRAM) plugins/*$(PLUGIN_EXT) $(DESTDIR)$(plugindir)
 
 clean: testclean clean-plugins
-	-rm -f gmon.out *.o *.a *~ $(PROGRAMS) version.h
+	-rm -f gmon.out *.o mpileup2/*.o *.a *~ $(PROGRAMS) version.h
 	-rm -rf *.dSYM test/*.dSYM
 
 clean-plugins:

--- a/convert.c
+++ b/convert.c
@@ -28,6 +28,7 @@ THE SOFTWARE.  */
 #include <assert.h>
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/plugins/vrfs.c
+++ b/plugins/vrfs.c
@@ -347,7 +347,7 @@ static int batch_profile_run1(args_t *args, char *aln_fname)
     while ( (ret=mpileup_next(args->mplp))==1 )
     {
         char *chr = mpileup_get_val(args->mplp,char*,CHROM);
-        hts_pos_t pos = mpileup_get_val(args->mplp,int,POS);
+        hts_pos_t pos = mpileup_get_val(args->mplp,hts_pos_t,POS);
 
         if ( !regidx_overlap(args->sites_idx, chr,pos,pos, args->sites_itr) )
         {

--- a/reheader.c
+++ b/reheader.c
@@ -418,7 +418,7 @@ static void reheader_vcf_gz(args_t *args)
     // Output all remaining data read with the header block
     if ( fp->block_length - skip_until > 0 )
     {
-        if ( bgzf_write(bgzf_out, buffer+skip_until, fp->block_length-skip_until)<0 ) error("Error: %d\n",fp->errcode);
+        if ( bgzf_write(bgzf_out, buffer+skip_until, fp->block_length-skip_until)<0 ) error("Error: %d\n",bgzf_out->errcode);
     }
     if ( bgzf_flush(bgzf_out)<0 ) error("Error: %d\n",bgzf_out->errcode);
 
@@ -434,8 +434,8 @@ static void reheader_vcf_gz(args_t *args)
         int count = bgzf_raw_write(bgzf_out, buf, nread);
         if (count != nread) error("Write failed, wrote %d instead of %d bytes.\n", count,(int)nread);
     }
-    if (bgzf_close(bgzf_out) < 0) error("Error closing %s: %d\n",args->output_fname ? args->output_fname : "-",bgzf_out->errcode);
-    if (hts_close(args->fp)) error("Error closing %s: %d\n",args->fname,fp->errcode);
+    if (bgzf_close(bgzf_out) < 0) error("Error closing %s: %s\n",args->output_fname ? args->output_fname : "-",strerror(errno));
+    if (hts_close(args->fp)) error("Error closing %s: %s\n",args->fname,strerror(errno));
     free(buf);
 }
 static void reheader_vcf(args_t *args)

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -919,7 +919,7 @@ static void naive_concat(args_t *args)
         // Output all non-header data that were read together with the header block
         if ( fp->block_length - nskip > 0 )
         {
-            if ( bgzf_write(bgzf_out, (char *)fp->uncompressed_block+nskip, fp->block_length-nskip)<0 ) error("\nError: %d\n",fp->errcode);
+            if ( bgzf_write(bgzf_out, (char *)fp->uncompressed_block+nskip, fp->block_length-nskip)<0 ) error("\nError: %d\n",bgzf_out->errcode);
         }
         if ( bgzf_flush(bgzf_out)<0 ) error("\nError: %d\n",bgzf_out->errcode);
 
@@ -952,7 +952,7 @@ static void naive_concat(args_t *args)
     }
     free(buf);
     free(tmp.s);
-    if (bgzf_close(bgzf_out) < 0) error("Error: %d\n",bgzf_out->errcode);
+    if (bgzf_close(bgzf_out) < 0) error("Error: %s\n",strerror(errno));
 }
 
 static void usage(args_t *args)


### PR DESCRIPTION
The incorrect type in `mpileup_get_val()` in _plugins/vrfs.c_ caused incorrect results and test failures on big-endian machines, as `pos` was essentially always set to 0 (being the high-order bits of the `int64_t`).

Accessing `fileptr->errcode` after closing the `fileptr` is invalid as generally the file structure will have been deallocated. This replaces that with `strerror(errno)`, as is already done in _vcfconvert.c_. Also report the right file pointer's `errcode` after `bgzf_write()` failure.

And some other _Makefile_ fixes and other miscellanea.