### PR TITLE
Fix wrong loop variable in family trio sample remapping

### DIFF
--- a/vcfcall.c
+++ b/vcfcall.c
@@ -387,8 +387,8 @@ static void set_samples(args_t *args, const char *fn, int is_file)
         family_t *fam = &args->aux.fams[i];
         for (j=0; j<3; j++)
         {
-            fam->sample[i] = old2new[fam->sample[i]];
-            if ( fam->sample[i]<0 ) nmiss++;
+            fam->sample[j] = old2new[fam->sample[j]];
+            if ( fam->sample[j]<0 ) nmiss++;
         }
         assert( nmiss==0 || nmiss==3 );
     }


### PR DESCRIPTION
## Summary
- Fix use of outer loop variable `i` instead of inner loop variable `j` when remapping family trio sample indices in `vcfcall.c`
- The inner loop iterates `j=0..2` (CHILD, FATHER, MOTHER) but indexed `fam->sample[i]` instead of `fam->sample[j]`, corrupting family data and causing out-of-bounds access when `i >= 3`

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify trio calling with `-G` option produces correct family genotype constraints