### PR TITLE
Fix clang build failure due to --verbosity option handling

### DIFF
--- a/bcftools.h
+++ b/bcftools.h
@@ -50,6 +50,9 @@ void error(const char *format, ...) HTS_NORETURN HTS_FORMAT(HTS_PRINTF_FMT, 1, 2
 //  newline will be added by the function.
 void error_errno(const char *format, ...) HTS_NORETURN HTS_FORMAT(HTS_PRINTF_FMT, 1, 2);
 
+//  Set hts_verbose and return 0, or return -1 if str is not a valid integer
+int apply_verbosity(const char *str);
+
 // For on the fly index creation with --write-index
 int init_index2(htsFile *fh, bcf_hdr_t *hdr, const char *fname, char **idx_fname, int idx_fmt);
 int init_index(htsFile *fh, bcf_hdr_t *hdr, const char *fname, char **idx_fname);

--- a/consensus.c
+++ b/consensus.c
@@ -1259,15 +1259,12 @@ int main_consensus(int argc, char *argv[])
         {0,0,0,0}
     };
     int c;
-    char *tmp;
     while ((c = getopt_long(argc, argv, "h?s:S:1Ii:e:H:f:o:m:c:M:p:a:v:",loptions,NULL)) >= 0)
     {
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 : args->mark_del = optarg[0]; break;
             case  2 :

--- a/mpileup.c
+++ b/mpileup.c
@@ -1469,13 +1469,10 @@ int main_mpileup(int argc, char *argv[])
         {"verbosity",required_argument,NULL,'v'},
         {NULL, 0, NULL, 0}
     };
