### PR TITLE
Use gunzip instead of zless

### DIFF
--- a/misc/roh-viz
+++ b/misc/roh-viz
@@ -154,7 +154,7 @@ sub process_data
 	my ($opts) = @_;
 
     print STDERR "Parsing $$opts{outdir}/roh.txt\n";
-    open(my $in,"zless $$opts{roh_file} |") or error("zless $$opts{roh_file}: $!");
+    open(my $in, '-|', 'zless', $$opts{roh_file}) or error("zless $$opts{roh_file}: $!");
     while (my $line=<$in>)
     {
         chomp($line);

--- a/misc/roh-viz
+++ b/misc/roh-viz
@@ -154,7 +154,7 @@ sub process_data
 	my ($opts) = @_;
 
     print STDERR "Parsing $$opts{outdir}/roh.txt\n";
-    open(my $in, '-|', 'zless', $$opts{roh_file}) or error("zless $$opts{roh_file}: $!");
+    open(my $in, '-|', 'gunzip', '-cfq', $$opts{roh_file}) or error("gunzip $$opts{roh_file}: $!");
     while (my $line=<$in>)
     {
         chomp($line);
@@ -175,7 +175,7 @@ sub process_data
             push @{$$opts{roh}{$chr}{$smpl}},"$beg,$end,$nsnp,$qual";
         }
     }
-    close($in) or error("close failed: zless $$opts{roh_file} (status=$?, error=$!)");
+    close($in) or error("close failed: gunzip $$opts{roh_file} (status=$?, error=$!)");
 
     my $bin_size = $$opts{bin_size};
     my %chr_len = ();

--- a/misc/roh-viz
+++ b/misc/roh-viz
@@ -154,7 +154,7 @@ sub process_data
 	my ($opts) = @_;
 
     print STDERR "Parsing $$opts{outdir}/roh.txt\n";
-    open(my $in, '-|', 'gunzip', '-cfq', $$opts{roh_file}) or error("gunzip $$opts{roh_file}: $!");
+    open(my $in, '-|', 'gunzip', '-cfq', $$opts{roh_file}) or error("failed to start gunzip $$opts{roh_file}: $!");
     while (my $line=<$in>)
     {
         chomp($line);

--- a/misc/roh-viz
+++ b/misc/roh-viz
@@ -175,7 +175,7 @@ sub process_data
             push @{$$opts{roh}{$chr}{$smpl}},"$beg,$end,$nsnp,$qual";
         }
     }
-    close($in) or error("close failed: zless $$opts{in_file}");
+    close($in) or error("close failed: zless $$opts{roh_file} (status=$?, error=$!)");
 
     my $bin_size = $$opts{bin_size};
     my %chr_len = ();


### PR DESCRIPTION
Hi.

Reading the code, I think you don't need the "less" capability of `zless` in `roh-viz`. I think the script just needs a plain-text stream of a potentially-compressed input file. Since `less` is an extra dependency that is not necessarily installed, especially in containers, and is just a wrapper around `gzip`, I propose to invoke `gunzip` directly.
Importantly, it needs the `-f` and `-q` option `zless` uses to transparently handle uncompressed files.

I also address two issues Copilot found during its review:
 - open the command without shell interpretation
 - reference the right variable in the error message

Best regards,
Matthieu