### PR TITLE
Make gtcheck use a stable sort for "idbl"

### DIFF
--- a/vcfgtcheck.c
+++ b/vcfgtcheck.c
@@ -827,7 +827,7 @@ static int cmp_idbl(const void *_a, const void *_b)
     idbl_t *b = (idbl_t*)_b;
     if ( a->val < b->val ) return -1;
     if ( a->val > b->val ) return 1;
-    return 0;
+    return a->ism - b->ism; // j^{th}
 }
 static void report_distinctive_sites(args_t *args)
 {


### PR DESCRIPTION
Qsort isn't always a stable sort.  Use the array index for ties. (We could use the pointers themselves, but the struct already contains an index.)

Fixes a test issue on OpenSolaris, and probably Alpine (although it looks to have gotten lucky.)