### PR TITLE
Fix warning about discarding const in init_index2()

### DIFF
--- a/version.c
+++ b/version.c
@@ -160,7 +160,7 @@ int init_index2(htsFile *fh, bcf_hdr_t *hdr, const char *fname,
 
     if ( !fname || !*fname || !strcmp(fname, "-") ) return -1;
 
-    char *delim = strstr(fname, HTS_IDX_DELIM);
+    const char *delim = strstr(fname, HTS_IDX_DELIM);
     if (delim) {
         delim += strlen(HTS_IDX_DELIM);
         *idx_fname = strdup(delim);


### PR DESCRIPTION
The warning is a bit odd, as the variable in question is initialised from `strstr()` which is supposed to return `char *` (even though the input is `const char *`).  However, as there are no writes to the new pointer, there's no problem with changing it to a `const char *`.