### PR TITLE
Fix bam2bcf indel calling: memset destroying consensus, uninit variable, wrong sizes

### DIFF
--- a/bam2bcf.c
+++ b/bam2bcf.c
@@ -211,7 +211,6 @@ void bcf_callaux_clean(bcf_callaux_t *bca, bcf_call_t *call)
     if ( call->ADF ) memset(call->ADF,0,sizeof(int32_t)*(call->n+1)*B2B_MAX_ALLELES);
     if ( call->ADR ) memset(call->ADR,0,sizeof(int32_t)*(call->n+1)*B2B_MAX_ALLELES);
     if ( call->SCR ) memset(call->SCR,0,sizeof(*call->SCR)*(call->n+1));
-    if ( call->SCR ) memset(call->SCR,0,sizeof(*call->SCR)*(call->n+1));
     if ( bca->fmt_flag&B2B_FMT_NMBZ )
     {
         memset(call->ref_nm,0,sizeof(*call->ref_nm)*(call->n+1)*B2B_N_NM);

--- a/bam2bcf_iaux.c
+++ b/bam2bcf_iaux.c
@@ -228,7 +228,7 @@ static int iaux_init_ins_types(indel_aux_t *iaux)
         iaux->minscns = ncns;
     }
     else cns = iaux->inscns;
-    memset(aux,0,ncns*sizeof(*cns));
+    memset(cns,0,ncns*sizeof(*cns));
 
     // use the majority rule to construct the consensus
     for (t=0; t<iaux->ntypes; t++)

--- a/bam2bcf_iaux.c
+++ b/bam2bcf_iaux.c
@@ -162,7 +162,7 @@ static int iaux_init_scores(indel_aux_t *iaux, int ismpl)
         iaux->mread_scores = n;
         iaux->read_scores  = tmp;
     }
-    memset(iaux->read_scores,0,n);
+    memset(iaux->read_scores,0,n*sizeof(int));
     return 0;
 }
 
@@ -287,7 +287,7 @@ static int iaux_init_types(indel_aux_t *iaux)
         nalt = naux - nalt;
         if ( iaux->bca->per_sample_flt )
         {
-            double frac = (double)nalt/naux;
+            double frac = (double)nalt/ntot;
             if ( nalt >= iaux->bca->min_support && frac >= iaux->bca->min_frac ) indel_support_ok = 1;
             if ( nalt > iaux->bca->max_support && frac > 0 ) iaux->bca->max_support = nalt, iaux->bca->max_frac = frac;
         }

--- a/bam2bcf_indel.c
+++ b/bam2bcf_indel.c
@@ -702,7 +702,7 @@ int bcf_call_gap_prep(int n, int *n_plp, bam_pileup1_t **plp, int pos,
 
     int i, s, j, k, t, n_types, *types, max_rd_len, left, right, max_ins;
     int *score, max_ref2;
-    int N, K, l_run, ref_type, n_alt;
+    int N, K = 0, l_run, ref_type, n_alt;
     char *inscns = 0, *ref2, *query, **ref_sample;
 
     // determine if there is a gap


### PR DESCRIPTION
## Summary
- Fix `memset(aux, 0, ...)` to `memset(cns, 0, ...)` in `bam2bcf_iaux.c` — was zeroing nucleotide frequency counts just computed, causing the consensus builder to discard all insertion data
- Fix `memset(read_scores, 0, n)` to `memset(read_scores, 0, n * sizeof(int))` — only zeroed 1/4 of the int array
- Fix per-sample indel fraction denominator from `naux` (cross-sample running total) to `ntot` (per-sample count)
- Initialize uninitialized variable `K` in `bam2bcf_indel.c`
- Remove duplicate `memset(call->SCR, ...)` in `bam2bcf.c`

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify indel calling with `--indels-2.0` produces correct insertion consensus sequences