-    char *tmp;
     while ((c = getopt_long(argc, argv, "Ag:f:r:R:q:Q:C:BDd:L:b:P:po:e:h:Im:F:EG:6O:xa:s:S:t:T:M:X:UW::v:",lopts,NULL)) >= 0) {
         switch (c) {
         case 'v':
-            int verbose = strtol(optarg,&tmp,10);
-            if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-            if ( verbose > 3 ) hts_verbose = verbose;
+            if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
             break;
         case 'x': mplp.flag &= ~MPLP_SMART_OVERLAPS; break;
         case  16 :

--- a/plugins/check-sparsity.c
+++ b/plugins/check-sparsity.c
@@ -246,9 +246,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'n':
                 args->min_sites = strtol(optarg,&tmp,10);

--- a/plugins/contrast.c
+++ b/plugins/contrast.c
@@ -499,9 +499,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 : args->force_samples = 1; break;
             case 'f': args->max_AC_str = optarg; break;

--- a/plugins/gvcfz.c
+++ b/plugins/gvcfz.c
@@ -347,9 +347,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'a': args->trim_alts = 1; break;
             case 'e':

--- a/plugins/indel-stats.c
+++ b/plugins/indel-stats.c
@@ -706,9 +706,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 :
                 MAX_LEN = strtod(optarg,&tmp);

--- a/plugins/isecGT.c
+++ b/plugins/isecGT.c
@@ -99,9 +99,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'o': args->output_fname = optarg; break;
             case 'O':

--- a/plugins/mendelian2.c
+++ b/plugins/mendelian2.c
@@ -832,9 +832,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");

--- a/plugins/parental-origin.c
+++ b/plugins/parental-origin.c
@@ -345,9 +345,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");

--- a/plugins/prune.c
+++ b/plugins/prune.c
@@ -363,9 +363,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 : args->rand_missing = 1; break;
             case  2 : args->af_tag = optarg; break;

--- a/plugins/remove-overlaps.c
+++ b/plugins/remove-overlaps.c
@@ -244,9 +244,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'm': args->mark_expr = optarg; break;
             case 'M': args->mark_tag = optarg; break;

--- a/plugins/scatter.c
+++ b/plugins/scatter.c
@@ -372,9 +372,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");

--- a/plugins/smpl-stats.c
+++ b/plugins/smpl-stats.c
@@ -446,15 +446,12 @@ int run(int argc, char **argv)
         {NULL,0,NULL,0}
     };
     int c, i;
-    char *tmp;
     while ((c = getopt_long(argc, argv, "o:s:i:e:r:R:t:T:v:",loptions,NULL)) >= 0)
     {
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");

--- a/plugins/split-vep.c
+++ b/plugins/split-vep.c
@@ -1588,9 +1588,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  2 : args->record_cmd_line = 0; break;
             case  1 : args->column_types = optarg; break;

--- a/plugins/split.c
+++ b/plugins/split.c
@@ -668,9 +668,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 : args->hts_opts = hts_readlist(optarg,0,&args->nhts_opts); break;
             case 'k': args->keep_tags = optarg; break;

--- a/plugins/trio-dnm2.c
+++ b/plugins/trio-dnm2.c
@@ -1685,9 +1685,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 : args->force_ad = 1; break;
             case  2 : free(args->dnm_score_tag); args->dnm_score_tag = strdup(optarg); break;

--- a/plugins/trio-stats.c
+++ b/plugins/trio-stats.c
@@ -728,15 +728,12 @@ int run(int argc, char **argv)
         {NULL,0,NULL,0}
     };
     int c, i;
-    char *tmp;
     while ((c = getopt_long(argc, argv, "P:p:o:s:i:e:r:R:t:T:a:d:v:",loptions,NULL)) >= 0)
     {
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'd':
             {

--- a/plugins/variant-distance.c
+++ b/plugins/variant-distance.c
@@ -260,9 +260,7 @@ int run(int argc, char **argv)
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'd':
                 if ( !strcasecmp("nearest",optarg) ) args->direction = DIR_NEAREST;

--- a/reheader.c
+++ b/reheader.c
@@ -699,15 +699,12 @@ int main_reheader(int argc, char *argv[])
         {"verbosity",required_argument,NULL,'v'},
         {0,0,0,0}
     };
-    char *tmp;
     while ((c = getopt_long(argc, argv, "s:h:o:f:T:v:",loptions,NULL)) >= 0)
     {
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case  1 : args->n_threads = strtol(optarg, 0, 0); break;
             case 'T': break; // unused - was temp file prefix

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -3739,9 +3739,7 @@ int main_vcfannotate(int argc, char *argv[])
     {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'f': args->force = 1; break;
             case 'k': args->keep_sites = 1; break;

--- a/vcfcall.c
+++ b/vcfcall.c
@@ -1154,9 +1154,7 @@ int main_vcfcall(int argc, char *argv[])
                     error("Unsupported index format '%s'\n", optarg);
                 break;
             case 10:
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             default: usage(&args);
         }

--- a/vcfcnv.c
+++ b/vcfcnv.c
@@ -1303,9 +1303,7 @@ int main_vcfcnv(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "h?r:R:t:T:s:o:p:l:T:c:b:P:x:e:O:W::f:a:L:d:k:v:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'L':
                 args->lrr_smooth_win = strtol(optarg,&tmp,10);

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -1729,9 +1729,7 @@ int main_vcfconvert(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "?h:r:R:s:S:t:T:i:e:g:G:o:O:c:f:H:W::v:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'e':
                 if ( args->filter_str ) error("Error: only one -i or -e expression can be given, and they cannot be combined\n");

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -545,9 +545,7 @@ int main_vcffilter(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "e:i:t:T:r:R:h?s:m:M:o:O:g:G:S:W::v:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'g':
                 args->snp_gap = strtol(optarg,&tmp,10);

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -1255,9 +1255,7 @@ int main_vcfgtcheck(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "hg:p:s:S:p:P:Hr:R:at:T:G:c:u:e:E:i:o:O:v:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'o': args->output_fname = optarg; break;
             case 'O':

--- a/vcfhead.c
+++ b/vcfhead.c
@@ -61,14 +61,11 @@ int main_vcfhead(int argc, char *argv[])
     uint64_t nheaders = 0;
     uint64_t nrecords = 0;
 
-    char *tmp;
     int c, nargs;
     while ((c = getopt_long(argc, argv, "h:n:s:v:", loptions, NULL)) >= 0)
         switch (c) {
         case 'v':
-            int verbose = strtol(optarg,&tmp,10);
-            if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-            if ( verbose > 3 ) hts_verbose = verbose;
+            if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
             break;
         case 'h': all_headers = 0; nheaders = strtoull(optarg, NULL, 0); break;
         case 'n': nrecords = strtoull(optarg, NULL, 0); break;

--- a/vcfindex.c
+++ b/vcfindex.c
@@ -249,9 +249,7 @@ int main_vcfindex(int argc, char *argv[])
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'c': tbi = 0; break;
             case 't': tbi = 1; min_shift = 0; break;

--- a/vcfisec.c
+++ b/vcfisec.c
@@ -573,9 +573,7 @@ int main_vcfisec(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "hc:r:R:p:n:w:t:T:Cf:o:O:i:e:l:W::v:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'o': args->output_fname = optarg; break;
             case 'O':

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -2725,6 +2725,8 @@ void gvcf_flush(args_t *args, int done)
 
 static inline int is_gvcf_block(args_t *args, bcf1_t *line)
 {
+    maux_t *ma;
+
     if ( line->rlen<=1 ) return 0;
     if ( strlen(line->d.allele[0])==line->rlen ) return 0;
     if ( line->n_allele==1 ) goto is_gvcf;
@@ -2739,7 +2741,7 @@ static inline int is_gvcf_block(args_t *args, bcf1_t *line)
     return 0;
 
 is_gvcf:
-    maux_t *ma = args->maux;
+    ma = args->maux;
     if ( !ma->gvcf )
     {
         args->do_gvcf = 1;
@@ -3607,9 +3609,7 @@ int main_vcfmerge(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "hm:f:r:R:o:O:i:M:l:g:F:0L:W::v:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'L':
                 args->local_alleles = strtol(optarg,&tmp,10);

--- a/vcfquery.c
+++ b/vcfquery.c
@@ -301,7 +301,6 @@ int main_vcfquery(int argc, char *argv[])
         {"verbosity",required_argument,NULL,4},
         {0,0,0,0}
     };
-    char *tmp;
     while ((c = getopt_long(argc, argv, "hlr:R:F:f:a:s:S:Ht:T:c:v:i:e:o:uN",loptions,NULL)) >= 0) {
         switch (c) {
             case 'o': args->fn_out = optarg; break;
@@ -354,9 +353,7 @@ int main_vcfquery(int argc, char *argv[])
                 break;
             case  3 : args->force_samples = 1; break;
             case  4 :
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'h':
             case '?': usage(); break;

--- a/vcfroh.c
+++ b/vcfroh.c
@@ -1173,9 +1173,7 @@ int main_vcfroh(int argc, char *argv[])
     while ((c = getopt_long(argc, argv, "h?r:R:t:T:H:a:s:S:m:M:G:Ia:e:V:b:O:o:iv:",loptions,NULL)) >= 0) {
         switch (c) {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 0: args->af_tag = optarg; naf_opts++; break;
             case 1: args->af_fname = optarg; naf_opts++; break;

--- a/vcfsort.c
+++ b/vcfsort.c
@@ -790,9 +790,7 @@ int main_sort(int argc, char *argv[])
         switch (c)
         {
             case 'v':
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
             case 'm': args->max_mem = parse_mem_string(optarg); break;
             case 'T': args->tmp_dir = optarg; break;

--- a/vcfview.c
+++ b/vcfview.c
@@ -753,9 +753,7 @@ int main_vcfview(int argc, char *argv[])
             case  9 : args->n_threads = strtol(optarg, 0, 0); break;
             case  8 : args->record_cmd_line = 0; break;
             case 10 :
-                int verbose = strtol(optarg,&tmp,10);
-                if ( *tmp || verbose<0 ) error("Could not parse argument: --verbosity %s\n", optarg);
-                if ( verbose > 3 ) hts_verbose = verbose;
+                if ( apply_verbosity(optarg) < 0 ) error("Could not parse argument: --verbosity %s\n", optarg);
                 break;
 
             case 'W':

--- a/version.c
+++ b/version.c
@@ -61,6 +61,15 @@ void error_errno(const char *format, ...)
     exit(-1);
 }
 
+int apply_verbosity(const char *str)
+{
+    char *tmp;
+    int verbose = strtol(str,&tmp,10);
+    if ( *tmp || verbose<0 ) return -1;
+    if ( verbose > 3 ) hts_verbose = verbose;
+    return 0;
+}
+
 const char *hts_bcf_wmode(int file_type)
 {
     if ( file_type == FT_BCF ) return "wbu";    // uncompressed BCF


### PR DESCRIPTION
Clang considers declaring a variable after a case label to be an error. Introduce a function encapsulating `--verbosity` parsing to avoid needing a local variable within this option parsing case.

Similarly in vcfmerge.c, avoid declaring a variable after a goto label.

(Perhaps this is valid in C11 and GCC is defaulting to that language level…)