### PR TITLE
Fix roh-viz JS libraries embedding for offline rendering

### DIFF
--- a/misc/roh-viz
+++ b/misc/roh-viz
@@ -281,10 +281,6 @@ sub generate_html
     .line { fill: none; }
   </style>
 
-  <script src="https://d3js.org/d3.v6.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.4/pako.min.js"></script>
-
-
   $d3js
   $pakojs
   <script type="text/javascript" defer>
@@ -779,7 +775,7 @@ sub embed_js
         {
             my $tmp = "$$opts{outfile}.rmme";
             cmd(qq[wget -O $tmp $file]);
-            my $dat = join('',`cat $tmp`);
+            $dat = join('',`cat $tmp`);
             unlink($tmp);
         }
         return $dat;


### PR DESCRIPTION
When roh-viz is executed with --embed-d3 1, the generated HTML file still does not contain the embedded script. Also, the script definitions referencing online resources are unconditionally inserted into the generated HTML file.

The corresponding logs contain the following: 
"Use of uninitialized value in concatenation (.) or string at /usr/local/bin/roh-viz line 228.
Use of uninitialized value in concatenation (.) or string at /usr/local/bin/roh-viz line 229."

The PR fixes this by means of two small changes as follows:
1) Unshadows the $dat variable in "sub embed_js" to allow it to return the embedded script. 
2) Removes a pair of hard-coded script definitions from HTML code, which are redundant in the presence of $d3js and  $pakojs.

Fixes #2471.