### PR TITLE
Fix ccall type-punning and mcall division by zero

### DIFF
--- a/ccall.c
+++ b/ccall.c
@@ -141,7 +141,8 @@ static int update_bcf1(call_t *call, bcf1_t *rec, const bcf_p1rst_t *pr, double 
     int has_I16, is_var;
     float fq, r;
     anno16_t a;
-    float tmpf[4], tmpi;
+    float tmpf[4];
+    int32_t tmpi;
 
     bcf_get_info_float(call->hdr, rec, "I16", &call->anno16, &call->n16);
 

--- a/mcall.c
+++ b/mcall.c
@@ -1659,7 +1659,8 @@ int mcall(call_t *call, bcf1_t *rec)
         int32_t dp[4]; dp[0] = call->anno16[0]; dp[1] = call->anno16[1]; dp[2] = call->anno16[2]; dp[3] = call->anno16[3];
         bcf_update_info_int32(call->hdr, rec, "DP4", dp, 4);
 
-        int32_t mq = (call->anno16[8]+call->anno16[10])/(call->anno16[0]+call->anno16[1]+call->anno16[2]+call->anno16[3]);
+        int32_t dp4_sum = call->anno16[0]+call->anno16[1]+call->anno16[2]+call->anno16[3];
+        int32_t mq = dp4_sum > 0 ? (call->anno16[8]+call->anno16[10])/dp4_sum : 0;
         bcf_update_info_int32(call->hdr, rec, "MQ", &mq, 1);
 
         if ( call->output_tags & CALL_FMT_PV4 )


### PR DESCRIPTION
## Summary
- Fix `tmpi` declaration from `float` to `int32_t` in `ccall.c` — was passed to `bcf_update_info_int32` which interpreted float bit pattern as garbage integer for CLR tag
- Add zero-denominator guard in `mcall.c` before dividing by sum of DP4 counts — produces `mq = 0` when depth is zero, matching the pattern in `test16_core`

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify CLR INFO tag contains correct integer values after consensus calling