### PR TITLE
Improve INSTALL documentation: add link to BCFtools online manual

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,9 @@
 For the impatient
 =================
 
+For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.
+
+
 The latest source code can be downloaded from github and compiled using:
 
     git clone --recurse-submodules https://github.com/samtools/htslib.git


### PR DESCRIPTION
## Summary

This PR improves the installation documentation for BCFtools by adding a direct link to the online manual in the INSTALL file.

## Changes

Added the following line to the INSTALL file, placed prominently after the "For the impatient" section header:

```
For detailed documentation, visit the BCFtools online manual at https://samtools.github.io/bcftools/.
```

## Motivation

The INSTALL file provides build and installation instructions but previously lacked a reference to the comprehensive online documentation. Adding this link helps users quickly find detailed usage information, command references, and further resources directly from the INSTALL file, which is often the first file users read when getting started with BCFtools.

This change is based on the INSTALL file as it exists at tag `1.10` and applies to the current `master` branch.