### PR TITLE
Fix regidx out-of-bounds array access and double free

### DIFF
--- a/regidx.c
+++ b/regidx.c
@@ -289,6 +289,7 @@ regidx_t *regidx_init(const char *fname, regidx_parse_f parser, regidx_free_f fr
     }
 
     free(str.s);
+    str.s = NULL;
     if ( hts_close(fp)!=0 )
     {
         fprintf(stderr,"[%s] Error: close failed .. %s\n", __func__,fname);
@@ -441,7 +442,7 @@ int regidx_overlap(regidx_t *regidx, const char *chr, uint32_t beg, uint32_t end
         if ( !i )
         {
             int iend = iBIN(end);
-            if ( iend > list->nidx ) iend = list->nidx;
+            if ( iend >= list->nidx ) iend = list->nidx - 1;
             for (i=ibeg; i<=iend; i++)
                 if ( list->idx[i] ) break;
             if ( i>iend ) return 0;


### PR DESCRIPTION
## Summary
- Cap `iend` to `list->nidx - 1` instead of `list->nidx` in `regidx_overlap` — the loop `for (i=ibeg; i<=iend; i++)` could read `list->idx[nidx]`, one past the allocated array
- Set `str.s = NULL` after `free(str.s)` in `regidx_init` — prevents double free if `hts_close()` fails and the error path frees `str.s` again

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify region overlap queries at chromosome boundaries