### PR TITLE
Add link to BCFtools online manual in INSTALL file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,8 @@
 For the impatient
 =================
 
+For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.
+
 The latest source code can be downloaded from github and compiled using:
 
     git clone --recurse-submodules https://github.com/samtools/htslib.git


### PR DESCRIPTION
## Description

This PR improves the installation documentation for BCFtools by adding a direct link to the online manual in the INSTALL file.

### Changes
- Added the line: _"For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/."_ at the top of the INSTALL file, right after the "For the impatient" section heading.

### Rationale
- Users reading the INSTALL file for setup instructions can benefit from an immediate reference to the comprehensive online documentation.
- The online manual at https://samtools.github.io/bcftools/ provides detailed usage information that complements the installation instructions.

### Testing
- The change is documentation-only and does not affect any code functionality.