### PR TITLE
Fix silent truncation when synced reader encounters I/O errors

### DIFF
--- a/consensus.c
+++ b/consensus.c
@@ -411,6 +411,7 @@ static bcf1_t **next_vcf_line(args_t *args)
         }
         return &args->files->readers[0].buffer[0];
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     return NULL;
 }
 static void unread_vcf_line(args_t *args, bcf1_t **rec_ptr)

--- a/csq.c
+++ b/csq.c
@@ -3918,6 +3918,7 @@ int main_csq(int argc, char *argv[])
     {
         process(args, &args->sr->readers[0].buffer[0]);
     }
+    if ( args->sr->errnum ) error("Error: %s\n", bcf_sr_strerror(args->sr->errnum));
     process(args,NULL);
 
     destroy_data(args);

--- a/vcfannotate.c
+++ b/vcfannotate.c
@@ -3902,6 +3902,7 @@ int main_vcfannotate(int argc, char *argv[])
         if ( args->filter_ext && !args->keep_sites && !keep ) continue;
         if ( bcf_write1(args->out_fh, args->hdr_out, line)!=0 ) error("[%s] Error: failed to write to %s\n", __func__,args->output_fname);
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     destroy_data(args);
     bcf_sr_destroy(args->files);
     free(args);

--- a/vcfcnv.c
+++ b/vcfcnv.c
@@ -1433,6 +1433,7 @@ int main_vcfcnv(int argc, char *argv[])
         bcf1_t *line = bcf_sr_get_line(args->files,0);
         cnv_next_line(args, line);
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     cnv_next_line(args, NULL);
     create_plots(args);
     fprintf(stderr,"Number of lines: total/processed: %d/%d\n", args->ntot,args->nused);

--- a/vcfconcat.c
+++ b/vcfconcat.c
@@ -594,6 +594,7 @@ static void concat(args_t *args)
                 bcf1_t *line1 = args->files->nreaders > 1 ? bcf_sr_get_line(args->files,1) : NULL;
                 phased_push(args, line0, line1, is_overlap);
             }
+            if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
 
             if ( args->files->nreaders )
             {
@@ -617,6 +618,7 @@ static void concat(args_t *args)
                 if ( args->remove_dups ) break;
             }
         }
+        if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     }
     else    // concatenate as is
     {

--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -991,6 +991,7 @@ static void vcf_to_gensample(args_t *args)
             nok++;
         }
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     fprintf(stderr, "%d records written, %d skipped: %d/%d/%d/%d no-ALT/non-biallelic/filtered/duplicated\n",
         nok, no_alt+non_biallelic+filtered+ndup, no_alt, non_biallelic, filtered, ndup);
 
@@ -1129,6 +1130,7 @@ static void vcf_to_haplegendsample(args_t *args)
         }
         nok++;
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     fprintf(stderr, "%d records written, %d skipped: %d/%d/%d no-ALT/non-biallelic/filtered\n", nok,no_alt+non_biallelic+filtered, no_alt, non_biallelic, filtered);
     if ( str.m ) free(str.s);
     if ( hout && bgzf_close(hout)!=0 ) error("Error closing %s: %s\n", hap_fname, strerror(errno));
@@ -1261,6 +1263,7 @@ static void vcf_to_hapsample(args_t *args)
         }
         nok++;
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     fprintf(stderr, "%d records written, %d skipped: %d/%d/%d no-ALT/non-biallelic/filtered\n", nok, no_alt+non_biallelic+filtered, no_alt, non_biallelic, filtered);
     if ( str.m ) free(str.s);
     if ( hout && bgzf_close(hout)!=0 ) error("Error closing %s: %s\n", hap_fname, strerror(errno));
