### PR TITLE
Change sed regex to remove all 'redhat-hardened-ld*' entries from Perl options.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,8 +247,8 @@ AS_IF([test "$enable_perl_filters" != "no" ], [dnl
     fi
     AS_CASE([$PERL_LIBS],
       [*redhat/redhat-hardened-ld*],[[
-        PERL_CCOPTS="`echo $PERL_CCOPTS | sed 's,-specs=[a-z/]*/redhat/redhat-hardened-[a-z0-9]* *,,g'`"
-        PERL_LIBS="`echo $PERL_LIBS | sed 's,-specs=[a-z/]*/redhat/redhat-hardened-[a-z0-9]* *,,g'`"]
+        PERL_CCOPTS="`echo $PERL_CCOPTS | sed 's,-specs=[a-z/]*/redhat/redhat-hardened-[a-z0-9-]* *,,g'`"
+        PERL_LIBS="`echo $PERL_LIBS | sed 's,-specs=[a-z/]*/redhat/redhat-hardened-[a-z0-9-]* *,,g'`"]
         AC_MSG_NOTICE([removing -specs=...redhat-hardened... from Perl options])])
     AC_SUBST([PERL_CCOPTS])
     AC_SUBST([PERL_LIBS])


### PR DESCRIPTION
Fixes #2495 