### PR TITLE
Copyright year update and build cleanup

### DIFF
--- a/main.c
+++ b/main.c
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
     if (argc < 2) { usage(stderr); return 1; }
 
     if (strcmp(argv[1], "version") == 0 || strcmp(argv[1], "--version") == 0 || strcmp(argv[1], "-v") == 0) {
-        printf("bcftools %s\nUsing htslib %s\nCopyright (C) 2024 Genome Research Ltd.\n", bcftools_version(), hts_version());
+        printf("bcftools %s\nUsing htslib %s\nCopyright (C) 2025 Genome Research Ltd.\n", bcftools_version(), hts_version());
 #if USE_GPL
         printf("License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\n");
 #else

--- a/plugins/vcf2table.c
+++ b/plugins/vcf2table.c
@@ -38,7 +38,6 @@
 #include <unistd.h>  // for isatty
 
 #include "../bcftools.h"
-#include "hts_internal.h"
 
 #define ASSERT_NOT_NULL(a)                                                \
   do {                                                                    \


### PR DESCRIPTION
Removed hts_internal.h reference in plugin/vcf2table.c as it caused build failure while using pre-installed htslib.
Updated the copyright year to 2025