### PR TITLE
Fix missing header finalization and unchecked faidx return

### DIFF
--- a/vcfconvert.c
+++ b/vcfconvert.c
@@ -489,6 +489,7 @@ static void gensample_to_vcf(args_t *args)
         *se = 0;
         bcf_hdr_add_sample(args->header,samples[i]);
     }
+    bcf_hdr_add_sample(args->header,NULL);
     for (i=0; i<nsamples; i++) free(samples[i]);
     free(samples);
 

--- a/vcfstats.c
+++ b/vcfstats.c
@@ -309,6 +309,12 @@ int indel_ctx_type(indel_ctx_t *ctx, char *chr, int pos, char *ref, char *alt, i
 
     int i, fai_ref_len;
     char *fai_ref = faidx_fetch_seq(ctx->ref, chr, pos-1, pos+win_size, &fai_ref_len);
+    if ( !fai_ref )
+    {
+        *nrep = 0;
+        *nlen = 0;
+        return alt_len - ref_len;
+    }
     for (i=0; i<fai_ref_len; i++)
         if ( (int)fai_ref[i]>96 ) fai_ref[i] -= 32;
 


### PR DESCRIPTION
## Summary
- Add missing `bcf_hdr_add_sample(args->header, NULL)` in `gensample_to_vcf` (`vcfconvert.c`) — header was not finalized after adding samples, matching the pattern in `haplegendsample_to_vcf`
- Add NULL check on `faidx_fetch_seq` return in `indel_ctx_type` (`vcfstats.c`) — prevents NULL dereference when chromosome is not in the reference

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify `bcftools convert --gensample2vcf` with sample files
- [ ] Verify `bcftools stats --ref-file` with mismatched reference