### PR TITLE
Improve INSTALL documentation: Add link to BCFtools online manual

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,5 @@
+For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.
+
 For the impatient
 =================
 


### PR DESCRIPTION
## Summary

This PR improves the installation documentation for BCFtools by adding a direct link to the online manual at the top of the INSTALL file.

## Changes

Added the following line at the beginning of the INSTALL file:

```
For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.
```

## Motivation

The INSTALL file provides build and installation instructions but does not direct users to the comprehensive online documentation. Adding this link helps users find detailed usage information and command references more easily.

## Reference

Based on the INSTALL file at tag `1.10`, this documentation enhancement makes the online manual more discoverable for all users.