### PR TITLE
Add link to BCFtools online manual in INSTALL (v1.10)

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -268,3 +268,6 @@ mingw-w64-x86_64-tools-git
 
 (The last is only needed for building libraries compatible with MSVC.)
 
+
+
+For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.


### PR DESCRIPTION
This PR adds a direct link to the BCFtools online manual in the INSTALL file for version 1.10.

For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.