### PR TITLE
Fix tabix NULL deref on open failure and dead detect=0 code

### DIFF
--- a/tabix.c
+++ b/tabix.c
@@ -53,8 +53,8 @@ int main_tabix(int argc, char *argv[])
             else {
                 fprintf(stderr, "The type '%s' not recognised\n", optarg);
                 return 1;
-            detect = 0;
             }
+            detect = 0;
 
         }
     if (optind == argc) {
@@ -77,6 +77,10 @@ int main_tabix(int argc, char *argv[])
         BGZF *fp;
         s.l = s.m = 0; s.s = 0;
         fp = bgzf_open(argv[optind], "r");
+        if (!fp) {
+            fprintf(stderr, "[E::%s] could not open '%s'\n", __func__, argv[optind]);
+            return 1;
+        }
         while (bgzf_getline(fp, '\n', &s) >= 0) puts(s.s);
         bgzf_close(fp);
         free(s.s);


### PR DESCRIPTION
## Summary
- Add NULL check on `bgzf_open` return in the read-all branch — was guaranteed to crash if the file could not be opened
- Move `detect = 0` from inside the error `else` block (dead code after `return 1`) to after the type-matching block — `-p` preset was being overridden by filename auto-detection

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify `bcftools tabix -p bed foo.vcf.gz` uses BED format, not VCF