### PR TITLE
Fix 10 assorted medium-severity bugs across multiple files

### DIFF
--- a/bin.c
+++ b/bin.c
@@ -101,6 +101,6 @@ int bin_get_idx(bin_t *bin, float value)
         else return i;
     }
     if ( bin->bins[imax] <= value ) return imax;
-    return imin - 1;
+    return imin > 0 ? imin - 1 : 0;
 }
 

--- a/convert.c
+++ b/convert.c
@@ -992,10 +992,10 @@ static void process_gt_to_hap(convert_t *convert, bcf1_t *line, fmt_t *fmt, int 
         else
         {
             kputw(bcf_gt_allele(ptr[0]),str);
-            if ( bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
+            if ( !bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
             str->s[str->l++] = ' ';
             kputw(bcf_gt_allele(ptr[1]),str);
-            if ( bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
+            if ( !bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
             str->s[str->l++] = ' ';
         }
     }
@@ -1118,10 +1118,10 @@ static void process_gt_to_hap2(convert_t *convert, bcf1_t *line, fmt_t *fmt, int
         else
         {
             kputw(bcf_gt_allele(ptr[0]),str);
-            if ( bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
+            if ( !bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
             str->s[str->l++] = ' ';
             kputw(bcf_gt_allele(ptr[1]),str);
-            if ( bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
+            if ( !bcf_gt_is_phased(ptr[1]) ) str->s[str->l++] = '*';
             str->s[str->l++] = ' ';
         }
     }
@@ -1228,7 +1228,7 @@ static void process_pbinom(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isa
 
         // Check that the first field is GT
         int gt_id = bcf_hdr_id2int(convert->header, BCF_DT_ID, "GT");
-        if ( !bcf_hdr_idinfo_exists(convert->header, BCF_HL_FMT, fmt->id)  ) error("Error: FORMAT/GT is not defined in the header\n");
+        if ( !bcf_hdr_idinfo_exists(convert->header, BCF_HL_FMT, gt_id)  ) error("Error: FORMAT/GT is not defined in the header\n");
         for (i=0; i<(int)line->n_fmt; i++)
             if ( line->d.fmt[i].id==gt_id ) { fmt->usr = &line->d.fmt[i]; break; }  // it should always be first according to VCF spec, but...
 
@@ -1246,7 +1246,7 @@ static void process_pbinom(convert_t *convert, bcf1_t *line, fmt_t *fmt, int isa
     {
         if ( bcf_gt_is_missing(gt[i]) || gt[i] == bcf_int8_vector_end ) goto invalid;
         int al = bcf_gt_allele(gt[i]);
-        if ( al > line->n_allele || al >= fmt->fmt->n ) goto invalid;
+        if ( al >= line->n_allele || al >= fmt->fmt->n ) goto invalid;
 
         #define BRANCH(type_t, convert, missing, vector_end) { \
             type_t val = convert(&fmt->fmt->p[(al + isample*fmt->fmt->n)*sizeof(type_t)]); \

--- a/dist.c
+++ b/dist.c
@@ -97,7 +97,7 @@ uint32_t dist_insert_n(dist_t *dist, uint32_t value, uint32_t cnt)
     if ( !cnt ) return 0;
     int ibin = dist_insert(dist, value);
     dist->bins[ibin] += cnt - 1;
-    dist->nvalues += cnt;
+    dist->nvalues += cnt - 1;
     return ibin;
 }
 

--- a/gff.c
+++ b/gff.c
@@ -312,12 +312,12 @@ static inline int gff_parse_biotype(char *line)
         case 'M':
             if ( !strncmp(line,"Mt_tRNA_pseudogene",18) ) return GF_MT_tRNA_PSEUDOGENE;
             else if ( !strncasecmp(line,"Mt_tRNA",7) ) return GF_MT_tRNA;
-            else if ( !strncasecmp(line,"Mt_rRNA",7) ) return GF_MT_tRNA;
+            else if ( !strncasecmp(line,"Mt_rRNA",7) ) return GF_MT_rRNA;
             else if ( !strncasecmp(line,"MRNA",4) ) return GF_PROTEIN_CODING;
             break;
         case 'l':
             if ( !strncmp(line,"lincRNA",7) ) return GF_lincRNA;
-            if ( !strncmp(line,"lncRNA",7) ) return GF_lncRNA;
+            if ( !strncmp(line,"lncRNA",6) ) return GF_lncRNA;
             break;
         case 'm':
             if ( !strncmp(line,"macro_lncRNA",12) ) return GF_macro_lncRNA;

--- a/read_consensus.c
+++ b/read_consensus.c
@@ -489,7 +489,7 @@ static int select_candidate_variants(read_cns_t *rcns, const char *ref)
     // Find the longest deletion at the query position
     i = rcns->pos - rcns->beg;
     rcns->max_del = 0;
-    for (j=0; j<NI && j<dfreq[i].len[j]; j++)
+    for (j=0; j<NI && dfreq[i].len[j]; j++)
     {
         if ( rcns->max_del < dfreq[i].len[j] ) rcns->max_del = dfreq[i].len[j];
     }

--- a/vcffilter.c
+++ b/vcffilter.c
@@ -310,7 +310,7 @@ static void buffered_filters(args_t *args, bcf1_t *line)
         if ( k_flush || !line )
         {
             // Select the best indel from the cluster of k_flush indels
-            int k = 0, max_ac = -1, imax_ac = -1, max_qual = -1, imax_qual = -1;
+            int k = 0, max_ac = -1, imax_ac = -1, imax_qual = -1; float max_qual = -1;
             for (i=-1; rbuf_next(&args->rbuf,&i) && k<k_flush; )
             {
                 k++;

--- a/vcfview.c
+++ b/vcfview.c
@@ -415,7 +415,7 @@ int subset_vcf(args_t *args, bcf1_t *line)
     {
         if (args->min_ac_type == ALLELE_NONREF && args->min_ac>non_ref_ac) return 0; // min AC
         else if (args->min_ac_type == ALLELE_MINOR && args->min_ac>minor_ac) return 0; // min minor AC
-        else if (args->min_ac_type == ALLELE_ALT1 && args->min_ac>args->ac[1]) return 0; // min 1st alternate AC
+        else if (args->min_ac_type == ALLELE_ALT1 && (line->n_allele<2 || args->min_ac>args->ac[1])) return 0; // min 1st alternate AC
         else if (args->min_ac_type == ALLELE_MAJOR && args->min_ac > major_ac) return 0; // min major AC
         else if (args->min_ac_type == ALLELE_NONMAJOR && args->min_ac > an-major_ac) return 0; // min non-major AC
     }
@@ -423,7 +423,7 @@ int subset_vcf(args_t *args, bcf1_t *line)
     {
         if (args->max_ac_type == ALLELE_NONREF && args->max_ac<non_ref_ac) return 0; // max AC
         else if (args->max_ac_type == ALLELE_MINOR && args->max_ac<minor_ac) return 0; // max minor AC
-        else if (args->max_ac_type == ALLELE_ALT1 && args->max_ac<args->ac[1]) return 0; // max 1st alternate AC
+        else if (args->max_ac_type == ALLELE_ALT1 && line->n_allele>=2 && args->max_ac<args->ac[1]) return 0; // max 1st alternate AC
         else if (args->max_ac_type == ALLELE_MAJOR && args->max_ac < major_ac) return 0; // max major AC
         else if (args->max_ac_type == ALLELE_NONMAJOR && args->max_ac < an-major_ac) return 0; // max non-major AC
     }
@@ -432,7 +432,7 @@ int subset_vcf(args_t *args, bcf1_t *line)
         if (an == 0) return 0; // freq not defined, skip site
         if (args->min_af_type == ALLELE_NONREF && args->min_af>non_ref_ac/(double)an) return 0; // min AF
         else if (args->min_af_type == ALLELE_MINOR && args->min_af>minor_ac/(double)an) return 0; // min minor AF
-        else if (args->min_af_type == ALLELE_ALT1 && args->min_af>args->ac[1]/(double)an) return 0; // min 1st alternate AF
+        else if (args->min_af_type == ALLELE_ALT1 && (line->n_allele<2 || args->min_af>args->ac[1]/(double)an)) return 0; // min 1st alternate AF
         else if (args->min_af_type == ALLELE_MAJOR && args->min_af > major_ac/(double)an) return 0; // min major AF
         else if (args->min_af_type == ALLELE_NONMAJOR && args->min_af > (an-major_ac)/(double)an) return 0; // min non-major AF
     }
@@ -441,7 +441,7 @@ int subset_vcf(args_t *args, bcf1_t *line)
         if (an == 0) return 0; // freq not defined, skip site
         if (args->max_af_type == ALLELE_NONREF && args->max_af<non_ref_ac/(double)an) return 0; // max AF
         else if (args->max_af_type == ALLELE_MINOR && args->max_af<minor_ac/(double)an) return 0; // max minor AF
-        else if (args->max_af_type == ALLELE_ALT1 && args->max_af<args->ac[1]/(double)an) return 0; // max 1st alternate AF
+        else if (args->max_af_type == ALLELE_ALT1 && line->n_allele>=2 && args->max_af<args->ac[1]/(double)an) return 0; // max 1st alternate AF
         else if (args->max_af_type == ALLELE_MAJOR && args->max_af < major_ac/(double)an) return 0; // max major AF
         else if (args->max_af_type == ALLELE_NONMAJOR && args->max_af < (an-major_ac)/(double)an) return 0; // max non-major AF
     }


### PR DESCRIPTION
## Summary
- **vcffilter.c**: `max_qual` int→float (QUAL truncation in IndelGap filtering)
- **vcfview.c**: Guard `ac[1]` access with `n_allele >= 2` for 4 ALLELE_ALT1 paths
- **convert.c**: Invert `bcf_gt_is_phased` for unphased `*` marker in hap output (2 functions)
- **convert.c**: Use `gt_id` instead of `fmt->id` in GT existence check
- **convert.c**: Fix allele bounds `al > n_allele` to `al >= n_allele`
- **dist.c**: Fix `nvalues` off-by-one in `dist_insert_n` (counted cnt+1 instead of cnt)
- **bin.c**: Prevent `bin_get_idx` returning -1 for values below first bin
- **read_consensus.c**: Fix loop condition `j<dfreq[i].len[j]` to `dfreq[i].len[j]` (nonzero check)
- **gff.c**: Fix `Mt_rRNA` returning `GF_MT_tRNA` (copy-paste error)
- **gff.c**: Fix `strncmp("lncRNA", 7)` to length 6 — was never matching lncRNA biotype

Fixes #2496

## Test plan
- [x] Existing test suite passes (1920/1920)
- [ ] Verify GFF3 files with lncRNA and Mt_rRNA biotypes are parsed correctly