### PR TITLE
Fix vcfnorm writing float missing values to wrong buffer

### DIFF
--- a/vcfnorm.c
+++ b/vcfnorm.c
@@ -1135,7 +1135,7 @@ static void split_format_numeric(args_t *args, bcf1_t *src, bcf_fmt_t *fmt, int 
     switch (bcf_hdr_id2type(args->hdr,BCF_HL_FMT,fmt->id))
     {
         case BCF_HT_INT:  BRANCH_NUMERIC(int32, int32_t, src_vals[isrc]==bcf_int32_vector_end, src_vals[isrc]==bcf_int32_missing, dst_vals[idst]=bcf_int32_vector_end, dst_vals[idst]=bcf_int32_missing); break;
-        case BCF_HT_REAL: BRANCH_NUMERIC(float, float, bcf_float_is_vector_end(src_vals[isrc]), bcf_float_is_missing(src_vals[isrc]), bcf_float_set_vector_end(dst_vals[idst]), bcf_float_set_missing(src_vals[idst])); break;
+        case BCF_HT_REAL: BRANCH_NUMERIC(float, float, bcf_float_is_vector_end(src_vals[isrc]), bcf_float_is_missing(src_vals[isrc]), bcf_float_set_vector_end(dst_vals[idst]), bcf_float_set_missing(dst_vals[idst])); break;
     }
     #undef BRANCH_NUMERIC
 }


### PR DESCRIPTION
## Summary
- In `split_format_numeric`, `bcf_float_set_missing(src_vals[idst])` wrote to the source buffer instead of the destination — changed to `dst_vals[idst]` to match the int32 case on the preceding line

## Test plan
- [x] Existing test suite passes (updated atomize.split.1.{0,1}.out for correct missing fields)
- [ ] Verify splitting multiallelic float FORMAT fields (GL, GP) produces correct missing values