### PR TITLE
Fix off-by-one in HMM forward-backward posterior indexing

### DIFF
--- a/HMM.c
+++ b/HMM.c
@@ -215,11 +215,12 @@ void hmm_reset(hmm_t *hmm, void *_snapshot)
 
 void hmm_set_tprob(hmm_t *hmm, double *tprob, int ntprob)
 {
+    int old_ntprob_arr = hmm->ntprob_arr;
     hmm->ntprob_arr = ntprob;
     if ( ntprob<=0 ) ntprob = 1;
 
-    if ( !hmm->tprob_arr )
-        hmm->tprob_arr  = (double*) malloc(sizeof(double)*hmm->nstates*hmm->nstates*ntprob);
+    if ( !hmm->tprob_arr || ntprob != old_ntprob_arr )
+        hmm->tprob_arr  = (double*) realloc(hmm->tprob_arr, sizeof(double)*hmm->nstates*hmm->nstates*ntprob);
 
     memcpy(hmm->tprob_arr,tprob,sizeof(double)*hmm->nstates*hmm->nstates);
 

--- a/vcfcnv.c
+++ b/vcfcnv.c
@@ -1037,7 +1037,7 @@ static void cnv_flush_viterbi(args_t *args)
     for (isite=0; isite<args->nsites; isite++)
     {
         int state = vpath[args->nstates*isite];
-        double *pval = fwd + isite*args->nstates;
+        double *pval = fwd + (isite+1)*args->nstates;
 
         qual += pval[start_cn];
 

--- a/vcfroh.c
+++ b/vcfroh.c
@@ -525,7 +525,7 @@ static void flush_viterbi(args_t *args, int ismpl)
         for (i=0; i<end; i++)
         {
             int state = vpath[i*2]==STATE_AZ ? 1 : 0;
-            double qual = phred_score(1.0 - fwd[i*2 + state]);
+            double qual = phred_score(1.0 - fwd[(i+1)*2 + state]);
             if ( args->output_type & OUTPUT_ST )
             {
                 args->str.l = 0;


### PR DESCRIPTION
## Summary
- Fix `fwd[i*2 + state]` to `fwd[(i+1)*2 + state]` in `vcfroh.c` and equivalent in `vcfcnv.c` — the `fwd[0..nstates-1]` slot contains initial state probabilities, not site 0 posteriors
- Fix `hmm_set_tprob()` in `HMM.c` to reallocate `tprob_arr` when called with a larger `ntprob`, preventing heap buffer overflow

## Test plan
- [x] Existing test suite passes (updated roh.1.{2,3,4}.out to match corrected posteriors)
- [ ] Verify ROH quality scores are more accurate with corrected posteriors