@@ -1496,6 +1499,7 @@ static void vcf_to_vcf(args_t *args)
         }
         if ( bcf_write(out_fh,hdr,line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->outfname);
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     if ( args->write_index )
     {
         if ( bcf_idx_save(out_fh)<0 )
@@ -1588,6 +1592,7 @@ static void gvcf_to_vcf(args_t *args)
             free(ref);
         }
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     free(itmp);
     if ( args->write_index )
     {

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -728,6 +728,7 @@ int main_vcffilter(int argc, char *argv[])
                 buffered_filters(args, line);
         }
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     buffered_filters(args, NULL);
     if ( args->write_index )
     {

--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -1505,6 +1505,7 @@ int main_vcfgtcheck(int argc, char *argv[])
             if ( args->dry_run ) break;
         }
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     if ( !args->dry_run )
     {
         report(args);

--- a/vcfisec.c
+++ b/vcfisec.c
@@ -262,6 +262,7 @@ void isec_vcf(args_t *args)
             }
         }
     }
+    if ( files->errnum ) error("Error: %s\n", bcf_sr_strerror(files->errnum));
     if ( str.s ) free(str.s);
     if ( out_fh )
     {

--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -3500,6 +3500,7 @@ void merge_vcf(args_t *args)
         clean_buffer(args);
         // debug_state(args);
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     free(rid_tab);
     if ( args->do_gvcf )
         gvcf_flush(args,1);

--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -2495,6 +2495,7 @@ static void normalize_vcf(args_t *args)
         if ( j>0 ) flush_buffer(args, args->out, j);
     }
     flush_buffer(args, args->out, args->rbuf.n);
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     if ( args->write_index )
     {
         if ( bcf_idx_save(args->out)<0 )

--- a/vcfplugin.c
+++ b/vcfplugin.c
@@ -835,6 +835,7 @@ int main_plugin(int argc, char *argv[])
             if ( bcf_write1(args->out_fh, args->hdr_out, line)!=0 ) error("[%s] Error: cannot write to %s\n", __func__,args->output_fname);
         }
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     destroy_data(args);
     bcf_sr_destroy(args->files);
     free(args);

--- a/vcfquery.c
+++ b/vcfquery.c
@@ -170,6 +170,7 @@ static void query_vcf(args_t *args)
         convert_line(args->convert, line, &str);
         if ( str.l && fwrite(str.s, str.l, 1, args->out)!=1 ) error("[%s] Error: cannot write to %s\n", __func__,args->fn_out?args->fn_out:"standard output");
     }
+    if ( args->files->errnum ) error("Error: %s\n", bcf_sr_strerror(args->files->errnum));
     if ( str.m ) free(str.s);
 }
 

--- a/vcfstats.c
+++ b/vcfstats.c
@@ -1299,6 +1299,7 @@ static void do_vcf_stats(args_t *args)
         if ( bcf_get_info_int32(reader->header,line,"DP",&args->iarr,&args->miarr)==1 )
             (*idist(&stats->dp_sites, args->iarr[0]))++;
     }
+    if ( files->errnum ) error("Error: %s\n", bcf_sr_strerror(files->errnum));
 }
 
 static void print_header(args_t *args)


### PR DESCRIPTION
## Summary

`bcf_sr_next_line()` returns 0 on both EOF and error, and 14 of 16 bcftools commands using the synced reader never check `files->errnum` after the read loop. When an I/O error occurs (e.g. an HTTP connection drop or cloud storage throttle), these commands interpret the 0 return as normal EOF, produce silently truncated output, and exit with code 0. There is no error message and no indication that anything went wrong.

This is the root cause of spurious truncations observed during periods of high GCS load. The companion htslib PR (samtools/htslib#1987) adds retry/resilience so most transient errors never reach callers, but when retries are exhausted the error must not be swallowed.

Add post-loop `errnum` checks to all 14 affected commands so that unrecoverable read errors produce an error message and non-zero exit code.

## Affected commands
`stats`, `query`, `filter`, `plugin`, `cnv`, `isec`, `gtcheck`, `merge`, `concat`, `convert`, `annotate`, `norm`, `csq`, `consensus`

## Already safe (no change needed)
`view`, `call`