### PR TITLE
Fix Windows trio-dnm3 tests.

### DIFF
--- a/test/test.pl
+++ b/test/test.pl
@@ -1173,7 +1173,9 @@ sub parse_params
     if ( $$opts{htsdir} ) {
         if ($^O eq 'cygwin' || $^O =~ /^msys/) {
             # Set PATH so against-htslib-source builds can find the htslib dll
-            $ENV{PATH} = "$$opts{htsdir}:"."$$opts{htsdir}/bin:"."$$opts{htsdir}/lib:".$ENV{PATH};
+            my $abs_htsdir = abs_path($$opts{htsdir});
+            $ENV{PATH} = "$abs_htsdir:"."$abs_htsdir/bin:"."$abs_htsdir/lib:".$ENV{PATH};
+            print "Setting Windows PATH to $ENV{PATH}\n";
         }
     }
     $$opts{tmp} = $$opts{keep_files} ? $$opts{keep_files} : safe_tempdir;


### PR DESCRIPTION
These fail because the test script has a cd within it, but for the plugins to work on Windows we need PATH to include the plugin directory, which gets copied from $HTSDIR.  Unfortunately if our htslib directory is specified as a relative path then the cd breaks this.