### PR TITLE
Work around Microsoft's UCRT-x64 pathname rewriting.

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -646,7 +646,7 @@ run_test(\&test_vcf_plugin,$opts,in=>'setGT.3',out=>'setGT.3.3.out',cmd=>'+setGT
 run_test(\&test_vcf_plugin,$opts,in=>'setGT.3',out=>'setGT.3.4.out',cmd=>'+setGT --no-version',args=>'-- -t a -n c:"1|1"');
 run_test(\&test_vcf_plugin,$opts,in=>'setGT.3',out=>'setGT.3.5.out',cmd=>'+setGT --no-version',args=>'-- -t a -n c:"m|M"');
 run_test(\&test_vcf_plugin,$opts,in=>'setGT.3',out=>'setGT.3.6.out',cmd=>'+setGT --no-version',args=>'-- -t a -n c:0/1/1');
-run_test(\&test_vcf_plugin,$opts,in=>'setGT.3',out=>'setGT.3.7.out',cmd=>'+setGT --no-version',args=>q[-i 'GT="mis"' -- -t . -n c:././.]);
+run_test(\&test_vcf_plugin,$opts,in=>'setGT.3',out=>'setGT.3.7.out',cmd=>'+setGT --no-version',args=>q[-i 'GT="mis"' -- -t . -nc:././.]);
 run_test(\&test_vcf_plugin,$opts,in=>'setGT.4',out=>'setGT.4.1.out',cmd=>'+setGT --no-version',args=>q[-- -t q -n . -e 'FMT/DP>90']);
 run_test(\&test_vcf_plugin,$opts,in=>'setGT.4',out=>'setGT.4.2.out',cmd=>'+setGT --no-version',args=>q[-- -t q -n . -e 'FMT/DP>100']);
 run_test(\&test_vcf_plugin,$opts,in=>'setGT.5',out=>'setGT.5.1.out',cmd=>'+setGT --no-version',args=>q[-- -t a -n X]);


### PR DESCRIPTION
MINGW x64 works fine, but UCRT-x64 fails one of the setGT tests. Specifically, `-n c:././.` gets silently rewritten before main() so the argv element contains `-n c;.\.\.` instead.  This is a pain, and arguably we should provide a less problematic CLI alternative for this as c: was always going to trip up Windows boxes.

However for now we can work around it by not having it as a separate argument and letting getopt do the tokenisation of argv into option and optarg for us by removing the space.

This doesn't fix the bug obviously, but it makes it pass tests if using the UCRT environment.