### PR TITLE
Ignore first phasing bit in process_gt_to_hap / process_gt_to_hap2

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -878,7 +878,7 @@ static void process_gt_to_hap(convert_t *convert, bcf1_t *line, fmt_t *fmt, int 
         ptr += fmt_gt->n;
         if ( fmt_gt->n==1 ) // haploid genotypes
         {
-            if ( ptr[0]==2 ) /* 0 */
+            if ( ( ptr[0] >> 1 )==1 ) /* 0 */
             {
                 str->s[str->l++] = '0'; str->s[str->l++] = ' '; str->s[str->l++] = '-'; str->s[str->l++] = ' ';
             }
@@ -886,7 +886,7 @@ static void process_gt_to_hap(convert_t *convert, bcf1_t *line, fmt_t *fmt, int 
             {
                 str->s[str->l++] = '?'; str->s[str->l++] = ' '; str->s[str->l++] = '?'; str->s[str->l++] = ' ';
             }
-            else if ( ptr[0]==4 ) /* 1 */
+            else if ( ( ptr[0] >> 1 )==2 ) /* 1 */
             {
                 str->s[str->l++] = '1'; str->s[str->l++] = ' '; str->s[str->l++] = '-'; str->s[str->l++] = ' ';
             }
@@ -895,7 +895,7 @@ static void process_gt_to_hap(convert_t *convert, bcf1_t *line, fmt_t *fmt, int 
                 kputw(bcf_gt_allele(ptr[0]),str); str->s[str->l++] = ' '; str->s[str->l++] = '-'; str->s[str->l++] = ' ';
             }
         }
-        else if ( ptr[0]==2 )
+        else if ( ( ptr[0] >> 1 )==1 )
         {
             if ( ptr[1]==3 ) /* 0|0 */
             {
@@ -934,7 +934,7 @@ static void process_gt_to_hap(convert_t *convert, bcf1_t *line, fmt_t *fmt, int 
                 str->s[str->l++] = '*'; str->s[str->l++] = ' ';
             }
         }
-        else if ( ptr[0]==4 )
+        else if ( ( ptr[0] >> 1 )==2 )
         {
             if ( ptr[1]==3 ) /* 1|0 */
             {
@@ -1028,7 +1028,7 @@ static void process_gt_to_hap2(convert_t *convert, bcf1_t *line, fmt_t *fmt, int
     for (i=0; i<convert->nsamples; i++)
     {
         ptr += fmt_gt->n;
-        if ( ptr[0]==2 )
+        if ( ( ptr[0] >> 1 )==1 )
         {
             if ( ptr[1]==3 ) /* 0|0 */
             {
@@ -1067,7 +1067,7 @@ static void process_gt_to_hap2(convert_t *convert, bcf1_t *line, fmt_t *fmt, int
                 str->s[str->l++] = '*'; str->s[str->l++] = ' ';
             }
         }
-        else if ( ptr[0]==4 )
+        else if ( ( ptr[0] >> 1 )==2 )
         {
             if ( ptr[1]==3 ) /* 1|0 */
             {


### PR DESCRIPTION
HTSlib version 1.22 introduced [prefixed phasing support](https://github.com/samtools/htslib/pull/1861) for VCF files with version 4.4 or later.  Prior to this the first GT phase (when reading VCF) was always zero; after it is set either explicitly or when all other alleles are phased.  This updates `process_gt_to_hap()` and `process_gt_to_hap2()` to ignore the first phase bit, removing an assumption it is always zero.

Fixes incorrect reporting of phase when using HTSlib 1.22 to read VCF files with version 4.4 or 4.5.

To reproduce the issue:
```
./bcftools view -Oz -o /tmp/convert.vcf.gz test/convert.vcf
sed 's/fileformat=VCFv4\.1/fileformat=VCFv4.4/' test/convert.vcf | ./bcftools view -Oz -o /tmp/convert44.vcf.gz
./bcftools convert -h -,.,. /tmp/convert.vcf.gz 2> /dev/null | head -n 1
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
./bcftools convert -h -,.,. /tmp/convert44.vcf.gz 2> /dev/null | head -n 1
0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0* 0*
```
After applying this patch:
```
./bcftools convert -h -,.,. /tmp/convert44.vcf.gz 2> /dev/null | head -n 1
0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
```

Pull request samtools/htslib#1938 will change HTSlib to set the first phase bit for all VCF files irrespective of version, after which this problem will become rather more obvious.  It would be useful to merge this change before the HTSlib one goes in.