### PR TITLE
Add link to BCFtools online manual in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,8 @@
 For the impatient
 =================
 
+For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.
+
 The latest source code can be downloaded from github and compiled using:
 
     git clone --recurse-submodules https://github.com/samtools/htslib.git
@@ -136,7 +138,7 @@ the occurrence of -arch i386 from config.mk solved the problem.
 
 
 Optional Compilation with GSL
-=============================
+==============================
 
 The 'polysomy' command depends on the GNU Scientific Library (GSL) and is not
 enabled by default. In order to compile it, supply the --enable-libgsl
@@ -267,4 +269,3 @@ mingw-w64-x86_64-xz mingw-w64-x86_64-curl mingw-w64-x86_64-autotools
 mingw-w64-x86_64-tools-git
 
 (The last is only needed for building libraries compatible with MSVC.)
-


### PR DESCRIPTION
This PR adds a direct link to the BCFtools online manual in the INSTALL file for version 1.10 documentation.

The added line:

For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.

Improves accessibility of documentation for new users.