### PR TITLE
uses macro to check missing allele

### DIFF
--- a/csq.c
+++ b/csq.c
@@ -3182,9 +3182,9 @@ int test_cds(args_t *args, bcf1_t *rec, vbuf_t *vbuf)
         for (ismpl=0; ismpl<args->smpl->n; ismpl++)
         {
             int32_t *gt = args->gt_arr + args->smpl->idx[ismpl]*ngts;
-            if ( gt[0]==bcf_gt_missing ) continue;
+            if ( bcf_gt_is_missing(gt[0]) ) continue;
 
-            if ( ngts>1 && gt[1]!=bcf_gt_missing && gt[1]!=bcf_int32_vector_end && bcf_gt_allele(gt[0])!=bcf_gt_allele(gt[1]) )
+            if ( ngts>1 && !bcf_gt_is_missing(gt[1]) && gt[1]!=bcf_int32_vector_end && bcf_gt_allele(gt[0])!=bcf_gt_allele(gt[1]) )
             {
                 if ( args->phase==PHASE_MERGE )
                 {
@@ -3206,7 +3206,7 @@ int test_cds(args_t *args, bcf1_t *rec, vbuf_t *vbuf)
 
             for (ihap=0; ihap<ngts; ihap++)
             {
-                if ( gt[ihap]==bcf_gt_missing || gt[ihap]==bcf_int32_vector_end ) continue;
+                if ( bcf_gt_is_missing(gt[ihap]) || gt[ihap]==bcf_int32_vector_end ) continue;
 
                 i = 2*ismpl + ihap;
 
@@ -3311,7 +3311,7 @@ void csq_stage(args_t *args, csq_t *csq, bcf1_t *rec)
             int32_t *gt = args->gt_arr + args->smpl->idx[i]*ngt;
             for (j=0; j<ngt; j++)
             {
-                if ( gt[j]==bcf_gt_missing || gt[j]==bcf_int32_vector_end ) continue;
+                if ( bcf_gt_is_missing(gt[j]) || gt[j]==bcf_int32_vector_end ) continue;
                 int ial = bcf_gt_allele(gt[j]);
                 if ( !ial || ial!=csq->type.vcf_ial ) continue;
                 csq_print_text(args, csq, args->smpl->idx[i],j+1);
@@ -3326,7 +3326,7 @@ void csq_stage(args_t *args, csq_t *csq, bcf1_t *rec)
         int32_t *gt = args->gt_arr + args->smpl->idx[i]*ngt;
         for (j=0; j<ngt; j++)
         {
-            if ( gt[j]==bcf_gt_missing || gt[j]==bcf_int32_vector_end ) continue;
+            if ( bcf_gt_is_missing(gt[j]) || gt[j]==bcf_int32_vector_end ) continue;
             int ial = bcf_gt_allele(gt[j]);
             if ( !ial || ial!=csq->type.vcf_ial ) continue;
 

--- a/filter.c
+++ b/filter.c
@@ -1397,7 +1397,7 @@ static void filters_set_nmissing(filter_t *flt, bcf1_t *line, token_t *tok)
             { \
                 type_t val = convert(&ptr[j * sizeof(type_t)]); \
                 if ( val==is_vector_end ) break; \
-                if ( val==bcf_gt_missing ) { nmissing++; break; } \
+                if ( bcf_gt_is_missing(val) ) { nmissing++; break; } \
             } \
         } \
     }

--- a/plugins/check-sparsity.c
+++ b/plugins/check-sparsity.c
@@ -206,7 +206,7 @@ static void test_region(args_t *args, char *reg)
             int8_t *ptr = (int8_t*) (fmt_gt->p + args->smpl[i]*fmt_gt->size);
             int ial = 0;
             for (ial=0; ial<fmt_gt->n; ial++)
-                if ( ptr[ial]==bcf_gt_missing || ptr[ial]==bcf_int8_vector_end ) break;
+                if ( bcf_gt_is_missing(ptr[ial]) || ptr[ial]==bcf_int8_vector_end ) break;
             if ( ial==0 ) continue;     // missing
             if ( ++args->nsites[i] < args->min_sites ) continue;
             if ( i+1<args->nsmpl )

--- a/plugins/guess-ploidy.c
+++ b/plugins/guess-ploidy.c
@@ -167,7 +167,7 @@ void process_region_guess(args_t *args)
                 int32_t *ptr = args->arr + ismpl*ngt;
                 double *tmp = args->tmpf + ismpl*3;
 
-                if ( ptr[0]==bcf_gt_missing )
+                if ( bcf_gt_is_missing(ptr[0]) )
                 {
                     tmp[0] = -1;
                     continue;

--- a/plugins/mendelian2.c
+++ b/plugins/mendelian2.c
@@ -566,12 +566,12 @@ static int parse_gt(int32_t *gt, int ngt, uint64_t *a, uint64_t *b)
 {
     *a = *b = 0;
 
-    if ( gt[0]==bcf_gt_missing || gt[0]==bcf_int32_vector_end ) return 0;
+    if ( bcf_gt_is_missing(gt[0]) || gt[0]==bcf_int32_vector_end ) return 0;
     *a |= 1<<bcf_gt_allele(gt[0]);
 
     if ( ngt==1 || gt[1]==bcf_int32_vector_end ) return 1;
 
-    if ( gt[1]==bcf_gt_missing ) return 0;
+    if ( bcf_gt_is_missing(gt[1]) ) return 0;
     *b |= 1<<bcf_gt_allele(gt[1]);
 
     return 2;

--- a/plugins/missing2ref.c
+++ b/plugins/missing2ref.c
@@ -121,7 +121,7 @@ bcf1_t *process(bcf1_t *rec)
     // replace gts
     for (i=0; i<ngts; i++)
     {
-        if ( gts[i]==bcf_gt_missing )
+        if ( bcf_gt_is_missing(gts[i]) )
         {
             gts[i] = new_gt;
             changed++;

--- a/plugins/setGT.c
+++ b/plugins/setGT.c
@@ -403,7 +403,7 @@ static inline int set_gt_custom(args_t *args, int32_t *ptr, int ngts, int nals)
     {
         if ( args->custom.gt[i]==MINOR_ALLELE ) new_allele = args->custom.m_allele;
         else if ( args->custom.gt[i]==MAJOR_ALLELE ) new_allele = args->custom.M_allele;
-        else if ( args->custom.gt[i]==X_VAF_ALLELE ) new_allele = args->custom.x_vaf_allele==bcf_gt_missing ? nals : bcf_gt_allele(args->custom.x_vaf_allele);
+        else if ( args->custom.gt[i]==X_VAF_ALLELE ) new_allele = bcf_gt_is_missing(args->custom.x_vaf_allele) ? nals : bcf_gt_allele(args->custom.x_vaf_allele);
         else if ( args->custom.gt[i]==MISSING_ALLELE ) new_allele = nals; // this is to trigger the `new_allele = bcf_gt_missing` branch below
         else new_allele = args->custom.gt[i];
         if ( new_allele >= nals ) // cannot set, the requested index is bigger than there are alleles in ALT

--- a/plugins/trio-switch-rate.c
+++ b/plugins/trio-switch-rate.c
@@ -182,8 +182,8 @@ int parse_genotype(gt_t *gt, int32_t *ptr);
 
 inline int parse_genotype(gt_t *gt, int32_t *ptr)
 {
-    if ( ptr[0]==bcf_gt_missing ) return 0;
-    if ( ptr[1]==bcf_gt_missing ) return 0;
+    if ( bcf_gt_is_missing(ptr[0]) ) return 0;
+    if ( bcf_gt_is_missing(ptr[1]) ) return 0;
     if ( ptr[1]==bcf_int32_vector_end ) return 0;
     gt->phased = bcf_gt_is_phased(ptr[1]) ? 1 : 0;
     gt->a = bcf_gt_allele(ptr[0]); if ( gt->a > 1 ) return 0;  // consider only the first two alleles at biallelic sites

--- a/vcfbuf.c
+++ b/vcfbuf.c
@@ -842,7 +842,7 @@ static double _estimate_af(int8_t *ptr, int size, int nvals, int nsamples)
     {
         for (j=0; j<nvals; j++)
         {
-            if ( ptr[j]==bcf_gt_missing ) break;
+            if ( bcf_gt_is_missing(ptr[j]) ) break;
             if ( ptr[j]==bcf_int8_vector_end ) break;
             if ( bcf_gt_allele(ptr[j]) ) nalt++;
             else nref++;
@@ -911,7 +911,7 @@ static int _calc_r2_ld(vcfbuf_t *buf, bcf1_t *arec, bcf1_t *brec, vcfbuf_ld_t *l
         for (j=0; j<afmt->n; j++)
         {
             if ( aptr[j]==bcf_int8_vector_end ) break;
-            if ( aptr[j]==bcf_gt_missing )
+            if ( bcf_gt_is_missing(aptr[j]) )
             {
                 if ( !buf->ld.rand_missing ) break;
                 if ( hts_drand48() >= aaf ) adsg += 1;
@@ -922,7 +922,7 @@ static int _calc_r2_ld(vcfbuf_t *buf, bcf1_t *arec, bcf1_t *brec, vcfbuf_ld_t *l
         for (j=0; j<bfmt->n; j++)
         {
             if ( bptr[j]==bcf_int8_vector_end ) break;
-            if ( bptr[j]==bcf_gt_missing )
+            if ( bcf_gt_is_missing(bptr[j]) )
             {
                 if ( !buf->ld.rand_missing ) break;
                 if ( hts_drand48() >= baf ) bdsg += 1;


### PR DESCRIPTION
Update in mendelian2.c to use macro instead of raw value, as raw value contains phasing info as well and may not match when phasing is set. This will make bcftools tests to succeed with htslib phasing change ( https://github.com/samtools/htslib/pull/1938 ).

