### PR TITLE
Fix merge -m none incorrectly merging records with different allele sets

### DIFF
--- a/vcfmerge.c
+++ b/vcfmerge.c
@@ -3023,6 +3023,9 @@ static inline int types_compatible(args_t *args, selected_t *selected, buffer_t 
     }
     if ( k==rec->n_allele ) return 0;   // this record has a new allele rec->d.allele[k]
 
+    // In -m none mode, require exact allele match, not just a subset
+    if ( args->collapse==COLLAPSE_NONE && rec->n_allele!=maux->nals ) return 0;
+
     if ( selected->types&other_mask && rec_types&other_mask )
     {
         // both records have symbolic alleles and the alleles are the same


### PR DESCRIPTION
## Summary
- In `types_compatible()`, COLLAPSE_NONE mode checked if the incoming record's alleles were a subset of the merged alleles, but not the reverse — a record with ALT=T would merge with ALT=T,G
- Add `rec->n_allele != maux->nals` check to require exact allele count match

Fixes #2498

## Test plan
- [x] Existing test suite passes (added merge.multiallelics.1.none.out and merge.12.none.out, updated merge.2.none.out)
- [ ] Verify `bcftools merge -m none` keeps records with different ALT sets separate