### PR TITLE
Ensure PACKAGE_VERSION is set in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,13 @@ endif
 # version.h: force
 #	echo '#define BCFTOOLS_VERSION "`git describe --always --dirty`"' > $@
 version.h:
-	echo '#define BCFTOOLS_VERSION "$(PACKAGE_VERSION)"' > $@
+	@if test 'x$(PACKAGE_VERSION)' != x ; then \
+		echo "echo '#define BCFTOOLS_VERSION "'"$(PACKAGE_VERSION)"'"' > $@" ; \
+		echo '#define BCFTOOLS_VERSION "$(PACKAGE_VERSION)"' > $@ ; \
+	else \
+		echo "Error: PACKAGE_VERSION is not defined." 1>&2 ; \
+		false ; \
+	fi
 
 print-version:
 	@echo $(PACKAGE_VERSION)


### PR DESCRIPTION
In git repositories, this is set by expanding `$(shell git describe --always --dirty)`.
As this is not in a normal Makefile rule, failure just results in an empty variable.  To check that it really was set, add a check to ensure it's not empty in the rule that builds the `version.h` file.

See also https://github.com/samtools/samtools/issues/2337 where failing to set this variable resulted in broken files.  It's less of a problem for bcftools due as it always [appends the string "+htslib" to its headers](https://github.com/samtools/bcftools/blob/15a40910a1624e8bd03bcd4eb7e03a2115ceddc6/vcfmerge.c#L3366), however it's probably a good idea to catch the failue to set a value if it occurs.